### PR TITLE
Add commit-msg hook enforcing Conventional Commits metadata

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,41 +1,73 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-msg_file="$1"
+commit_msg_file="$1"
 
-# 첫 유효 라인(공백/주석 제외)
-first_line="$(sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' "$msg_file" | awk 'NF && $0 !~ /^#/ {print; exit}')"
+fail() {
+  echo "[commit-msg] $1" >&2
+  echo "[commit-msg] 수정 후에는 \`git commit --amend --no-edit\` 등으로 메시지를 고치세요." >&2
+  exit 1
+}
 
-# 자동 생성 커밋 예외 허용(merge/revert/fixup/squash)
-if [[ "$first_line" =~ ^(Merge|Revert|fixup!|squash!) ]]; then
-  exit 0
+trim() {
+  # shellcheck disable=SC2001
+  sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' <<<"$1"
+}
+
+first_line_raw="$(sed -n '1p' "$commit_msg_file" | tr -d '\r')"
+subject="$(trim "$first_line_raw")"
+
+if [[ -z "$subject" ]]; then
+  fail "커밋 메시지의 첫 줄이 비어 있습니다. Conventional Commits 형식으로 작성해 주세요."
 fi
 
-# Conventional Commits 패턴: type(scope)!?: subject
-pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9._/-]+\))?(!)?: [^\s].{0,71}$'
-
-if [[ "$first_line" =~ $pattern ]]; then
-  exit 0
+allowed_types="build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|release"
+if ! grep -Eq "^($allowed_types)(\([a-z0-9._-]+\))?(!)?: [^ ].+" <<<"$subject"; then
+  fail "첫 줄이 Conventional Commits 형식과 일치하지 않습니다: '<type>([scope])?: <subject>'"
 fi
 
-cat >&2 <<'ERR'
-⛔ Commit message does not follow Conventional Commits.
+subject_length=$(printf "%s" "$subject" | wc -m)
+max_length=72
+if (( subject_length > max_length )); then
+  fail "커밋 제목이 ${max_length}자를 초과했습니다(현재 ${subject_length}자). 더 간결하게 작성해 주세요."
+fi
 
-Required:
-  type(scope)!?: subject  (subject <= 72 chars)
+subject_body="${subject#*: }"
+if [[ -z "$subject_body" ]]; then
+  fail "커밋 제목의 본문이 비어 있습니다."
+fi
 
-Examples:
-  feat(button): add aria support
-  fix(tooltip): prevent overflow on hover
-  docs(readme): add Stack snapshot
-  chore: update .gitignore
-  refactor(core)!: remove deprecated API
+require_line() {
+  local label="$1"
+  local pattern="^${label}[[:space:]]*:"
+  local line
+  line=$(grep -E -m1 "$pattern" "$commit_msg_file" || true)
+  if [[ -z "$line" ]]; then
+    fail "'${label}:' 행을 찾을 수 없습니다. 커밋 템플릿을 채워 주세요."
+  fi
+  # shellcheck disable=SC2001
+  local value
+  value=$(sed -E "s/^${label}[[:space:]]*:[[:space:]]*//" <<<"$line")
+  value="$(trim "$value")"
+  if [[ -z "$value" ]]; then
+    fail "'${label}:' 행이 비어 있습니다."
+  fi
+  if grep -Eq '[<>]' <<<"$value"; then
+    fail "'${label}:' 행에 플레이스홀더(<...>)가 남아 있습니다. 실제 값을 채워 주세요."
+  fi
+  printf '%s' "$value"
+}
 
-Tips:
-  - 작은 수정은: git commit --amend --no-edit
-  - 메시지 수정: git commit --amend
-ERR
+wbs_value=$(require_line "WBS")
+if ! grep -Eq '^W-[0-9]{6}$' <<<"$wbs_value"; then
+  fail "WBS 값은 'W-000123' 형식이어야 합니다."
+fi
 
