### PR TITLE
feat: @ara/tokens 패키지 초기화

### DIFF
--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,0 +1,43 @@
+# @ara/tokens
+
+Ara 디자인 시스템 전반에서 사용하는 색상·타이포그래피 토큰을 제공하는 패키지다. React/웹 앱뿐 아니라 디자인 자동화 스크립트에서도 재사용할 수 있도록 TypeScript API와 JSON 산출물을 동시에 노출한다.
+
+## 설치
+
+모노레포 내에서는 pnpm 워크스페이스에 이미 포함되어 있으므로 별도 설치가 필요 없다.
+
+## 사용 방법
+
+### TypeScript/JavaScript
+
+```ts
+import { colors, typography, tokens, getColor } from "@ara/tokens";
+
+const primary = getColor("brand", "500");
+const bodyFontSize = typography.fontSize.md;
+```
+
+세분화된 모듈이 필요하면 경로를 지정해 가져올 수 있다.
+
+```ts
+import { typography } from "@ara/tokens/typography";
+```
+
+### JSON 소비자
+
+디자인 자동화나 비 Node.js 환경에서는 JSON 파일을 직접 읽을 수 있다.
+
+```ts
+import tokensJson from "@ara/tokens/tokens.json" assert { type: "json" };
+```
+
+JSON 구조는 `color`와 `typography` 두 최상위 키로 구성되어 있으며 TypeScript API와 동일한 값을 제공한다.
+
+## 개발 스크립트
+
+- `pnpm --filter @ara/tokens build` : `dist/` 디렉터리에 ESM 번들과 선언 파일을 생성한다.
+- `pnpm exec eslint packages/tokens` : 토큰 모듈에 대한 린트 검사를 실행한다.
+
+## 빌드 산출물
+
+`package.json` 의 `exports` 설정을 통해 기본 엔트리(`.`) 외에 `./colors`, `./typography`, `./tokens.json` 경로가 노출된다. 번들러는 `module`/`types` 필드를 이용해 ESM과 타입 선언을 자동으로 해상한다.

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@ara/tokens",
+  "version": "0.0.0",
+  "description": "Ara 디자인 시스템을 위한 디자인 토큰 모음",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./colors": {
+      "types": "./dist/colors.d.ts",
+      "default": "./dist/colors.js"
+    },
+    "./typography": {
+      "types": "./dist/typography.d.ts",
+      "default": "./dist/typography.js"
+    },
+    "./tokens.json": "./tokens.json"
+  },
+  "files": [
+    "dist",
+    "tokens.json",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --project tsconfig.json"
+  },
+  "keywords": [
+    "design tokens",
+    "colors",
+    "typography"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://example.com/ara-monorepo.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@ara/tsconfig": "workspace:*"
+  }
+}

--- a/packages/tokens/src/colors.ts
+++ b/packages/tokens/src/colors.ts
@@ -1,0 +1,49 @@
+export const colors = {
+  brand: {
+    "50": "#F5F9FF",
+    "100": "#E0EDFF",
+    "200": "#B8D5FF",
+    "300": "#8AB6FF",
+    "400": "#578DFF",
+    "500": "#2F6BFF",
+    "600": "#1F4FCC",
+    "700": "#173CA3",
+    "800": "#102A7A",
+    "900": "#0A1C52"
+  },
+  neutral: {
+    "50": "#F8FAFC",
+    "100": "#EEF2F6",
+    "200": "#E2E8F0",
+    "300": "#CBD5E1",
+    "400": "#94A3B8",
+    "500": "#64748B",
+    "600": "#475569",
+    "700": "#334155",
+    "800": "#1E293B",
+    "900": "#0F172A"
+  },
+  accent: {
+    "100": "#FDF4FF",
+    "200": "#FAE8FF",
+    "300": "#F5D0FE",
+    "400": "#E879F9",
+    "500": "#D946EF",
+    "600": "#C026D3",
+    "700": "#A21CAF",
+    "800": "#86198F",
+    "900": "#701A75"
+  }
+} as const;
+
+export type ColorTokens = typeof colors;
+export type ColorRampName = keyof ColorTokens;
+export type ColorRamp<TName extends ColorRampName = ColorRampName> = ColorTokens[TName];
+export type ColorShade<TName extends ColorRampName = ColorRampName> = keyof ColorTokens[TName] & string;
+
+export function getColor<R extends ColorRampName, S extends ColorShade<R>>(
+  ramp: R,
+  shade: S
+): ColorTokens[R][S] {
+  return colors[ramp][shade];
+}

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,0 +1,12 @@
+import { colors } from "./colors.js";
+import { typography } from "./typography.js";
+
+export * from "./colors.js";
+export * from "./typography.js";
+
+export const tokens = {
+  color: colors,
+  typography
+} as const;
+
+export type Tokens = typeof tokens;

