### PR TITLE
Add commit template and helper setup script

### DIFF
--- a/.commit-template
+++ b/.commit-template
@@ -1,0 +1,16 @@
+<type>[scope]: <subject>
+
+WBS: <WBS-ID>
+Task: <Task-ID>
+
+## Summary
+- 
+
+## Details
+- 
+
+## Breaking Changes
+- none
+
+## References
+- 

--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ VS Code(Git Bash) · Windows · React+TypeScript · Node 22 LTS · pnpm(workspac
  **경로** : root/planning
  **WBS** : WBS.CSV
  **Task** : Tasks.CSV
+
+## Git 설정
+- `scripts/git/setup-commit-template.sh` 실행으로 commit.template을 `.commit-template`에 고정.

--- a/scripts/git/setup-commit-template.sh
+++ b/scripts/git/setup-commit-template.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "${repo_root}" ]]; then
+  echo "Error: not inside a git repository" >&2
+  exit 1
+fi
+
+template_path="${repo_root}/.commit-template"
+
+if [[ ! -f "${template_path}" ]]; then
+  echo "Error: commit template not found at ${template_path}" >&2
+  exit 1
+fi
+
+relative_path="${template_path#${repo_root}/}"
+
+git config commit.template "${relative_path}"
+
+echo "Configured commit.template to ${relative_path}" 
+


### PR DESCRIPTION
## Summary
- add a shared commit message template that prompts for WBS/Task metadata and sections for details
- provide a helper script to configure git to use the new template
- document how to enable the template in the README

## Testing
- scripts/git/setup-commit-template.sh

------
https://chatgpt.com/codex/tasks/task_e_69005cd524308322ba9cba74cb7aaa54