### PR TITLE
docs: add monorepo scaffolding WBS and tasks

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -1,6 +1,6 @@
 TaskID,WBSID,WBS_Name,Task_Group_Name,Name,Status,Priority,Description,Check GPT
-T-000001,W-000001,개발환경설정,개발환경설정,Readme.md 파일생성,완료,Medium,Project 목적과 Stack 추가,
-T-000002,W-000001,개발환경설정,개발환경설정,"WBS.csv, Tasks.csv 생성",완료,Medium," ● 일정 관리 
+T-000001,W-000001,개발환경설정,개발환경설정,Readme.md 파일생성,완료,Medium,Project 목적과 Stack 추가,,
+T-000002,W-000001,개발환경설정,개발환경설정,"WBS.csv, Tasks.csv 생성",완료,Medium," ● 일정 관리
  ● GPT와 일정공유
  ● WBS는 대 일정에 대한 것이고 Tasks는 WBS의 하위 업문이다.",
 T-000003,W-000002,Git 규범/가드,파일 가드,.gitattributes 생성,완료,High,".gitattributes
@@ -39,11 +39,11 @@ T-000009,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,CODEOWNERS & 
  ● 흐름: PR 열면 템플릿이 미리 채워짐 → CODEOWNERS에게 리뷰 요청 자동 발송.",확인
 T-000010,W-000002,Git 규범/가드,커밋/브랜치 규칙 묶음,Changesets 초기화(버전/릴리스 흐름 고정),완료,High,"Changesets 초기화(버전/릴리스 흐름 고정)
  ● 목적: 패키지별 변경을 텍스트 파일로 기록 → 릴리스 시 버전/CHANGELOG 자동 산출.
- ● 효과: 모노레포 다중 패키지 버전 충돌 제거, 의도된 SemVer 반영.
+ ● 효과: 모노레포 다중 패키지 버전 충돌 제거, 의도된 SemVer 반.
  ● 흐름: 기능 완료 시 changeset 추가 → main 머지 후 릴리스 액션이 버전/배포 생성.",확인
 T-000011,W-000002,Git 규범/가드,CI 최소골격 & 브랜치 보호,.github/workflows/ci.yml (Node 22 + Corepack + pnpm install),완료,High,".github/workflows/ci.yml (Node 22 + Corepack + pnpm install)
  ● 목적
-         - PR/main 푸시에 자동 실행. 
+         - PR/main 푸시에 자동 실행.
          -Node 22 설치 → Corepack 활성화 → pnpm 준비 → pnpm -w install로 워크스페이스 종속성 검증(추후 test/build 추가).
  ● 효과: “내 PC에선 돼요” 방지, 잠재적 의존성 문제를 PR 단계에서 차단.
  ● 흐름: PR 생성/업데이트 → CI가 설치/검증 → 실패 시 머지 불가.",확인
@@ -53,3 +53,14 @@ T-000012,W-000002,Git 규범/가드,CI 최소골격 & 브랜치 보호,브랜치
           - 이부분은 혼자 개발 하니까 현제 제외 : 최소 1명 리뷰 요구. (옵션: Linear/Issue 링크, Conversations resolved 등)
  ● 효과: 실수 머지 방지, 품질 게이트 고정.
  ● 흐름: PR 생성 → CI 통과 + 리뷰 승인 없으면 Merge 버튼 비활성.",확인
