### PR TITLE
chore(build): add tsup.config.ts for tokens/theme/react-headless/react

### DIFF
--- a/packages/react-headless/tsup.config.ts
+++ b/packages/react-headless/tsup.config.ts
@@ -1,0 +1,18 @@
+﻿/**
+ * @ara/react-headless - tsup config
+ * - 로직/상태만 제공(스타일 없음)
+ * - React는 peer로 외부화
+ */
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+  treeshake: true,
+  format: ["esm", "cjs"],
+  target: "es2019",
+  external: ["react"],
+});

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -1,0 +1,22 @@
+﻿/**
+ * @ara/react - tsup config
+ * - 스타일 포함 UI 컴포넌트 패키지
+ * - react/react-dom은 peer로 외부화
+ * - JSX 자동 변환(React 17+)
+ */
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+  treeshake: true,
+  format: ["esm", "cjs"],
+  target: "es2019",
+  external: ["react", "react-dom"],
+  esbuildOptions(opts) {
+    opts.jsx = "automatic";
+  },
+});

--- a/packages/theme/tsup.config.ts
+++ b/packages/theme/tsup.config.ts
@@ -1,0 +1,18 @@
+﻿/**
+ * @ara/theme - tsup config
+ * - CSS 변수/테마 유틸 중심. DOM 주입 유틸은 sideEffects 예외(4-7에서 처리)
+ * - 외부 의존성 없음
+ * - SSR 시 테마 마운트 유틸 사용 시점 주의(가이드 별도)
+ */
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+  treeshake: true,
+  format: ["esm", "cjs"],
+  target: "es2019",
+});

--- a/packages/tokens/tsup.config.ts
+++ b/packages/tokens/tsup.config.ts
@@ -1,0 +1,17 @@
+﻿/**
+ * @ara/tokens - tsup config
+ * - 공통 빌드 규약: ESM/CJS + d.ts + treeshake + sourcemap
+ * - 외부 의존성 없음
+ */
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+  treeshake: true,
+  format: ["esm", "cjs"],
+  target: "es2019",
+});


### PR DESCRIPTION
요약(왜 하는가)

패키지마다 **동일한 빌드 규약(ESM/CJS + d.ts + treeshake + sourcemap)**을 적용해 산출물을 표준화합니다. 이렇게 해야 4-3의 메타 필드 정리와 4-5의 ESM/CJS 스모크가 예측 가능하게 통과합니다.

목표

@ara/tokens, @ara/theme, @ara/react-headless, @ara/react에 tsup.config.ts 생성.

React 계열(react, react-dom)은 번들에 포함하지 않도록 external 처리.