### PR TITLE
feat(e2e): 7-5: 컴포넌트 샘플(버튼) + 컴포넌트 단위 a11y/키보드 스모크

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,3 +1,4 @@
+#Playwright + HTML/A11y 리포트 업로드. Node 22.12.0(Vite 요구).
 name: e2e
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+#Vitest, 빌드 체크만. Node 20. 또는 22.(통일 권장).
 name: CI • Test (Step 6-3/7)
 
 on:

--- a/e2e/tests/component.button.smoke.spec.ts
+++ b/e2e/tests/component.button.smoke.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { runA11y } from '../lib/a11y';
+
+test('button: role/name + keyboard + click', async ({ page, browserName }, testInfo) => {
+  await page.goto('/?page=button');
+
+  // a11y 역할/이름 확인
+  const btn = page.getByRole('button', { name: '증가' });
+  await expect(btn).toBeVisible();
+
+  // 키보드 포커스: Safari(WebKit)는 Tab 포커스 이슈 있으니 focus() 사용
+  if (browserName === 'webkit') await btn.focus();
+  else {
+    // Skip link가 먼저 잡히므로 Tab 2~3번까지 고려
+    await page.keyboard.press('Tab'); // skip-link
+    await page.keyboard.press('Tab'); // 버튼
+  }
+  await expect(btn).toBeFocused();
+
+  // Space/Enter 동작 확인
+  await page.keyboard.press(' ');
+  await expect(page.getByTestId('count')).toHaveText('count: 1');
+  await page.keyboard.press('Enter');
+  await expect(page.getByTestId('count')).toHaveText('count: 2');
+
+  // Axe a11y (컴포넌트 영역 중심)
+  const { failed, reportFile } = await runA11y(page, {
+    include: ['#content'],
+    reportFile:
+      testInfo.project.outputDir.replace(/test-results.*$/, '') + 'e2e/a11y-report/button.html',
+    failOn: ['critical', 'serious'],
+  });
+  expect(failed, `See HTML: ${reportFile}`).toHaveLength(0);
+});

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "pnpm -w turbo run build --filter @ara/react",
     "test": "vitest",
     "dev": "vite --port 5173",
     "build": "vite build",
     "preview": "vite preview --port 5173"
   },
   "dependencies": {
+    "@ara/react": "workspace:^",
     "react": "18",
     "react-dom": "18"
   },

--- a/packages/docs/src/App.tsx
+++ b/packages/docs/src/App.tsx
@@ -1,18 +1,62 @@
 import React from 'react';
+import { Button } from '@ara/react';
+
+function useQuery() {
+  return new URLSearchParams(window.location.search);
+}
+
+function Home() {
+  return (
+    <main id="content" style={{ padding: 24 }}>
+      <h1 data-testid="title">Ara Docs Smoke</h1>
+      <p data-testid="desc">e2e 연결을 위한 최소 페이지</p>
+      <a href="/?page=button">Button 데모로 이동</a>
+    </main>
+  );
+}
+
+function ButtonDemo() {
+  const [count, setCount] = React.useState(0);
+  return (
+    <main id="content" style={{ padding: 24 }}>
+      <h1 data-testid="title">Button Demo</h1>
+      <p data-testid="desc">컴포넌트 단위 a11y/키보드 스모크</p>
+      <div style={{ marginTop: 12 }}>
+        <Button
+          data-testid="btn"
+          aria-label="카운터 증가"
+          onClick={() => setCount((c) => c + 1)}
+          className="ara-btn"
+        >
+          증가
+        </Button>
+        <span data-testid="count" style={{ marginLeft: 12 }}>
+          count: {count}
+        </span>
+      </div>
+    </main>
+  );
+}
 
 export function App() {
+  const q = useQuery();
+  const page = q.get('page');
   return (
     <>
-      {/* 키보드 사용자용 Skip Link */}
+      {/* Skip link (7-3) */}
       <a href="#content" className="skip-link">
         Skip to content
       </a>
-
-      <main id="content" style={{ padding: 24 }}>
-        <h1 data-testid="title">Ara Docs Smoke</h1>
-        <p data-testid="desc">e2e 연결을 위한 최소 페이지</p>
-        <button data-testid="cta">확인</button>
-      </main>
+      {page === 'button' ? <ButtonDemo /> : <Home />}
+      <style>{`
+        .skip-link {
+          position:absolute; left:-10000px; top:auto; width:1px; height:1px; overflow:hidden;
+        }
+        .skip-link:focus {
+          position:static; width:auto; height:auto; padding:8px; background:#eee; outline:2px solid;
+        }
+        .ara-btn:focus-visible { outline: 2px solid #2684ff; outline-offset: 2px; }
+      `}</style>
     </>
   );
 }

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -2,7 +2,31 @@
   "name": "@ara/react-headless",
   "version": "0.0.0",
   "private": true,
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch --dts",
     "test": "vitest"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.6.2",