+T-000013,W-000003,모노레포 스캐폴딩,워크스페이스 기준선,루트 워크스페이스 선언(pnpm workspaces),계획,High,"pnpm-workspace.yaml을 packages/*, apps/*, scripts/* 범위로 재검토하고 신규 패키지 경로(packages/{tsconfig,eslint-config,tokens,core,react,icons}, apps/{storybook,showcase})를 포함하도록 확정한다. Changesets와 CI가 동일 목록을 참조하도록 문서화까지 마무리한다.",
+T-000014,W-000003,모노레포 스캐폴딩,공통 설정 패키지,공통 tsconfig 패키지 초기화(packages/tsconfig),계획,High,"packages/tsconfig에 tsconfig.package.json(가칭)을 만들고 루트 tsconfig.base.json을 정의한다. 모듈 해석, 경로 alias(@ara/*) 기본값, JSX/emit 설정을 고정하고 이후 패키지들이 해당 설정을 extends하도록 README/작업순서를 명시한다.",
+T-000015,W-000003,모노레포 스캐폴딩,공통 설정 패키지,ESLint Flat 설정 패키지 초기화(packages/eslint-config),계획,High,"ESLint Flat 구성을 shareable 패키지로 만들고 기본 규칙(typescript-eslint, eslint-plugin-react)과 Prettier 연동을 정의한다. tokens/core/react 패키지에서 사용할 환경(브라우저/Node) 분리 preset을 제공하고 사용 방법을 문서화한다.",
+T-000016,W-000003,모노레포 스캐폴딩,디자인 시스템 토대,토큰/디자인 시스템 베이스 패키지 초기화(packages/tokens),계획,Medium,"디자인 토큰 패키지를 생성해 색상/타이포 등 최소 샘플 1~2종을 JSON 또는 TS 객체로 노출한다. 빌드 시 type 정의가 생성되도록 공통 tsconfig/rollup 설정을 연결하고 README에 소비 방법을 적는다.",
+T-000017,W-000003,모노레포 스캐폴딩,디자인 시스템 토대,코어(headless) 패키지 초기화(packages/core),계획,High,"비주얼 의존 없는 headless 로직 패키지 골격을 만들고 tokens에 의존하도록 구성한다. 기본 내보내기 파일과 단위 테스트 골격(Vitest)까지 포함해 이후 React 바인딩에서 재사용 가능함을 검증한다.",
+T-000018,W-000003,모노레포 스캐폴딩,디자인 시스템 토대,React 바인딩 패키지 초기화(packages/react),계획,High,"React 18 + TypeScript 패키지를 생성해 core 로직을 감싼 예시 컴포넌트(예: Button)를 추가한다. Vitest+RTL 테스트와 Storybook 스토리를 작성해 core/tokens 연계를 확인한다.",
+T-000019,W-000003,모노레포 스캐폴딩,디자인 시스템 토대,아이콘 패키지 초기화(packages/icons),계획,Medium,"SVG 기반 아이콘 패키지를 만들고 최소 1개 샘플 아이콘을 제공한다. React 패키지에서 tree-shaking 가능한 방식으로 소비할 수 있도록 export 구조와 d.ts 생성을 확인한다.",
+T-000020,W-000003,모노레포 스캐폴딩,앱/데모 구성,앱 골격 생성(apps/storybook, apps/showcase),계획,High,"Storybook 전용 앱과 showcase 샘플 앱을 스캐폴딩한다. 공통 tsconfig/ESLint 설정을 참조하도록 연결하고 pnpm 스크립트(pnpm storybook, pnpm showcase dev 등)로 실행 검증한다.",
+T-000021,W-000003,모노레포 스캐폴딩,빌드/테스트 파이프라인,빌드 파이프라인 연결(Rollup 설정 공유·d.ts 출력 확인),계획,High,"패키지 공통 빌드 설정(Rollup 또는 Vite library 모드)을 공유 설정으로 추출하고 tokens/core/react/icons에서 재사용한다. 각 패키지 빌드 시 타입 선언(d.ts)과 번들 산출물이 생성되는지 CI에서 pnpm -r build, pnpm -r test로 검증한다. Storybook/Vitest 워크플로 smoke 테스트까지 포함한다.",
+T-000022,W-000003,모노레포 스캐폴딩,빌드/테스트 파이프라인,루트 스크립트 정리(pnpm -w build/test/lint 통합),계획,Medium,"루트 package.json 스크립트에 pnpm -w build/test/lint/storybook 등을 정의하고 각 패키지가 의존하는 공통 스크립트가 순서대로 실행되도록 한다. Changesets version/release 스크립트와의 경계를 문서화해 배포 작업과 충돌하지 않도록 정리한다.",
+T-000023,W-000003,모노레포 스캐폴딩,문서화,README 구조 섹션 업데이트(모노레포 트리/패키지 표),계획,Medium,"README에 모노레포 디렉터리 트리, 패키지별 역할/의존 관계 표, 공통 설정 참조 방법을 추가해 신규 기여자가 기준선을 빠르게 이해하도록 한다.",

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -15,3 +15,4 @@ W-000002,T1,Git 규범/가드,완료,100,"Git 규범/가드
  ● PR: PR 템플릿 채움 → CODEOWNERS 자동 리뷰 요청 → CI가 pnpm 설치 검증(추후 test/build도).
  ● Merge: 보호 규칙 충족 시만 main 병합.
  ● 릴리스: Changesets 누적분을 액션이 읽어 버전/CHANGELOG/배포 자동화(세팅 후)"
+W-000003,T1,모노레포 스캐폴딩,계획,0,"pnpm 모노레포 기준선을 구축한다: workspaces 선언, 공통 tsconfig/ESLint/Changesets 패키지, 핵심 UI 패키지 및 앱 골격, 빌드·테스트 스크립트 공유, README 구조 업데이트까지 일괄 정비."


### PR DESCRIPTION
## Summary
- add a new WBS entry to cover the monorepo scaffolding baseline
- document detailed tasks for workspace setup, shared configs, package scaffolding, and documentation updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690183a8565883228e9405805d8bb438