### PR TITLE
[T1-06] @ara/theme 프로필 확장: light/dark + density/radius + composeTheme

### DIFF
--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,6 +1,19 @@
-import { lightProfile, darkProfile } from "./profiles";
+import {
+  lightProfile,
+  darkProfile,
+  densityCompact,
+  densityComfortable,
+  radiusSharp,
+  radiusSoft,
+  type ThemeVars,
+} from "./profiles";
 export type { ThemeVars } from "./profiles";
 export { applyTheme } from "./applyTheme";
+
+/** Merge any number of ThemeVars objects (right-most wins) */
+export function composeTheme(...profiles: ThemeVars[]): ThemeVars {
+  return Object.assign({}, ...profiles);
+}
 
 /** Convenience helpers */
 export function mountLightTheme(el?: HTMLElement | null) {
@@ -9,3 +22,13 @@ export function mountLightTheme(el?: HTMLElement | null) {
 export function mountDarkTheme(el?: HTMLElement | null) {
   return import("./applyTheme").then((m) => m.applyTheme(darkProfile, el));
 }
+
+/** Re-exports for consumers */
+export {
+  lightProfile,
+  darkProfile,
+  densityCompact,
+  densityComfortable,
+  radiusSharp,
+  radiusSoft,
+};

--- a/packages/theme/src/profiles.ts
+++ b/packages/theme/src/profiles.ts
@@ -1,9 +1,10 @@
 /**
  * Minimal demo profiles. Later we will wire real values from @ara/tokens.
- * Keep keys prefixed with --ara-*
+ * Keep keys aligned with variables.css names.
  */
 export type ThemeVars = Record<string, string>;
 
+/** Base color profiles */
 export const lightProfile: ThemeVars = {
   "--color-brand-primary": "#3b82f6",
   "--semantic-color-bg-default": "#ffffff",
@@ -14,4 +15,26 @@ export const darkProfile: ThemeVars = {
   "--color-brand-primary": "#3b82f6",
   "--semantic-color-bg-default": "#0b1220",
   "--semantic-color-fg-default": "#ffffff",
+};
+
+/** Density profiles (space scale) */
+export const densityCompact: ThemeVars = {
+  "--space-xs": "3px",
+  "--space-sm": "6px",
+};
+
+export const densityComfortable: ThemeVars = {
+  "--space-xs": "5px",
+  "--space-sm": "10px",
+};
+
+/** Radius profiles */
+export const radiusSharp: ThemeVars = {
+  "--radius-sm": "0px",
+  "--radius-md": "4px",
+};
+
+export const radiusSoft: ThemeVars = {
+  "--radius-sm": "4px",
+  "--radius-md": "12px",
 };


### PR DESCRIPTION
## What
- profiles.ts: densityCompact/densityComfortable, radiusSharp/radiusSoft 추가
- index.ts: composeTheme 유틸 추가 + 새 프로필 export
- d.ts 반영 확인 완료

## Why
- 테마 조합(밝기/밀도/라운드)을 분리-합성 가능한 구조로 제공

## Changes
- packages/theme/src/profiles.ts
- packages/theme/src/index.ts
- packages/theme/dist/index.d.ts (빌드 산출)

## Gate Check (T1-06)
- [x] 빌드 성공(tsup)
- [x] index.d.ts에 composeTheme + 6개 프로필 export 반영

## Evidence
- Build logs + index.d.ts 상단/composeTheme 선언

## Impact/Risk
- 낮음(신규 export 추가). 이후 T1-07에서 Docs 토글 연동 예정.

## Checklist
- [x] 브랜치: feat/t1-06-profiles
- [x] 라벨: tier-1, t1-06, theme
- [x] 리뷰어 지정
