### PR TITLE
chore(eslint): add browser+vitest globals override for test files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,6 +69,28 @@ export default [
     },
   },
 
+  {
+    files: ['**/__tests__/**/*.{ts,tsx,js,jsx}', '**/*.{test,spec}.{ts,tsx,js,jsx}'],
+    languageOptions: {
+      globals: {
+        // 브라우저 전역(document, window 등)
+        ...globals.browser,
+        // (옵션) 테스트 내 Node 전역도 허용하려면 함께 둠
+        ...globals.node,
+        // Vitest 전역
+        vi: 'readonly',
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+      },
+    },
+  },
+
   // 5) Prettier와 충돌하는 규칙 비활성화(항상 마지막)
   prettier,
 ];


### PR DESCRIPTION
## What
- 테스트 파일 오버라이드 추가
  - globals: browser + node(optional) + vitest(vi/describe/it/expect…)

## Why
- jsdom 환경 테스트에서 document/window, Vitest 전역을 린터가 인식하도록

## Verify
pnpm -w exec eslint packages/react/src/__tests__/env.smoke.test.ts
pnpm --filter @ara/react run test -- --run
