### PR TITLE
chore(test) : 4-5 ESM/CJS TEST

### DIFF
--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -15,7 +15,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"

--- a/packages/react-headless/tsup.config.ts
+++ b/packages/react-headless/tsup.config.ts
@@ -16,6 +16,6 @@ export default defineConfig({
   target: 'es2019',
   external: ['react'],
   outExtension({ format }) {
-    return { js: format === 'cjs' ? '.cjs' : '.js' };
+    return { js: format === 'cjs' ? '.cjs' : '.mjs' };
   },
 });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -16,7 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -20,6 +20,6 @@ export default defineConfig({
     opts.jsx = 'automatic';
   },
   outExtension({ format }) {
-    return { js: format === 'cjs' ? '.cjs' : '.js' };
+    return { js: format === 'cjs' ? '.cjs' : '.mjs' };
   },
 });

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -12,7 +12,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"

--- a/packages/theme/tsup.config.ts
+++ b/packages/theme/tsup.config.ts
@@ -16,6 +16,6 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   target: 'es2019',
   outExtension({ format }) {
-    return { js: format === 'cjs' ? '.cjs' : '.js' };
+    return { js: format === 'cjs' ? '.cjs' : '.mjs' };
   },
 });

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -12,7 +12,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"

--- a/packages/tokens/tsup.config.ts
+++ b/packages/tokens/tsup.config.ts
@@ -15,6 +15,6 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   target: 'es2019',
   outExtension({ format }) {
-    return { js: format === 'cjs' ? '.cjs' : '.js' };
+    return { js: format === 'cjs' ? '.cjs' : '.mjs' };
   },
 });


### PR DESCRIPTION
1.  ESM/CJS 확장자 통일(.mjs / .cjs)

2.  트러블슈팅(요약)
  -ERR_UNSUPPORTED_DIR_IMPORT: import('.') 사용 → 파일경로 or self-import로 변경
  -Unexpected token 'export': ESM 파일이 .js로 빌드됨 → outExtension .mjs, exports.import/module을 .mjs로 교정 후 재빌드
  -Cannot find ... dist/index.js: exports.import 또는 module이 여전히 .js를 가리킴 → .mjs로 수정 후 재빌드