### PR TITLE
chore: ignore local turbo plan JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Thumbs.db
 .vscode/
 .idea/
 dist/
+
+# local turbo plan outputs
+.plan*.json


### PR DESCRIPTION
터보 테스트 plan 파일 제외