### PR TITLE
feat(tooling): enforce package governance policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ VS Code(Git Bash) · Windows · React+TypeScript · Node 22 LTS · pnpm(workspac
 
 > `pnpm -w list --depth -1` 명령으로 위 경로들이 워크스페이스에 인식되는지 수시로 점검한다.
 
+### 패키지 거버넌스 정책
+- [패키지 거버넌스 가이드](docs/package-governance.md)를 참고해 `@ara/` 스코프, 공개/비공개 정책, 메타데이터(`engines`, `license`, `repository`)를 맞춘다.
+- 새 패키지를 추가하거나 변경한 뒤에는 `pnpm run check:manifests` 로 자동 점검을 수행한다.
+
 ## 일정 (WBS/Tasks)
  **경로** : root/planning
  **WBS** : WBS.CSV

--- a/docs/package-governance.md
+++ b/docs/package-governance.md
@@ -1,0 +1,50 @@
+# 패키지 거버넌스 가이드 (T-000014)
+
+모든 `packages/*` 및 `apps/*` 매니페스트가 동일한 규칙을 따르도록 아래 정책을 유지한다. 규칙이 변경되면 본 문서를 먼저 업데이트한 뒤 자동 점검 스크립트를 수정한다.
+
+## 1. 네이밍 및 공개 범위
+
+| 구분 | name | private | publishConfig.access |
+| --- | --- | --- | --- |
+| 라이브러리(`packages/*`) | `@ara/<패키지>` | `false` (생략) | `public` |
+| 애플리케이션(`apps/*`) | 자유 형식 (예: `ara-storybook`) | `true` | 설정 금지 |
+
+- `packages/*` 경로의 패키지는 모두 `@ara/` 스코프를 사용한다.
+- `publishConfig.access` 를 `public` 으로 고정해 Changesets → npm 배포 플로우에서 접근 수준이 바뀌지 않도록 한다.
+- `apps/*` 경로는 브라우저 번들을 배포하지 않으므로 항상 `private: true` 로 유지하며, 실수로 공개 배포되지 않도록 `publishConfig` 를 사용하지 않는다.
+
+## 2. 공통 메타데이터
+
+| 필드 | 값/규칙 | 비고 |
+| --- | --- | --- |
+| `engines.node` | `">=22.0.0"` | Node 22 LTS 이상 고정 |
+| `license` | 현재는 `UNLICENSED` | 상업화 단계에서 실제 라이선스를 지정한다. |
+| `repository` | 깃 리포지터리 URL (예: `https://example.com/ara-monorepo.git`) | 실제 원격 주소로 교체 가능 |
+
+> **주의:** 라이선스/저장소 값은 실제 배포 전략이 확정되면 재검토한다. 값이 달라지면 `scripts/package-governance/check-manifests.mjs` 의 검증 규칙도 함께 업데이트해야 한다.
+
+## 3. 자동 검증 스크립트
+
+`scripts/package-governance/check-manifests.mjs` 는 `packages/*` 와 `apps/*` 하위의 `package.json` 을 순회하며 다음 항목을 검사한다.
+
+- `@ara/` 스코프 및 `publishConfig.access` = `public` (packages)
+- `private: true` 및 `publishConfig` 미사용 (apps)
+- `license`, `repository`, `engines.node (>=22)` 필드 존재 여부
+
+### 실행 방법
+
+```bash
+pnpm run check:manifests
+# 또는
+node scripts/package-governance/check-manifests.mjs
+```
+
+현재는 워크스페이스에 패키지가 없어 "확인할 패키지 매니페스트가 없습니다" 라는 메시지를 출력하며 종료된다. 패키지를 추가하는 즉시 규칙을 어기지 않았는지 확인한다.
+
+## 4. README 반영 체크리스트
+
+- README “모노레포 워크스페이스 경계” 섹션 아래에 본 문서를 링크한다.
+- 새 패키지를 만들 때 아래 항목을 확인한다.
+  1. `name` 스코프와 `private/publishConfig` 설정
+  2. `engines`, `license`, `repository` 필드
+  3. Changesets 릴리스 전에 `pnpm run check:manifests` 실행

--- a/package.json
+++ b/package.json
@@ -5,9 +5,18 @@
   "packageManager": "pnpm@10.5.2+sha512.da9dc28cd3ff40d0592188235ab25d3202add8a207afbedc682220e4a0029ffbff4562102b9e6e46b4e3f9e8bd53e6d05de48544b0c57d4b0179e22c76d1199b",
   "scripts": {
     "changeset": "changeset",
-    "release": "changeset version && changeset publish"
+    "release": "changeset version && changeset publish",
+    "check:manifests": "node ./scripts/package-governance/check-manifests.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.10"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://example.com/ara-monorepo.git"
   }
 }

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -53,12 +53,12 @@ T-000012,W-000002,Git 규범/가드,CI 최소골격 & 브랜치 보호,브랜치
           - 이부분은 혼자 개발 하니까 현제 제외 : 최소 1명 리뷰 요구. (옵션: Linear/Issue 링크, Conversations resolved 등)
  ● 효과: 실수 머지 방지, 품질 게이트 고정.
  ● 흐름: PR 생성 → CI 통과 + 리뷰 승인 없으면 Merge 버튼 비활성.",확인