-echo "" >&2
-echo "Your message: $first_line" >&2
-exit 1
+task_value=$(require_line "Task")
+if ! grep -Eq '^T-[0-9]{6}$' <<<"$task_value"; then
+  fail "Task 값은 'T-000123' 형식이어야 합니다."
+fi
+
+task_name_value=$(require_line "Task Name")
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ VS Code(Git Bash) · Windows · React+TypeScript · Node 22 LTS · pnpm(workspac
 
 ## Git 설정
 - 커밋 템플릿은 `.github/COMMIT_TEMPLATE` 을 직접 사용한다.
-- 설정 스크립트 실행: (Git Bash) 프롬프트에서 하위 실행 
-    `bash scripts/git/setup-commit-template.sh`
+- Conventional Commits를 강제하는 `commit-msg` 훅과 함께 사용한다.
+- 설정 스크립트 실행: (Git Bash) 프롬프트에서 하위 실행
+    ```bash
+    bash scripts/git/setup-commit-template.sh
+    bash scripts/git/setup-commit-msg-hook.sh
+    ```
 - 검증(테스트) 방법:
-  1. 스크립트 실행 후 `git config --local --get commit.template` 명령을 실행한다.
-  2. 출력이 `<repo>/.github/COMMIT_TEMPLATE` 경로와 동일한지 확인한다.
-  3. `git commit` 실행 시 템플릿이 자동으로 로드되는지 확인하면 끝.
+  1. `git config --local --get commit.template` 명령으로 템플릿 경로가 `<repo>/.github/COMMIT_TEMPLATE` 인지 확인한다.
+  2. `git config --local --get core.hooksPath` 명령으로 `<repo>/.githooks` 가 설정되었는지 확인한다.
+  3. `git commit` 실행 시 템플릿이 자동으로 로드되고, 메시지를 저장하면 Conventional Commits 규칙과 WBS/Task 정보가 모두 채워져 있어야 한다.

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -21,10 +21,10 @@ T-000006,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,COMMIT_TEMPLA
  ● 목적: git commit 창을 열면 초안 폼이 자동으로 채워지는 템플릿(제목/WBS·Task Info/본문/Breaking/Refs 자리).
  ● 효과: 초보라도 일관된 메시지 작성. Conventional Commits 형식 유도.
  ● 흐름: git config commit.template 설정 → 커밋마다 같은 골격으로 작성.",
-T-000007,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,"Conventional Commits 
-   + commit-msg(amend) 훅",시작전,High,"Conventional Commits + commit-msg(amend) 훅
+T-000007,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,"Conventional Commits
+   + commit-msg(amend) 훅",완료,High,"Conventional Commits + commit-msg(amend) 훅
  ● 목적
-        - feat: …, fix: … 같은 타입+제목 규칙. 
+        - feat: …, fix: … 같은 타입+제목 규칙.
         - 메시지 검증/자동 보정(예: 스코프/티켓ID 추가)과 사소한 수정은 --amend로 히스토리 청결 유지.
  ● 효과: 변경 의도 검색 용이, 자동 CHANGELOG 생성 기반, 리뷰 체계화.
  ● 흐름: 커밋 시 훅이 형식 검사 → 실패 시 차단, 성공 시 통과. 작은 수정은 git commit --amend --no-edit.",

--- a/scripts/git/setup-commit-msg-hook.sh
+++ b/scripts/git/setup-commit-msg-hook.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+hooks_dir="$repo_root/.githooks"
+hook_file="$hooks_dir/commit-msg"
+
+if [[ ! -f "$hook_file" ]]; then
+  echo "[setup-commit-msg-hook] commit-msg hook not found: $hook_file" >&2
+  exit 1
+fi
+
+git config --local core.hooksPath "$hooks_dir"
+
+echo "Configured git core.hooksPath -> $hooks_dir"


### PR DESCRIPTION
## Summary
- add a commit-msg hook that enforces Conventional Commits syntax and verifies WBS/Task metadata
- add a helper script to configure git to use the repository hooks directory and document the setup steps
- mark task T-000007 as complete in the planning tracker

## Testing
- bash scripts/git/setup-commit-msg-hook.sh
- .githooks/commit-msg /tmp/commitmsg-valid.txt
- .githooks/commit-msg /tmp/commitmsg-invalid.txt

------
https://chatgpt.com/codex/tasks/task_e_69006f03c6b8832290a6d765e26c7058