### PR TITLE
chore(repo): align Turbo test task & add test:changed (Step 6-0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "turbo run test",
+    "test:changed": "turbo run test --filter=...[origin/main]",
     "typecheck": "pnpm -r exec tsc --noEmit",
     "clean": "turbo run clean",
     "prepare": "husky"

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,8 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "outputs": ["coverage/**", "junit.xml?"]
+      "outputs": ["coverage/**", "junit*.xml"],
+      "cache": true
     },
     "typecheck": {
       "dependsOn": ["^typecheck"],


### PR DESCRIPTION
## What
- Turborepo `turbo.json`에 test 태스크 정렬
  - dependsOn: ["^build"]
  - outputs: ["coverage/**", "junit*.xml"]
  - cache: true
- root package.json 스크립트 보강
  - "test": "turbo run test"
  - "test:changed": "turbo run test --filter=...[origin/main]"

## Why
- Step 6 테스트 베이스라인의 발화점을 준비하여 이후 6-0.2(vitest.config 스캐폴드)부터 즉시 실행 가능하도록 함.
- CI 캐시/아티팩트(coverage, JUnit) 추적 용이.

## Changes
- UPDATE: turbo.json → tasks.test(outputs 패턴 교정, cache 활성화)
- ADD: package.json(scripts) → test:changed 추가

## How to test
```bash
pnpm run test -- --dry=json
pnpm run test:changed -- --dry=json