### PR TITLE
chore(build): 4-3 exports/types/files/sideEffects standardization (+p…

### DIFF
--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,5 +1,22 @@
 ﻿{
   "name": "@ara/react-headless",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  }  
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,23 @@
 ﻿{
   "name": "@ara/react",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  }  
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,5 +1,19 @@
 ﻿{
   "name": "@ara/theme",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  }  
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,5 +1,19 @@
 ﻿{
   "name": "@ara/tokens",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  }  
 }


### PR DESCRIPTION
요약(왜 하는가)

배포 산출물 규격을 표준화(ESM/CJS + d.ts + files=dist + 기본 sideEffects=false) 해 두면, 4-4 전체 빌드·4-5 스모크에서 예측 가능한 동작과 깨끗한 트리셰이킹이 보장됩니다.

목표

@ara/tokens, @ara/theme, @ara/react-headless, @ara/react의 package.json에 아래 필드 정렬

"main": "dist/index.cjs", "module": "dist/index.js", "types": "dist/index.d.ts"

"exports" 루트: types/import/require 3경로

"files": ["dist"]

"sideEffects": false (4-7에서 예외 화이트리스트 추가 예정)

React 계열은 peerDependencies 보강(react, react-dom)