### PR TITLE
Simplify commit template setup

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -17,7 +17,7 @@ T-000005,W-000002,Git 규범/가드,파일 가드,.editorconfig 생성,완료,Hi
  ● 목적: 에디터(예: VS Code)가 탭/스페이스, 들여쓰기, 파일 끝 개행, 인코딩을 통일.
  ● 효과: 사람마다 에디터 설정 달라도 같은 포맷 유지 → lint 이전 단계에서 잡음 제거.
  ● 흐름: 파일 저장 시 에디터가 규칙 적용 → PR 전에 포맷이 이미 일정.",확인
-T-000006,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,COMMIT_TEMPLATE 설정,시작전,High,"COMMIT_TEMPLATE
+T-000006,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,COMMIT_TEMPLATE 설정,완료,High,"COMMIT_TEMPLATE
  ● 목적: git commit 창을 열면 초안 폼이 자동으로 채워지는 템플릿(제목/WBS·Task Info/본문/Breaking/Refs 자리).
  ● 효과: 초보라도 일관된 메시지 작성. Conventional Commits 형식 유도.
  ● 흐름: git config commit.template 설정 → 커밋마다 같은 골격으로 작성.",

--- a/scripts/git/setup-commit-template.sh
+++ b/scripts/git/setup-commit-template.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Configure git commit template for this repository.
+
+repo_root="$(git rev-parse --show-toplevel)"
+src_template="$repo_root/.github/COMMIT_TEMPLATE"
+
+if [[ ! -f "$src_template" ]]; then
+  echo "[setup-commit-template] source template not found: $src_template" >&2
+  exit 1
+fi
+
+git config --local commit.template "$src_template"
+
+echo "Configured git commit template: $src_template"


### PR DESCRIPTION
## Summary
- update the helper script to configure Git to use .github/COMMIT_TEMPLATE directly
- remove the duplicated .commit-template copy from version control

## Testing
- scripts/git/setup-commit-template.sh

------
https://chatgpt.com/codex/tasks/task_e_690065e42d188322ac4ff90f05666a51