### PR TITLE
feat: scaffold headless core package

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,27 @@
+# @ara/core
+
+Ara 디자인 시스템의 headless 코어 패키지입니다. 디자인 토큰과 상태 유틸리티를 묶어 UI 레이어와 분리된 비즈니스 로직을 제공합니다.
+
+## 설치
+
+```sh
+pnpm add @ara/core
+```
+
+## 사용법
+
+기본 테마를 생성하고 필요한 토큰만 부분적으로 오버라이드할 수 있습니다.
+
+```ts
+import { createTheme } from "@ara/core";
+
+const theme = createTheme({
+  color: {
+    brand: {
+      500: "#1E40AF"
+    }
+  }
+});
+```
+
+테마 객체는 `@ara/tokens`이 제공하는 기본 토큰을 기반으로 하며, React 등의 바인딩 레이어에서 그대로 사용할 수 있습니다.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "@ara/core",
+  "version": "0.0.0",
+  "description": "Ara 디자인 시스템의 headless 코어 유틸리티",
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./theme": {
+      "types": "./dist/theme.d.ts",
+      "default": "./dist/theme.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "design system",
+    "headless",
+    "theme"
+  ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://example.com/ara-monorepo.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@ara/tokens": "workspace:*"
+  },
+  "devDependencies": {
+    "@ara/tsconfig": "workspace:*",
+    "vitest": "^2.1.3"
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,2 @@
+export type { Theme, ThemeOverrides } from "./theme.js";
+export { createTheme, defaultTheme } from "./theme.js";

--- a/packages/core/src/theme.test.ts
+++ b/packages/core/src/theme.test.ts
@@ -1,0 +1,48 @@
+import { tokens } from "@ara/tokens";
+import { describe, expect, it } from "vitest";
+
+import { createTheme, defaultTheme } from "./theme.js";
+
+describe("createTheme", () => {
+  it("기본 토큰을 그대로 반환한다", () => {
+    const theme = createTheme();
+
+    expect(theme).toEqual(tokens);
+    expect(theme).not.toBe(tokens);
+  });
+
+  it("중첩된 토큰만 선택적으로 오버라이드한다", () => {
+    const theme = createTheme({
+      color: {
+        brand: {
+          500: "#123456"
+        }
+      }
+    });
+
+    expect(theme.color.brand["500"]).toBe("#123456");
+    expect(theme.typography.fontFamily.sans).toBe(tokens.typography.fontFamily.sans);
+  });
+
+  it("기본 토큰 객체를 변형하지 않는다", () => {
+    const original = tokens.color.brand["500"];
+
+    createTheme({
+      color: {
+        brand: {
+          500: "#654321"
+        }
+      }
+    });
+
+    expect(tokens.color.brand["500"]).toBe(original);
+  });
+});
+
+describe("defaultTheme", () => {
+  it("createTheme으로 생성된 불변 객체를 제공한다", () => {
+    expect(defaultTheme).toEqual(tokens);
+    expect(Object.isFrozen(defaultTheme)).toBe(true);
+    expect(Object.isFrozen(defaultTheme.color.brand)).toBe(true);
+  });
+});

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -1,0 +1,86 @@
+import { tokens } from "@ara/tokens";
+
+export type Theme = typeof tokens;
+
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Record<string, unknown> ? DeepPartial<T[K]> : T[K];
+};
+
+export type ThemeOverrides = DeepPartial<Theme>;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+function cloneValue<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneValue(item)) as unknown as T;
+  }
+
+  if (isPlainObject(value)) {
+    return Object.keys(value).reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = cloneValue((value as Record<string, unknown>)[key]);
+      return acc;
+    }, {}) as T;
+  }
+
+  return value;
+}
+
+function mergeObjects<T extends Record<string, unknown>>(base: T, override: DeepPartial<T> | undefined): T {
+  if (!override) {
+    return cloneValue(base);
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const key of Object.keys(base) as (keyof T)[]) {
+    const baseValue = base[key];
+    const overrideValue = override[key];
+
+    if (overrideValue === undefined) {
+      result[key as string] = cloneValue(baseValue);
+      continue;
+    }
+
+    if (isPlainObject(baseValue) && isPlainObject(overrideValue)) {
+      result[key as string] = mergeObjects(
+        baseValue as Record<string, unknown>,
+        overrideValue as DeepPartial<Record<string, unknown>>
+      );
+      continue;
+    }
+
+    result[key as string] = overrideValue as unknown;
+  }
+
+  for (const key of Object.keys(override)) {
+    if ((base as Record<string, unknown>)[key] === undefined) {
+      result[key] = override[key];
+    }
+  }
+
+  return result as T;
+}
+
+function deepFreeze<T>(value: T): T {
+  if (Array.isArray(value)) {
+    value.forEach((item) => deepFreeze(item));
+    return Object.freeze(value) as unknown as T;
+  }
+
+  if (isPlainObject(value)) {
+    Object.values(value).forEach((item) => {
+      deepFreeze(item);
+    });
+    return Object.freeze(value) as T;
+  }
+
+  return value;
+}
+
+export function createTheme(overrides: ThemeOverrides = {}): Theme {
+  return mergeObjects(tokens, overrides);
+}
+
+export const defaultTheme = deepFreeze(createTheme());

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "paths": {
+      "@ara/tokens": ["../tokens/dist/index.d.ts", "../tokens/dist/index.js"],
+      "@ara/tokens/*": ["../tokens/dist/*.d.ts", "../tokens/dist/*.js"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reporter: ["text", "html"],
+      reportsDirectory: "coverage"
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add the @ara/core headless package with theme creation utilities and default theme exports
- set up package metadata, TypeScript configuration, and Vitest harness aligned with existing workspace tooling

## Testing
- pnpm --filter @ara/tokens build
- pnpm --filter @ara/core build
- pnpm --filter @ara/core test *(fails: vitest CLI is unavailable in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902b553f9c4832291faa660d01a34c4