+    "@types/react": "^18.2.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,14 +2,36 @@
   "name": "@ara/react",
   "version": "0.0.0",
   "private": true,
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch --dts",
     "test": "vitest"
   },
+  "peerDependencies": {
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
+  },
   "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.6.2",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^14.6.1",
-    "@types/react": "^19.1.13",
-    "@types/react-dom": "^19.1.9"
+    "@testing-library/user-event": "^14.6.1"
   }
 }

--- a/packages/react/src/components/Button.tsx
+++ b/packages/react/src/components/Button.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  /**
+   * 시맨틱 버튼(기본). 필요 시 variant/scheme 확장.
+   */
+  variant?: 'primary' | 'ghost';
+  loading?: boolean;
+};
+
+/**
+ * 접근성 기본 보장:
+ * - 네이티브 <button> 사용(Enter/Space 키 지원)
+ * - disabled/aria-busy 동기화
+ * - 포커스 링은 소비자 측 스타일로 제어 (className 전달)
+ */
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', loading = false, disabled, className, children, ...rest }, ref) => {
+    const isDisabled = disabled || loading;
+    return (
+      <button
+        ref={ref}
+        type="button"
+        data-ara-button=""
+        data-variant={variant}
+        aria-busy={loading || undefined}
+        disabled={isDisabled}
+        className={className}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+Button.displayName = 'Button';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,2 @@
-// placeholder for 3-6 typecheck
-export {};
+export { Button } from './components/Button';
+export type { ButtonProps } from './components/Button';

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -10,11 +10,13 @@ export default defineConfig({
   entry: ['src/index.ts'],
   dts: true,
   sourcemap: true,
+  outDir: 'dist',
   clean: true,
   minify: false,
   treeshake: true,
+  splitting: false,
   format: ['esm', 'cjs'],
-  target: 'es2019',
+  target: 'es2021',
   external: ['react', 'react-dom'],
   esbuildOptions(opts) {
     opts.jsx = 'automatic';

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -2,7 +2,33 @@
   "name": "@ara/theme",
   "version": "0.0.0",
   "private": true,
+  "sideEffects": [
+    "./dist/**/*.css"
+  ],
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./styles.css": "./dist/styles.css"
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch --dts",
     "test": "vitest"
+  },
+  "dependencies": {
+    "@ara/tokens": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.6.2"
   }
 }

--- a/packages/theme/tsup.config.ts
+++ b/packages/theme/tsup.config.ts
@@ -7,15 +7,20 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: {
+    index: 'src/index.ts',
+    // 선택: 실제로 존재할 때만 유지하세요(없으면 제거)
+    styles: 'src/styles.css',
+  },
   dts: true,
+  format: ['esm', 'cjs'],
+  outDir: 'dist',
+  target: 'es2021',
   sourcemap: true,
   clean: true,
-  minify: false,
   treeshake: true,
-  format: ['esm', 'cjs'],
-  target: 'es2019',
-  outExtension({ format }) {
-    return { js: format === 'cjs' ? '.cjs' : '.mjs' };
-  },
+  splitting: false,
+  // CSS를 파일로 복사(번들 X)
+  loader: { '.css': 'copy' },
+  outExtension: ({ format }) => ({ js: format === 'cjs' ? '.cjs' : '.mjs' }),
 });

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -2,7 +2,27 @@
   "name": "@ara/tokens",
   "version": "0.0.0",
   "private": true,
+  "sideEffects": false,
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch --dts",
     "test": "vitest"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.6.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
 
   packages/docs:
     dependencies:
+      '@ara/react':
+        specifier: workspace:^
+        version: link:../react
       react:
         specifier: '18'
         version: 18.3.1


### PR DESCRIPTION
이 챕터에서 @ara/react에 Button 컴포넌트를 추가하고, Docs에 /?page=button 데모를 연결했습니다. e2e로 역할/이름·키보드·Space/Enter 동작을 검증하고 Axe a11y 리포트를 생성했습니다.