-T-000013,W-000003,모노레포 스캐폴딩,워크스페이스 기준선,루트 워크스페이스 선언(pnpm workspaces),진행중,High," ● 목적: 모노레포 워크스페이스 경계를 명시해 신규 패키지가 설치·빌드 파이프라인에 자동 편입되도록 한다.
+T-000013,W-000003,모노레포 스캐폴딩,워크스페이스 기준선,루트 워크스페이스 선언(pnpm workspaces),완료,High," ● 목적: 모노레포 워크스페이스 경계를 명시해 신규 패키지가 설치·빌드 파이프라인에 자동 편입되도록 한다.
  ● 내용: pnpm-workspace.yaml을 packages/*, apps/*, scripts/* 및 예정 패키지 경로(packages/{tsconfig,eslint-config,tokens,core,react,icons}, apps/{storybook,showcase})로 확정하고 Changesets·CI 문서에 동일 경로를 반영한다.
- ● 점검: pnpm -w list --depth -1 결과에 모든 패키지가 노출되고 README/CI 안내가 같은 경로를 가리키는지 확인한다.",
-T-000014,W-000003,모노레포 스캐폴딩,패키지 거버넌스,패키지 네이밍/퍼블리시 정책 확정,계획,High," ● 목적: 패키지 식별자/배포 정책을 초기에 고정해 apps·라이브러리의 접근성 및 배포 안전성을 확보한다.
+ ● 점검: pnpm -w list --depth -1 결과에 모든 패키지가 노출되고 README/CI 안내가 같은 경로를 가리키는지 확인한다.",확인
+T-000014,W-000003,모노레포 스캐폴딩,패키지 거버넌스,패키지 네이밍/퍼블리시 정책 확정,진행중,High," ● 목적: 패키지 식별자/배포 정책을 초기에 고정해 apps·라이브러리의 접근성 및 배포 안전성을 확보한다.
  ● 내용: packages/*는 scope @ara/*로 명명하고 apps/* 패키지는 private:true, 라이브러리는 publishConfig.access: public으로 설정한다. 공통 engines { node: 22 이상 }, license, repository 필드를 통일하고 README에 명시한다.
- ● 점검: pnpm -w list --json 출력에서 scope가 일관되는지 확인하고 pnpm pack/publish --dry-run 시 metadata(license/repository/access)가 기대값과 일치하는지 검토한다.",
+ ● 점검: pnpm -w list --json 출력에서 scope가 일관되는지 확인하고 pnpm pack/publish --dry-run 시 metadata(license/repository/access)가 기대값과 일치하는지 검토한다.",확인
 T-000015,W-000003,모노레포 스캐폴딩,공통 설정 패키지,공통 tsconfig 패키지 초기화(packages/tsconfig),계획,High," ● 목적: 모든 패키지가 동일한 TypeScript 컴파일 기준을 사용해 빌드/테스트 결과가 일관되도록 한다.
  ● 내용: packages/tsconfig에 공유 설정 패키지를 만들고 루트 tsconfig.base.json을 정의해 모듈 해석, 경로 alias(@ara/*), JSX/emit 옵션을 고정한다. 각 패키지 tsconfig에서 extends하도록 가이드 문서를 포함한다.
  ● 점검: tokens/core/react 등의 샘플 tsconfig에 extends 경로가 연결되고 pnpm exec tsc --showConfig로 공통 설정이 반영되는지 확인한다.",

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -15,7 +15,7 @@ W-000002,T1,Git 규범/가드,완료,100,"Git 규범/가드
  ● PR: PR 템플릿 채움 → CODEOWNERS 자동 리뷰 요청 → CI가 pnpm 설치 검증(추후 test/build도).
  ● Merge: 보호 규칙 충족 시만 main 병합.
  ● 릴리스: Changesets 누적분을 액션이 읽어 버전/CHANGELOG/배포 자동화(세팅 후)"
-W-000003,T1,모노레포 스캐폴딩,계획,0,"pnpm 모노레포 기준선을 구축
+W-000003,T1,모노레포 스캐폴딩,진행중,10,"pnpm 모노레포 기준선을 구축
  ● workspaces 선언
  ● 공통 tsconfig/ESLint/Changesets 패키지
  ● 핵심 UI 패키지 및 앱 골격

--- a/scripts/package-governance/check-manifests.mjs
+++ b/scripts/package-governance/check-manifests.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+const EXPECTED_SCOPE = '@ara/';
+const LIB_EXPECTED_ACCESS = 'public';
+const MINIMUM_NODE = /^\s*(>=|\^)\s*22(\.|$)/;
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readPackageManifest(manifestPath) {
+  const raw = await fs.readFile(manifestPath, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`package.json 파싱 실패 (${manifestPath}): ${error.message}`);
+  }
+}
+
+async function listDirectSubdirectories(targetDir) {
+  try {
+    const entries = await fs.readdir(targetDir, { withFileTypes: true });
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => path.join(targetDir, entry.name));
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function hasRepositoryField(manifest) {
+  if (!manifest.repository) {
+    return false;
+  }
+  if (typeof manifest.repository === 'string') {
+    return manifest.repository.trim().length > 0;
+  }
+  if (typeof manifest.repository === 'object') {
+    return typeof manifest.repository.url === 'string' && manifest.repository.url.trim().length > 0;
+  }
+  return false;
+}
+
+function collectManifestIssues({ manifest, relativeDir, kind }) {
+  const issues = [];
+
+  if (!manifest.name || typeof manifest.name !== 'string') {
+    issues.push('name 필드가 비어 있습니다.');
+  }
+
+  if (!manifest.license || typeof manifest.license !== 'string' || manifest.license.trim().length === 0) {
+    issues.push('license 필드를 채워야 합니다.');
+  }
+
+  const enginesNode = manifest.engines?.node;
+  if (!enginesNode || !MINIMUM_NODE.test(enginesNode)) {
+    issues.push('engines.node 필드는 ">=22" 이상을 명시해야 합니다.');
+  }
+
+  if (!hasRepositoryField(manifest)) {
+    issues.push('repository 필드를 설정해야 합니다.');
+  }
+
+  if (kind === 'package') {
+    if (typeof manifest.name === 'string' && !manifest.name.startsWith(EXPECTED_SCOPE)) {
+      issues.push(`패키지 이름은 ${EXPECTED_SCOPE} 스코프를 사용해야 합니다.`);
+    }
+    if (manifest.private === true) {
+      issues.push('packages/* 경로의 패키지는 private: true를 사용할 수 없습니다.');
+    }
+    const access = manifest.publishConfig?.access;
+    if (access !== LIB_EXPECTED_ACCESS) {
+      issues.push(`publishConfig.access 값이 "${LIB_EXPECTED_ACCESS}" 여야 합니다.`);
+    }
+  }
+
+  if (kind === 'app') {
+    if (manifest.private !== true) {
+      issues.push('apps/* 경로의 패키지는 private: true를 설정해야 합니다.');
+    }
+    if (manifest.publishConfig?.access) {
+      issues.push('apps/* 경로의 패키지는 publishConfig.access를 설정하지 않습니다.');
+    }
+  }
+
+  return issues.length > 0 ? { relativeDir, issues } : null;
+}
+
+async function gatherManifests(kind, relativeRoot) {
+  const rootDir = path.join(repoRoot, relativeRoot);
+  const directories = await listDirectSubdirectories(rootDir);
+  const manifests = [];
+
+  for (const dir of directories) {
+    const manifestPath = path.join(dir, 'package.json');
+    if (!(await pathExists(manifestPath))) {
+      continue;
+    }
+
+    const manifest = await readPackageManifest(manifestPath);
+    const relativeDir = path.relative(repoRoot, dir);
+    manifests.push({ manifest, relativeDir, kind });
+  }
+
+  return manifests;
+}
+
+async function main() {
+  const manifests = [
+    ...(await gatherManifests('package', 'packages')),
+    ...(await gatherManifests('app', 'apps')),
+  ];
+
+  if (manifests.length === 0) {
+    console.log('확인할 패키지 매니페스트가 없습니다. (packages/*, apps/* 경로가 비어 있음)');
+    return;
+  }
+
+  const problems = manifests
+    .map(collectManifestIssues)
+    .filter(Boolean);
+
+  if (problems.length > 0) {
+    console.error('패키지 거버넌스 규칙을 위반한 매니페스트가 발견되었습니다:');
+    for (const problem of problems) {
+      console.error(`\n- ${problem.relativeDir}`);
+      for (const issue of problem.issues) {
+        console.error(`  • ${issue}`);
+      }
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  for (const manifest of manifests) {
+    console.log(`✅ ${manifest.relativeDir} - 정책을 준수합니다.`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- document package naming, privacy, and metadata requirements for packages/* and apps/*
- add an automated manifest governance checker and expose it via pnpm scripts
- note the new workflow in README and update planning records for T-000014 progress

## Testing
- pnpm run check:manifests *(warns about local Node 20 vs required Node >=22)*

------
https://chatgpt.com/codex/tasks/task_e_6901a05d2958832295be3308a9bbe7a0