### PR TITLE
Feat/build/pkg exports meta

### DIFF
--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -2,11 +2,12 @@
   "name": "@ara/react-headless",
   "version": "0.0.0",
   "private": true,
-  
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "peerDependencies": {
     "react": "^18.0.0"
@@ -18,5 +19,5 @@
       "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
-  }  
+  }
 }

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,5 +1,22 @@
 ﻿{
   "name": "@ara/react-headless",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "peerDependencies": {
+    "react": "^18.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  }  
 }

--- a/packages/react-headless/tsup.config.ts
+++ b/packages/react-headless/tsup.config.ts
@@ -3,16 +3,16 @@
  * - 로직/상태만 제공(스타일 없음)
  * - React는 peer로 외부화
  */
-import { defineConfig } from "tsup";
+import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ['src/index.ts'],
   dts: true,
   sourcemap: true,
   clean: true,
   minify: false,
   treeshake: true,
-  format: ["esm", "cjs"],
-  target: "es2019",
-  external: ["react"],
+  format: ['esm', 'cjs'],
+  target: 'es2019',
+  external: ['react'],
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,11 +2,12 @@
   "name": "@ara/react",
   "version": "0.0.0",
   "private": true,
-
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "peerDependencies": {
     "react": "^18.0.0",
@@ -19,5 +20,5 @@
       "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
-  }  
+  }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,23 @@
 ﻿{
   "name": "@ara/react",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "peerDependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  }  
 }

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -4,19 +4,19 @@
  * - react/react-dom은 peer로 외부화
  * - JSX 자동 변환(React 17+)
  */
-import { defineConfig } from "tsup";
+import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ['src/index.ts'],
   dts: true,
   sourcemap: true,
   clean: true,
   minify: false,
   treeshake: true,
-  format: ["esm", "cjs"],
-  target: "es2019",
-  external: ["react", "react-dom"],
+  format: ['esm', 'cjs'],
+  target: 'es2019',
+  external: ['react', 'react-dom'],
   esbuildOptions(opts) {
-    opts.jsx = "automatic";
+    opts.jsx = 'automatic';
   },
 });

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,5 +1,19 @@
 ﻿{
   "name": "@ara/theme",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+  
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  }  
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -2,11 +2,12 @@
   "name": "@ara/theme",
   "version": "0.0.0",
   "private": true,
-  
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "exports": {
     ".": {
@@ -15,5 +16,5 @@
       "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
-  }  
+  }
 }

--- a/packages/theme/tsup.config.ts
+++ b/packages/theme/tsup.config.ts
@@ -4,15 +4,15 @@
  * - 외부 의존성 없음
  * - SSR 시 테마 마운트 유틸 사용 시점 주의(가이드 별도)
  */
-import { defineConfig } from "tsup";
+import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ['src/index.ts'],
   dts: true,
   sourcemap: true,
   clean: true,
   minify: false,
   treeshake: true,
-  format: ["esm", "cjs"],
-  target: "es2019",
+  format: ['esm', 'cjs'],
+  target: 'es2019',
 });

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -2,11 +2,12 @@
   "name": "@ara/tokens",
   "version": "0.0.0",
   "private": true,
-
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "exports": {
     ".": {
@@ -15,5 +16,5 @@
       "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
-  }  
+  }
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,5 +1,19 @@
 ﻿{
   "name": "@ara/tokens",
   "version": "0.0.0",
-  "private": true
+  "private": true,
+
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  }  
 }

--- a/packages/tokens/tsup.config.ts
+++ b/packages/tokens/tsup.config.ts
@@ -3,15 +3,15 @@
  * - 공통 빌드 규약: ESM/CJS + d.ts + treeshake + sourcemap
  * - 외부 의존성 없음
  */
-import { defineConfig } from "tsup";
+import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ['src/index.ts'],
   dts: true,
   sourcemap: true,
   clean: true,
   minify: false,
   treeshake: true,
-  format: ["esm", "cjs"],
-  target: "es2019",
+  format: ['esm', 'cjs'],
+  target: 'es2019',
 });


### PR DESCRIPTION
요약(왜 하는가)

배포 산출물 규격을 표준화(ESM/CJS + d.ts + files=dist + 기본 sideEffects=false) 해 두면, 4-4 전체 빌드·4-5 스모크에서 예측 가능한 동작과 깨끗한 트리셰이킹이 보장됩니다.

목표

@ara/tokens, @ara/theme, @ara/react-headless, @ara/react의 package.json에 아래 필드 정렬

"main": "dist/index.cjs", "module": "dist/index.js", "types": "dist/index.d.ts"

"exports" 루트: types/import/require 3경로

"files": ["dist"]

"sideEffects": false (4-7에서 예외 화이트리스트 추가 예정)

React 계열은 peerDependencies 보강(react, react-dom)