### PR TITLE
T-000004·T-000005: 저장소 가드 설정 정비

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,67 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+.node_repl_history
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Coverage directories
+coverage/
+*.lcov
+.nyc_output/
+
+# Build artifacts
+build/
+dist/
+storybook-static/
+.tmp/
+tmp/
+.turbo/
+
+# Dependency directories
+node_modules/
+bower_components/
+
+# Editor directories and files
+.idea/
+.vscode/*
+!.vscode/extensions.json
+!.vscode/settings.json
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# pnpm workspace state
+pnpm-debug.yaml
+.pnpm-store/
+
+# Local environment files
+.env
+.env.*
+!.env.example
+
+# Storybook/Vite caches
+.storybook-out/
+.vite/
+.eslintcache
+*.tsbuildinfo
+
+# Vitest cache
+.vitest/
+
+# Misc
+*.swp
+*.swo
+*~

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -3,20 +3,20 @@ T-000001,W-000001,개발환경설정,개발환경설정,Readme.md 파일생성,�
 T-000002,W-000001,개발환경설정,개발환경설정,"WBS.csv, Tasks.csv 생성",완료,Medium," ● 일정 관리 
  ● GPT와 일정공유
  ● WBS는 대 일정에 대한 것이고 Tasks는 WBS의 하위 업문이다.",
-T-000003,W-000002,Git 규범/가드,파일 가드,.gitattributes 생성,확인필요,High,".gitattributes
+T-000003,W-000002,Git 규범/가드,파일 가드,.gitattributes 생성,완료,High,".gitattributes
  ● 목적: Git이 “저장소 안”에서 줄바꿈·바이너리 처리 등을 표준화.
  ● 효과
          - 윈도우에서 작성해도 리포에선 LF로 고정(CRLF 혼선, 불필요한 diff 방지).
          - 바이너리(아이콘, 폰트)도 오탐지 없이 취급.
- ● 흐름: 체크아웃/커밋 시 Git이 자동 변환·정규화 → 팀 전체 diff/merge가 일관.",
-T-000004,W-000002,Git 규범/가드,파일 가드,.gitignore 생성,시작전,High,".gitignore
+ ● 흐름: 체크아웃/커밋 시 Git이 자동 변환·정규화 → 팀 전체 diff/merge가 일관.",확인
+T-000004,W-000002,Git 규범/가드,파일 가드,.gitignore 생성,완료,High,".gitignore
  ● 목적: 빌드 산출물, 캐시, OS 파일 등을 커밋에서 제외.
  ● 효과: 리포가 “소스만” 담음 → CI 속도↑, 충돌↓, 보안 리스크↓(토큰 파일 등).
- ● 흐름: git status에서 보이지 않음 → 실수로 커밋할 일이 사라짐.",
-T-000005,W-000002,Git 규범/가드,파일 가드,.editorconfig 생성,시작전,High,".editorconfig
+ ● 흐름: git status에서 보이지 않음 → 실수로 커밋할 일이 사라짐.",확인
+T-000005,W-000002,Git 규범/가드,파일 가드,.editorconfig 생성,완료,High,".editorconfig
  ● 목적: 에디터(예: VS Code)가 탭/스페이스, 들여쓰기, 파일 끝 개행, 인코딩을 통일.
  ● 효과: 사람마다 에디터 설정 달라도 같은 포맷 유지 → lint 이전 단계에서 잡음 제거.
- ● 흐름: 파일 저장 시 에디터가 규칙 적용 → PR 전에 포맷이 이미 일정.",
+ ● 흐름: 파일 저장 시 에디터가 규칙 적용 → PR 전에 포맷이 이미 일정.",확인
 T-000006,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,COMMIT_TEMPLATE 설정,시작전,High,"COMMIT_TEMPLATE
  ● 목적: git commit 창을 열면 초안 폼이 자동으로 채워지는 템플릿(제목/본문/Breaking/Refs 자리).
  ● 효과: 초보라도 일관된 메시지 작성. Conventional Commits 형식 유도.

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -8,7 +8,7 @@ W-000001,T1,개발환경설정,완료,100,"Ara Project를 위한 개발 환경�
  ● 린트/포맷: ESLint(Flat) + Prettier
  ● 형상관리: GitHub (리포 공개 or GPT 열람 가능한 미러)
  ● 라인엔딩/훅: .gitattributes( LF ) + .editorconfig + commit-msg(amend) 훅 유지"
-W-000002,T1,Git 규범/가드,시작전,0%,"Git 규범/가드
+W-000002,T1,Git 규범/가드,진행중,30,"Git 규범/가드
  ● 새 작업: 브랜치 생성 → 코드 작성(에디터가 .editorconfig 적용).
  ● 커밋: 템플릿이 형식 유도, 훅이 규칙 검사(필요 시 amend).
  ● PR: PR 템플릿 채움 → CODEOWNERS 자동 리뷰 요청 → CI가 pnpm 설치 검증(추후 test/build도).


### PR DESCRIPTION
## 요약
- Node 및 pnpm 환경에 맞춰 `.gitignore`를 확장해 커버리지, Storybook 정적 산출물, 캐시, TS 빌드 정보 등을 버전 관리에서 제외했습니다.
- `.editorconfig`를 추가해 UTF-8 인코딩, LF 줄바꿈, 2칸 들여쓰기, Markdown/Makefile 예외 등 기본 서식 규칙을 통일했습니다.
- `planning/Tasks.csv`와 `planning/WBS.csv`에 T-000004·T-000005 완료 상태와 진척률 30%를 반영했습니다.

## 테스트
- 실행하지 않음

------
https://chatgpt.com/codex/tasks/task_e_6900251019288322820dd044173e9a60