### PR TITLE
test(coverage): add V8 coverage baseline & enable in CI (Step 6-4)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,8 @@ jobs:
         run: pnpm -s run test:plan
 
       # 전체 한 번 실행(run 모드) — 로컬과 동일
-      - name: Run tests
-        run: pnpm exec turbo run test -- --run
+      - name: Run tests (one shot + coverage)
+        run: pnpm exec turbo run test -- --run --coverage --passWithNoTests
 
       # 커버리지 HTML 아티팩트 업로드(있으면)
       - name: Upload coverage

--- a/packages/docs/vitest.config.mts
+++ b/packages/docs/vitest.config.mts
@@ -10,7 +10,23 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       reportsDirectory: './coverage',
-      exclude: ['**/dist/**', '**/*.d.ts'],
+      thresholds: {                      // ★ 지금은 "수집/통과"에 집중 (실패 안 함)
+        lines: 0,
+        branches: 0,
+        functions: 0,
+        statements: 0,
+      },      
+      exclude: [
+        '**/dist/**',        
+        'dist/**',
+        '**/*.d.ts',
+        '**/__tests__/**',
+        '**/*.test.*',
+        '**/*.spec.*',
+        // 필요시 예외 추가: 스토리, 스냅샷 등
+        '**/*.stories.*',        
+      ],
     },
   },
 });
+

--- a/packages/react-headless/vitest.config.mts
+++ b/packages/react-headless/vitest.config.mts
@@ -10,7 +10,22 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       reportsDirectory: './coverage',
-      exclude: ['**/dist/**', '**/*.d.ts'],
+      thresholds: {                      // ★ 지금은 "수집/통과"에 집중 (실패 안 함)
+        lines: 0,
+        branches: 0,
+        functions: 0,
+        statements: 0,
+      },      
+      exclude: [
+        '**/dist/**',        
+        'dist/**',
+        '**/*.d.ts',
+        '**/__tests__/**',
+        '**/*.test.*',
+        '**/*.spec.*',
+        // 필요시 예외 추가: 스토리, 스냅샷 등
+        '**/*.stories.*',        
+      ],
     },
   },
 });

--- a/packages/react/vitest.config.mts
+++ b/packages/react/vitest.config.mts
@@ -13,7 +13,22 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       reportsDirectory: './coverage',
-      exclude: ['**/dist/**', '**/*.d.ts'],
+      thresholds: {                      // ★ 지금은 "수집/통과"에 집중 (실패 안 함)
+        lines: 0,
+        branches: 0,
+        functions: 0,
+        statements: 0,
+      },      
+      exclude: [
+        '**/dist/**',        
+        'dist/**',
+        '**/*.d.ts',
+        '**/__tests__/**',
+        '**/*.test.*',
+        '**/*.spec.*',
+        // 필요시 예외 추가: 스토리, 스냅샷 등
+        '**/*.stories.*',        
+      ],
     },
   },
 });

--- a/packages/theme/vitest.config.mts
+++ b/packages/theme/vitest.config.mts
@@ -10,7 +10,22 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       reportsDirectory: './coverage',
-      exclude: ['**/dist/**', '**/*.d.ts'],
+      thresholds: {                      // ★ 지금은 "수집/통과"에 집중 (실패 안 함)
+        lines: 0,
+        branches: 0,
+        functions: 0,
+        statements: 0,
+      },      
+      exclude: [
+        '**/dist/**',        
+        'dist/**',
+        '**/*.d.ts',
+        '**/__tests__/**',
+        '**/*.test.*',
+        '**/*.spec.*',
+        // 필요시 예외 추가: 스토리, 스냅샷 등
+        '**/*.stories.*',        
+      ],
     },
   },
 });

--- a/packages/tokens/vitest.config.mts
+++ b/packages/tokens/vitest.config.mts
@@ -10,7 +10,22 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'html'],
       reportsDirectory: './coverage',
-      exclude: ['**/dist/**', '**/*.d.ts'],
+      thresholds: {                      // ★ 지금은 "수집/통과"에 집중 (실패 안 함)
+        lines: 0,
+        branches: 0,
+        functions: 0,
+        statements: 0,
+      },      
+      exclude: [
+        '**/dist/**',        
+        'dist/**',
+        '**/*.d.ts',
+        '**/__tests__/**',
+        '**/*.test.*',
+        '**/*.spec.*',
+        // 필요시 예외 추가: 스토리, 스냅샷 등
+        '**/*.stories.*',        
+      ],
     },
   },
 });


### PR DESCRIPTION
## What
- vitest coverage(v8) 공통 설정 추가(각 패키지):
  - reportsDirectory=coverage, reporter=[text, html]
  - thresholds=0(현 단계는 수집 안정화 목적)
  - exclude: dist/**, __tests__/**, *.test|spec.*, *.stories.*
- CI(test.yml):
  - pnpm exec turbo run test -- --run --coverage --passWithNoTests

## Why
- 커버리지 수집·리포트를 기본값으로 고정
- pre-push/CI 모두 동일 커맨드로 재현 가능
- 이후 단계(임계치 상향)에서 실패 조건 손쉽게 적용

## How to verify
- 로컬: pnpm run test -- -- --run --coverage --passWithNoTests
- CI: 워크플로 로그에 turbo+vitest 커버리지 실행 및 coverage 아티팩트 확인
