### PR TITLE
Step 7-2: A11y 자동점검(AxeBuilder) + HTML 리포트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ e2e/traces/
 # Vite
 **/dist/
 **/.vite/
+
+# A11y report
+e2e/a11y-report/

--- a/e2e/lib/a11y.ts
+++ b/e2e/lib/a11y.ts
@@ -1,8 +1,85 @@
 import { AxeBuilder } from '@axe-core/playwright';
 import type { Page } from '@playwright/test';
+import type { AxeResults, Result as AxeResult, NodeResult } from 'axe-core';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
-export async function runA11y(page: Page) {
-  // 필요 시 .withTags(['wcag2a','wcag2aa']) 등 체이닝 가능
-  const results = await new AxeBuilder({ page }).analyze();
-  return results; // { violations, passes, ... }
+export type A11yOptions = {
+  tags?: string[];
+  include?: string[];
+  exclude?: string[];
+  reportFile?: string;
+  failOn?: Array<'critical' | 'serious' | 'moderate' | 'minor'>;
+};
+
+export async function runA11y(page: Page, options: A11yOptions = {}) {
+  const {
+    tags = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    include = [],
+    exclude = [],
+    reportFile = path.join(process.cwd(), 'e2e', 'a11y-report', 'home.html'),
+    failOn = ['critical', 'serious'],
+  } = options;
+
+  let builder = new AxeBuilder({ page }).withTags(tags);
+  include.forEach((sel) => (builder = builder.include(sel)));
+  exclude.forEach((sel) => (builder = builder.exclude(sel)));
+
+  const results: AxeResults = await builder.analyze();
+  const violations: AxeResult[] = results.violations ?? [];
+
+  // HTML 리포트 저장
+  const html = toHtmlReport(results);
+  fs.mkdirSync(path.dirname(reportFile), { recursive: true });
+  fs.writeFileSync(reportFile, html, 'utf8');
+
+  type Impact = NonNullable<AxeResult['impact']>;
+  const failed = violations.filter(
+    (v) =>
+      (v.impact as Impact | undefined) && (options.failOn ?? failOn).includes(v.impact as Impact),
+  );
+
+  return { results, violations, failed, reportFile };
+}
+
+function toHtmlReport(results: AxeResults): string {
+  const rows = (results.violations || [])
+    .map((v: AxeResult) => {
+      const nodes = (v.nodes || [])
+        .map(
+          (n: NodeResult) => `
+      <li>
+        <code>${escapeHtml((n.target || []).join(' '))}</code>
+        <div>${escapeHtml(n.failureSummary || '')}</div>
+      </li>`,
+        )
+        .join('');
+      return `
+      <tr>
+        <td><strong>${escapeHtml(v.id)}</strong></td>
+        <td>${escapeHtml(v.impact || '')}</td>
+        <td>${escapeHtml(v.help || '')}</td>
+        <td><a href="${escapeHtml(v.helpUrl || '')}" target="_blank" rel="noreferrer">docs</a></td>
+        <td><ul>${nodes}</ul></td>
+      </tr>`;
+    })
+    .join('');
+  return `<!doctype html>
+<html lang="ko"><head><meta charset="utf-8"/><title>A11y Report</title>
+<style>body{font-family:system-ui,Arial;padding:16px}table{border-collapse:collapse;width:100%}td,th{border:1px solid #ddd;padding:8px}th{background:#f7f7f7}</style>
+</head><body>
+<h1>A11y Report</h1>
+<p>Violations: <strong>${results.violations?.length || 0}</strong></p>
+<table>
+  <thead><tr><th>Rule</th><th>Impact</th><th>Help</th><th>Link</th><th>Nodes</th></tr></thead>
+  <tbody>${rows || '<tr><td colspan="5">No violations 🎉</td></tr>'}</tbody>
+</table>
+</body></html>`;
+}
+
+function escapeHtml(s: string) {
+  return s.replace(
+    /[&<>"']/g,
+    (m) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[m]!,
+  );
 }

--- a/e2e/tests/a11y.home.spec.ts
+++ b/e2e/tests/a11y.home.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { runA11y } from '../lib/a11y';
+
+test('a11y: home @a11y', async ({ page }, testInfo) => {
+  await page.goto('/'); // baseURL + webServer 사용
+  const { failed, violations, reportFile } = await runA11y(page, {
+    // 필요시 태그/영역 조정
+    tags: ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'],
+    reportFile:
+      testInfo.project.outputDir.replace(/test-results.*$/, '') + 'e2e/a11y-report/home.html',
+    failOn: ['critical', 'serious'],
+  });
+
+  // JSON도 첨부(Playwright Report에서 확인)
+  await testInfo.attach('a11y-violations.json', {
+    body: Buffer.from(JSON.stringify(violations, null, 2)),
+    contentType: 'application/json',
+  });
+
+  // 실패 기준: critical/serious 0
+  expect(failed, `See HTML: ${reportFile}`).toHaveLength(0);
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "@playwright/test"] // ← 'playwright' → '@playwright/test'
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:plan:changed": "turbo run test --filter=...[origin/main] --dry=json",
     "e2e": "playwright test -c e2e/playwright.config.ts",
     "e2e:headed": "playwright test -c e2e/playwright.config.ts --headed",
-    "e2e:ui": "playwright test -c e2e/playwright.config.ts --ui"
+    "e2e:ui": "playwright test -c e2e/playwright.config.ts --ui",
+    "e2e:a11y": "playwright test -c e2e/playwright.config.ts -g \"@a11y\""
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.2",
@@ -40,6 +41,7 @@
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
     "@vitest/coverage-v8": "^3.2.4",
+    "axe-core": "^4.10.3",
     "cross-env": "^10.0.0",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@24.4.0)(jiti@2.5.1)(jsdom@27.0.0(postcss@8.5.6))(yaml@2.8.1))
+      axe-core:
+        specifier: ^4.10.3
+        version: 4.10.3
       cross-env:
         specifier: ^10.0.0
         version: 10.0.0


### PR DESCRIPTION
해당 챕터 적용 요약 — 홈 페이지에 AxeBuilder 기반 A11y 자동점검을 적용했고, wcag 태그/임팩트 필터와 HTML 리포트(critical/serious 0 기준)를 추가했습니다.