--- a/packages/tokens/src/typography.ts
+++ b/packages/tokens/src/typography.ts
@@ -1,0 +1,41 @@
+export const typography = {
+  fontFamily: {
+    sans: "'Pretendard Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    mono: "'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace"
+  },
+  fontSize: {
+    xs: "0.75rem",
+    sm: "0.875rem",
+    md: "1rem",
+    lg: "1.25rem",
+    xl: "1.5rem"
+  },
+  lineHeight: {
+    tight: "1.25",
+    normal: "1.5",
+    relaxed: "1.75"
+  },
+  fontWeight: {
+    regular: 400,
+    medium: 500,
+    bold: 700
+  },
+  letterSpacing: {
+    tighter: "-0.01em",
+    normal: "0",
+    wider: "0.05em"
+  }
+} as const;
+
+export type TypographyTokens = typeof typography;
+export type TypographyCategory = keyof TypographyTokens;
+export type TypographyScale<
+  TCategory extends TypographyCategory = TypographyCategory
+> = TypographyTokens[TCategory];
+
+export function getTypographyValue<C extends TypographyCategory, K extends keyof TypographyTokens[C]>(
+  category: C,
+  key: K
+): TypographyTokens[C][K] {
+  return typography[category][key];
+}

--- a/packages/tokens/tokens.json
+++ b/packages/tokens/tokens.json
@@ -1,0 +1,67 @@
+{
+  "color": {
+    "brand": {
+      "50": "#F5F9FF",
+      "100": "#E0EDFF",
+      "200": "#B8D5FF",
+      "300": "#8AB6FF",
+      "400": "#578DFF",
+      "500": "#2F6BFF",
+      "600": "#1F4FCC",
+      "700": "#173CA3",
+      "800": "#102A7A",
+      "900": "#0A1C52"
+    },
+    "neutral": {
+      "50": "#F8FAFC",
+      "100": "#EEF2F6",
+      "200": "#E2E8F0",
+      "300": "#CBD5E1",
+      "400": "#94A3B8",
+      "500": "#64748B",
+      "600": "#475569",
+      "700": "#334155",
+      "800": "#1E293B",
+      "900": "#0F172A"
+    },
+    "accent": {
+      "100": "#FDF4FF",
+      "200": "#FAE8FF",
+      "300": "#F5D0FE",
+      "400": "#E879F9",
+      "500": "#D946EF",
+      "600": "#C026D3",
+      "700": "#A21CAF",
+      "800": "#86198F",
+      "900": "#701A75"
+    }
+  },
+  "typography": {
+    "fontFamily": {
+      "sans": "'Pretendard Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+      "mono": "'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace"
+    },
+    "fontSize": {
+      "xs": "0.75rem",
+      "sm": "0.875rem",
+      "md": "1rem",
+      "lg": "1.25rem",
+      "xl": "1.5rem"
+    },
+    "lineHeight": {
+      "tight": "1.25",
+      "normal": "1.5",
+      "relaxed": "1.75"
+    },
+    "fontWeight": {
+      "regular": 400,
+      "medium": 500,
+      "bold": 700
+    },
+    "letterSpacing": {
+      "tighter": "-0.01em",
+      "normal": "0",
+      "wider": "0.05em"
+    }
+  }
+}

--- a/packages/tokens/tsconfig.json
+++ b/packages/tokens/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@ara/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "emitDeclarationOnly": false
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- 색상·타이포그래피 토큰을 담은 @ara/tokens 패키지를 추가했습니다.
- TypeScript API, JSON 산출물, tsconfig 및 빌드 스크립트를 구성했습니다.
- 패키지 활용 방법과 제공 엔트리를 README에 문서화했습니다.

## Testing
- pnpm --filter @ara/tokens build
- pnpm run check:manifests

------
https://chatgpt.com/codex/tasks/task_e_6902a9e2b36c83228ede4ff0930051c0