### PR TITLE
Fix DeepPartial to allow mutable theme overrides

### DIFF
--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -15,7 +15,9 @@ type WidenIfLiteral<T> = T extends Primitive
   : T;
 
 export type DeepPartial<T> = {
-  [K in keyof T]?: T[K] extends Record<string, unknown> ? DeepPartial<T[K]> : WidenIfLiteral<T[K]>;
+  -readonly [K in keyof T]?: T[K] extends Record<string, unknown>
+    ? DeepPartial<T[K]>
+    : WidenIfLiteral<T[K]>;
 };
 
 export type ThemeOverrides = DeepPartial<Theme>;


### PR DESCRIPTION
## Summary
- remove the readonly modifier from DeepPartial so nested theme override properties widen to primitive types

## Testing
- pnpm --filter @ara/react test -- --run

------
https://chatgpt.com/codex/tasks/task_e_6902faa6b9c08322b044f397182f9752