### PR TITLE
test(docs): add module-load smoke (Step 6-3/5)

### DIFF
--- a/packages/docs/src/__tests__/exports.smoke.test.ts
+++ b/packages/docs/src/__tests__/exports.smoke.test.ts
@@ -1,0 +1,12 @@
+// 목적: @ara/docs 모듈이 에러 없이 로드됨을 보장
+// (문서 패키지는 런타임 export가 없을 수 있어 '키 > 0' 검사는 생략)
+import { describe, it, expect } from 'vitest';
+
+describe('@ara/docs exports', () => {
+  it('module loads (no runtime exports required yet)', async () => {
+    const mod = await import('..'); // packages/docs/src/index.ts 기준
+    expect(mod).toBeTruthy();
+    expect(typeof mod).toBe('object');
+    // NOTE: export 키 개수 검사는 생략 (0이어도 OK)
+  });
+});


### PR DESCRIPTION
## What
- packages/docs/src/__tests__/exports.smoke.test.ts
  - 모듈 로드만 확인(문서 패키지는 런타임 export 불필요)

## Why
- docs 패키지의 빌드/배포 경로 최소 보증

## Verify
pnpm --filter @ara/docs run test -- --run
# 기대: Pass

## Risk/BC
- 개발 전용 테스트 (런타임 영향 없음)
