### PR TITLE
chore: expand monorepo scaffolding governance tasks

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -56,6 +56,9 @@ T-000012,W-000002,Git 규범/가드,CI 최소골격 & 브랜치 보호,브랜치
 T-000013,W-000003,모노레포 스캐폴딩,워크스페이스 기준선,루트 워크스페이스 선언(pnpm workspaces),계획,High," ● 목적: 모노레포 워크스페이스 경계를 명시해 신규 패키지가 설치·빌드 파이프라인에 자동 편입되도록 한다.
  ● 내용: pnpm-workspace.yaml을 packages/*, apps/*, scripts/* 및 예정 패키지 경로(packages/{tsconfig,eslint-config,tokens,core,react,icons}, apps/{storybook,showcase})로 확정하고 Changesets·CI 문서에 동일 경로를 반영한다.
  ● 점검: pnpm -w list --depth -1 결과에 모든 패키지가 노출되고 README/CI 안내가 같은 경로를 가리키는지 확인한다.",
+T-000024,W-000003,모노레포 스캐폴딩,패키지 거버넌스,패키지 네이밍/퍼블리시 정책 확정,계획,High," ● 목적: 패키지 식별자/배포 정책을 초기에 고정해 apps·라이브러리의 접근성 및 배포 안전성을 확보한다.
+ ● 내용: packages/*는 scope @ara/*로 명명하고 apps/* 패키지는 private:true, 라이브러리는 publishConfig.access: public으로 설정한다. 공통 engines { node: "22" 이상 }, license, repository 필드를 통일하고 README에 명시한다.
+ ● 점검: pnpm -w list --json 출력에서 scope가 일관되는지 확인하고 pnpm pack/publish --dry-run 시 metadata(license/repository/access)가 기대값과 일치하는지 검토한다.",
 T-000014,W-000003,모노레포 스캐폴딩,공통 설정 패키지,공통 tsconfig 패키지 초기화(packages/tsconfig),계획,High," ● 목적: 모든 패키지가 동일한 TypeScript 컴파일 기준을 사용해 빌드/테스트 결과가 일관되도록 한다.
  ● 내용: packages/tsconfig에 공유 설정 패키지를 만들고 루트 tsconfig.base.json을 정의해 모듈 해석, 경로 alias(@ara/*), JSX/emit 옵션을 고정한다. 각 패키지 tsconfig에서 extends하도록 가이드 문서를 포함한다.
  ● 점검: tokens/core/react 등의 샘플 tsconfig에 extends 경로가 연결되고 pnpm exec tsc --showConfig로 공통 설정이 반영되는지 확인한다.",
@@ -80,9 +83,15 @@ T-000020,W-000003,모노레포 스캐폴딩,앱/데모 구성,"앱 골격 생성
 T-000021,W-000003,모노레포 스캐폴딩,빌드/테스트 파이프라인,빌드 파이프라인 연결(Rollup 설정 공유·d.ts 출력 확인),계획,High," ● 목적: 모든 패키지가 동일한 빌드·테스트 파이프라인을 공유해 산출물 형식과 품질 검증을 표준화한다.
  ● 내용: 공통 Rollup/Vite 라이브러리 설정을 추출해 tokens/core/react/icons 패키지에서 재사용하고 d.ts/번들 생성 흐름을 마련한다. CI에서 pnpm -r build, pnpm -r test, Storybook smoke 테스트를 통합한다.
  ● 점검: 공통 설정을 참조한 패키지 빌드가 성공하고 CI 로그에 빌드·테스트·Storybook 단계가 모두 통과하는지 확인한다.",
+T-000025,W-000003,모노레포 스캐폴딩,빌드/테스트 파이프라인,빌드 산출물 계약(Exports Map) 확립,계획,High," ● 목적: 패키지 빌드 산출물 형식을 계약화해 소비자 앱과 도구가 일관된 엔트리 포인트/타입 선언을 사용할 수 있게 한다.
+ ● 내용: tokens/core/react/icons 패키지 package.json에 exports 필드를 정의해 기본 ESM(+선택 CJS) 엔트리를 노출하고 types/module 필드, sideEffects:false, typesVersions를 정리한다. Rollup/Vite 설정과 d.ts 생성 옵션을 동기화한다.
+ ● 점검: pnpm --filter @ara/* pack --dry-run 출력에서 exports/type/module/sideEffects 값이 기대와 일치하는지 확인하고 샘플 소비 앱이 import 해상도를 문제없이 수행하는지 검증한다.",
 T-000022,W-000003,모노레포 스캐폴딩,빌드/테스트 파이프라인,루트 스크립트 정리(pnpm -w build/test/lint 통합),계획,Medium," ● 목적: 루트 명령어만으로 모노레포 전반의 빌드/테스트/린트 흐름을 실행해 운영 편의성을 높인다.
  ● 내용: 루트 package.json에 pnpm -w build/test/lint/storybook 스크립트를 정의하고 실행 순서를 정리한다. Changesets version/release 스크립트와 경계를 문서화해 배포 절차와 충돌하지 않도록 한다.
  ● 점검: 루트에서 pnpm build/test/lint/storybook 실행 시 전 워크스페이스가 순차 실행되고 문서화된 경계가 README/CONTRIBUTING에 반영됐는지 확인한다.",
+T-000026,W-000003,모노레포 스캐폴딩,CI/운영 자동화,의존성 자동 업데이트 및 pnpm 캐시 구성,계획,Medium," ● 목적: 의존성 보안/버그 패치를 신속히 반영하고 CI 설치 속도를 안정적으로 유지한다.
+ ● 내용: Renovate(또는 Dependabot) 설정 파일을 추가해 packages/*, apps/*, 루트 의존성을 주기적으로 갱신하고, GitHub Actions CI에 pnpm install 캐시(corepack+pnpm store path, 키: pnpm-lock.yaml) 단계를 추가한다.
+ ● 점검: Renovate/Dependabot 테스트 PR이 생성되는지 확인하고 CI 워크플로 로그에서 pnpm 캐시 히트율과 설치 시간이 안정화되는지 검토한다.",
 T-000023,W-000003,모노레포 스캐폴딩,문서화,README 구조 섹션 업데이트(모노레포 트리/패키지 표),계획,Medium," ● 목적: 모노레포 구조와 패키지 역할을 문서로 명확히 제시해 신규 기여자의 온보딩 시간을 단축한다.
  ● 내용: README에 디렉터리 트리, 패키지별 역할/의존 관계 표, 공통 설정 참조 절차를 추가한다. 작업 순서를 정리해 패키지 생성 흐름을 안내한다.
  ● 점검: README 개정본에서 항목이 빠짐없이 소개되고 내부 링크/코드 블록이 최신 스캐폴딩 구조와 일치하는지 검토한다.",


### PR DESCRIPTION
## Summary
- add a governance task to lock down package naming and publish metadata for the pnpm workspace
- document an exports map contract task to complement the shared build pipeline
- add a CI automation task covering dependency updates and pnpm caching

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_69019852802083229d7135f2485b3a20