### PR TITLE
test(react): add a11y name + keyboard tab smokes (Step 6-3/4)

### DIFF
--- a/packages/react/src/__tests__/a11y.aria-name.smoke.test.tsx
+++ b/packages/react/src/__tests__/a11y.aria-name.smoke.test.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '../testing/test-utils';
+
+describe('a11y: aria name', () => {
+  it('button is queryable by accessible name', () => {
+    render(<button aria-label="Save changes" />);
+    const btn = screen.getByRole('button', { name: /save changes/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAccessibleName('Save changes');
+  });
+});

--- a/packages/react/src/__tests__/keyboard.tab.smoke.test.tsx
+++ b/packages/react/src/__tests__/keyboard.tab.smoke.test.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, userEvent } from '../testing/test-utils';
+
+describe('keyboard: tab navigation', () => {
+  it('moves focus with Tab', async () => {
+    const u = userEvent.setup();
+    render(
+      <>
+        <button>first</button>
+        <button>second</button>
+      </>,
+    );
+
+    // 첫 Tab -> first
+    await u.tab();
+    expect(screen.getByText('first')).toHaveFocus();
+
+    // 두 번째 Tab -> second
+    await u.tab();
+    expect(screen.getByText('second')).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## What
- a11y.aria-name.smoke.test.tsx: 접근 가능한 이름으로 버튼 조회 + 매처 확인
- keyboard.tab.smoke.test.tsx: userEvent.tab() 포커스 이동 확인

## Why
- RTL + jest-dom + user-event 경로를 추가 시나리오로 보강(키보드·접근성)

## Verify
pnpm --filter @ara/react run test -- --run
# 기대: 총 5 테스트 통과

## Risk/BC
- 개발 전용 테스트 (런타임 영향 없음)
