### PR TITLE
Align React TypeScript configs with Vitest setup

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,7 @@
   "sideEffects": false,
   "scripts": {
     "prebuild": "pnpm --filter @ara/core build",
-    "build": "tsc --project tsconfig.json",
+    "build": "tsc --project tsconfig.build.json",
     "pretest": "pnpm --filter @ara/core build",
     "test": "pnpm exec vitest run",
     "test:watch": "pnpm exec vitest"

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "sourceMap": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "paths": {
+      "@ara/core": ["../core/dist/index.d.ts", "../core/dist/index.js"],
+      "@ara/core/*": ["../core/dist/*.d.ts", "../core/dist/*.js"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.stories.tsx"
+  ]
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,22 +1,18 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.build.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist",
-    "jsx": "react-jsx",
-    "declaration": true,
-    "declarationMap": true,
-    "emitDeclarationOnly": false,
-    "sourceMap": true,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "paths": {
-      "@ara/core": ["../core/dist/index.d.ts", "../core/dist/index.js"],
-      "@ara/core/*": ["../core/dist/*.d.ts", "../core/dist/*.js"]
-    }
+    "noEmit": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.stories.tsx"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.stories.tsx",
+    "vitest.config.ts",
+    "vitest.setup.ts"
+  ],
+  "exclude": []
 }


### PR DESCRIPTION
## Summary
- add a build-specific TypeScript configuration that excludes tests from the emitted bundle
- update the package tsconfig used by editors to include tests and Vitest/Jest-DOM types
- point the React package build script at the new build config

## Testing
- pnpm --filter @ara/react test --run

------
https://chatgpt.com/codex/tasks/task_e_6902f4a8856883228bc850cf84858239