### PR TITLE
Harden pnpm install step in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,20 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-          cache: 'pnpm'
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Prepare pnpm
         run: corepack prepare pnpm@10.5.2 --activate
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install workspace dependencies
         run: pnpm -w install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'pnpm'
 
       - name: Enable Corepack
         run: corepack enable
@@ -29,6 +30,6 @@ jobs:
         run: corepack prepare pnpm@10.5.2 --activate
 
       - name: Install workspace dependencies
-        run: pnpm -w install
+        run: pnpm -w install --frozen-lockfile
         env:
           CI: true


### PR DESCRIPTION
## Summary
- enable pnpm caching via `actions/setup-node` to speed up dependency installs
- enforce `pnpm -w install --frozen-lockfile` to guard against unintended lockfile updates

## Testing
- pnpm -w install *(fails: ERR_PNPM_FETCH_403 due to missing npm registry auth)*

------
https://chatgpt.com/codex/tasks/task_e_690171d123f88322861772b135f59232