### PR TITLE
Fix Storybook symlink resolution on Windows

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -12,7 +12,11 @@ const config: StorybookConfig = {
   },
   viteFinal: async (config) => {
     config.resolve = config.resolve ?? {};
-    config.resolve.preserveSymlinks = true;
+    // Storybook's published ESM bundles expect Node's default symlink resolution
+    // behaviour so that transitive dependencies inside the pnpm virtual store are
+    // visible. Enabling preserveSymlinks on Windows breaks that resolution and
+    // causes "Could not resolve '@storybook/..." errors during bundling.
+    config.resolve.preserveSymlinks = process.platform !== "win32";
     return config;
   }
 };


### PR DESCRIPTION
## Summary
- avoid forcing Vite to preserve symlinks on Windows so Storybook can resolve its transitive packages
- document the reasoning inline to prevent future regressions

## Testing
- BROWSER=none pnpm --filter @ara/storybook storybook -- --smoke-test *(fails: Storybook CLI attempts to spawn the configured browser in this CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_6903100bbd1883228fb2acf291082453