### PR TITLE
chore: mark GPT checks for git guard tasks

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -20,14 +20,14 @@ T-000005,W-000002,Git 규범/가드,파일 가드,.editorconfig 생성,완료,Hi
 T-000006,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,COMMIT_TEMPLATE 설정,완료,High,"COMMIT_TEMPLATE
  ● 목적: git commit 창을 열면 초안 폼이 자동으로 채워지는 템플릿(제목/WBS·Task Info/본문/Breaking/Refs 자리).
  ● 효과: 초보라도 일관된 메시지 작성. Conventional Commits 형식 유도.
- ● 흐름: git config commit.template 설정 → 커밋마다 같은 골격으로 작성.",
+ ● 흐름: git config commit.template 설정 → 커밋마다 같은 골격으로 작성.",확인
 T-000007,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,"Conventional Commits
    + commit-msg(amend) 훅",완료,High,"Conventional Commits + commit-msg(amend) 훅
  ● 목적
         - feat: …, fix: … 같은 타입+제목 규칙.
         - 메시지 검증/자동 보정(예: 스코프/티켓ID 추가)과 사소한 수정은 --amend로 히스토리 청결 유지.
  ● 효과: 변경 의도 검색 용이, 자동 CHANGELOG 생성 기반, 리뷰 체계화.
- ● 흐름: 커밋 시 훅이 형식 검사 → 실패 시 차단, 성공 시 통과. 작은 수정은 git commit --amend --no-edit.",
+ ● 흐름: 커밋 시 훅이 형식 검사 → 실패 시 차단, 성공 시 통과. 작은 수정은 git commit --amend --no-edit.",확인
 T-000008,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,"기본 브랜치 main 
    + 브랜치 네이밍",시작전,High,"기본 브랜치 main + 브랜치 네이밍
  ● 목적: 배포 기준선은 main. 작업은 feat/button, fix/tooltip-crash처럼 프리픽스/설명 규칙.

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -8,9 +8,10 @@ W-000001,T1,개발환경설정,완료,100,"Ara Project를 위한 개발 환경�
  ● 린트/포맷: ESLint(Flat) + Prettier
  ● 형상관리: GitHub (리포 공개 or GPT 열람 가능한 미러)
  ● 라인엔딩/훅: .gitattributes( LF ) + .editorconfig + commit-msg(amend) 훅 유지"
-W-000002,T1,Git 규범/가드,진행중,30,"Git 규범/가드
+W-000002,T1,Git 규범/가드,진행중,40,"Git 규범/가드
  ● 새 작업: 브랜치 생성 → 코드 작성(에디터가 .editorconfig 적용).
  ● 커밋: 템플릿이 형식 유도, 훅이 규칙 검사(필요 시 amend).
+ ● 커밋 가드: COMMIT_TEMPLATE + commit-msg(amend) 훅 GPT 검증 완료.
  ● PR: PR 템플릿 채움 → CODEOWNERS 자동 리뷰 요청 → CI가 pnpm 설치 검증(추후 test/build도).
  ● Merge: 보호 규칙 충족 시만 main 병합.
  ● 릴리스: Changesets 누적분을 액션이 읽어 버전/CHANGELOG/배포 자동화(세팅 후)"


### PR DESCRIPTION
## Summary
- record GPT verification for tasks T-000006 and T-000007 in the planning tracker

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6900791d9698832295cdb7f25364acbd