### PR TITLE
Step 7-4: CI — e2e 실행 + HTML/A11y 리포트 업로드

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,52 @@
+name: e2e
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.12.0
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm -w install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm -w exec playwright install --with-deps
+
+      - name: Run e2e
+        run: pnpm -w e2e
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
+
+      - name: Upload A11y report (home)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-report
+          path: e2e/a11y-report
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
이 챕터에서 GitHub Actions를 추가해 PR마다 Playwright e2e를 실행하고, HTML 리포트와 A11y 리포트를 아티팩트로 업로드했습니다.