### PR TITLE
Initialize changesets release workflow

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,11 @@
+# Changesets
+
+이 디렉터리는 [`@changesets/cli`](https://github.com/changesets/changesets) 설정을 통해 버전과 릴리스를 관리합니다.
+
+## 기본 사용법
+
+- `pnpm changeset` 명령으로 변경 사항을 기록하는 새 Changeset 파일을 생성합니다.
+- `pnpm changeset version` 명령은 누적된 Changeset을 기반으로 패키지 버전과 체인질로그를 갱신합니다.
+- `pnpm changeset publish` 명령은 버전이 갱신된 패키지를 배포(예: npm registry)할 때 사용합니다.
+
+릴리스 작업은 항상 기본 브랜치(`main`) 기준으로 수행하고, 모든 변경 사항은 PR에 포함된 Changeset 파일을 통해 추적합니다.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "restricted",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ara-monorepo",
+  "private": true,
+  "version": "0.0.0",
+  "packageManager": "pnpm@10.5.2",
+  "scripts": {
+    "changeset": "changeset",
+    "release": "changeset version && changeset publish"
+  },
+  "devDependencies": {
+    "@changesets/cli": "^2.27.10"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - packages/*
+  - apps/*


### PR DESCRIPTION
## Summary
- add repository package manifest and workspace layout to support pnpm-based tooling
- configure Changesets for versioning with default base branch and changelog settings
- document basic Changesets commands for contributors

## Testing
- `pnpm changeset --help` *(fails: changeset CLI not installed in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_69015ecc3dd08322805e2a5e6f167282