### PR TITLE
Fix Button theme override test typing

### DIFF
--- a/packages/react/src/components/button/Button.test.tsx
+++ b/packages/react/src/components/button/Button.test.tsx
@@ -33,8 +33,10 @@ describe("Button", () => {
   });
 
   it("테마 덮어쓰기를 반영한다", () => {
+    const customBrand500: string = "#FF6B00";
+
     render(
-      <AraProvider theme={{ color: { brand: { "500": "#FF6B00" } } }}>
+      <AraProvider theme={{ color: { brand: { "500": customBrand500 } } }}>
         <Button>경고</Button>
       </AraProvider>
     );


### PR DESCRIPTION
## Summary
- widen the custom brand color override in the Button test so the override can use an arbitrary string value

## Testing
- pnpm --filter @ara/react test -- --run Button

------
https://chatgpt.com/codex/tasks/task_e_6902f9bd702c8322ac172c07b08d590e