### PR TITLE
chore: finalize apps scaffolding for T-000021

### DIFF
--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -28,6 +28,7 @@
     "@types/react-dom": "^18.2.23",
     "@vitejs/plugin-react": "^4.3.3",
     "typescript": "^5.5.4",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "vite-tsconfig-paths": "^5.1.2"
   }
 }

--- a/apps/showcase/vite.config.ts
+++ b/apps/showcase/vite.config.ts
@@ -1,8 +1,49 @@
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    tsconfigPaths({
+      projects: [
+        resolve(currentDir, "tsconfig.json"),
+        resolve(currentDir, "../../tsconfig.base.json")
+      ]
+    }),
+    react()
+  ],
+  resolve: {
+    alias: [
+      {
+        find: "@ara/react",
+        replacement: resolve(currentDir, "../../packages/react/src")
+      },
+      {
+        find: "@ara/react/",
+        replacement: `${resolve(currentDir, "../../packages/react/src")}/`
+      },
+      {
+        find: "@ara/core",
+        replacement: resolve(currentDir, "../../packages/core/src")
+      },
+      {
+        find: "@ara/core/",
+        replacement: `${resolve(currentDir, "../../packages/core/src")}/`
+      },
+      {
+        find: "@ara/tokens",
+        replacement: resolve(currentDir, "../../packages/tokens/src")
+      },
+      {
+        find: "@ara/tokens/",
+        replacement: `${resolve(currentDir, "../../packages/tokens/src")}/`
+      }
+    ]
+  },
   server: {
     port: 5173
   }

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -77,9 +77,9 @@ T-000019,W-000003,모노레포 스캐폴딩,디자인 시스템 토대,React 바
 T-000020,W-000003,모노레포 스캐폴딩,디자인 시스템 토대,아이콘 패키지 초기화(packages/icons),완료,Medium," ● 목적: 공통 아이콘 자산을 모듈화해 React 등 소비자 패키지가 일관된 인터페이스로 사용하도록 한다.
  ● 내용: SVG 기반 아이콘 패키지를 생성하고 최소 1개 샘플 아이콘을 추가한다. tree-shaking 가능한 export 구조와 타입 선언 생성을 설정한다.
  ● 점검: pnpm --filter @ara/icons build 산출물에서 ESM/CJS 번들과 d.ts가 생성되고 React 패키지에서 아이콘 import가 작동하는지 확인한다.",확인
-T-000021,W-000003,모노레포 스캐폴딩,앱/데모 구성,"앱 골격 생성(apps/storybook, apps/showcase)",계획,High," ● 목적: 컴포넌트 개발·데모 환경을 초기 구축해 패키지 변경을 즉시 확인할 수 있게 한다.
+T-000021,W-000003,모노레포 스캐폴딩,앱/데모 구성,"앱 골격 생성(apps/storybook, apps/showcase)",완료,High," ● 목적: 컴포넌트 개발·데모 환경을 초기 구축해 패키지 변경을 즉시 확인할 수 있게 한다.
  ● 내용: apps/storybook과 apps/showcase를 스캐폴딩하고 공통 tsconfig·ESLint 설정을 참조하도록 연결한다. pnpm 스크립트(pnpm storybook, pnpm showcase dev 등)를 준비한다.
- ● 점검: pnpm --filter @ara/storybook storybook --smoke-test, pnpm --filter @ara/showcase dev 실행이 성공하고 공통 설정 경고가 없는지 확인한다.",
+ ● 점검: pnpm --filter @ara/storybook storybook --smoke-test, pnpm --filter @ara/showcase dev 실행이 성공하고 공통 설정 경고가 없는지 확인한다.",확인
 T-000022,W-000003,모노레포 스캐폴딩,빌드/테스트 파이프라인,빌드 파이프라인 연결(Rollup 설정 공유·d.ts 출력 확인),계획,High," ● 목적: 모든 패키지가 동일한 빌드·테스트 파이프라인을 공유해 산출물 형식과 품질 검증을 표준화한다.
  ● 내용: 공통 Rollup/Vite 라이브러리 설정을 추출해 tokens/core/react/icons 패키지에서 재사용하고 d.ts/번들 생성 흐름을 마련한다. CI에서 pnpm -r build, pnpm -r test, Storybook smoke 테스트를 통합한다.
  ● 점검: 공통 설정을 참조한 패키지 빌드가 성공하고 CI 로그에 빌드·테스트·Storybook 단계가 모두 통과하는지 확인한다.",

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -15,7 +15,7 @@ W-000002,T1,Git 규범/가드,완료,100,"Git 규범/가드
  ● PR: PR 템플릿 채움 → CODEOWNERS 자동 리뷰 요청 → CI가 pnpm 설치 검증(추후 test/build도).
  ● Merge: 보호 규칙 충족 시만 main 병합.
  ● 릴리스: Changesets 누적분을 액션이 읽어 버전/CHANGELOG/배포 자동화(세팅 후)",--
-W-000003,T1,모노레포 스캐폴딩,진행중,55,"pnpm 모노레포 기준선을 구축
+W-000003,T1,모노레포 스캐폴딩,진행중,60,"pnpm 모노레포 기준선을 구축
  ● workspaces 선언
  ● 공통 tsconfig/ESLint/Changesets 패키지
  ● 핵심 UI 패키지 및 앱 골격

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       vite:
         specifier: ^5.4.1
         version: 5.4.21(@types/node@24.9.2)
+      vite-tsconfig-paths:
+        specifier: ^5.1.2
+        version: 5.1.4(typescript@5.9.3)(vite@5.4.21(@types/node@24.9.2))
 
   apps/storybook:
     dependencies:
@@ -1706,6 +1709,9 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2588,6 +2594,16 @@ packages:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
 
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -2662,6 +2678,14 @@ packages:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@5.4.21:
     resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
@@ -4617,6 +4641,8 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  globrex@0.1.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -5538,6 +5564,10 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
+  tsconfck@3.1.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -5649,6 +5679,17 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@5.4.21(@types/node@24.9.2)):
+    dependencies:
+      debug: 4.4.3
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.3)
+    optionalDependencies:
+      vite: 5.4.21(@types/node@24.9.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@5.4.21(@types/node@24.9.2):
     dependencies:


### PR DESCRIPTION
## Summary
- add vite-tsconfig-paths and explicit workspace aliases so the showcase dev server can resolve @ara/* packages without a prebuild
- mark task T-000021 as completed in the planning sheets and bump the W-000003 progress indicator

## Testing
- `pnpm --filter @ara/storybook storybook --smoke-test`
- `pnpm --filter @ara/showcase dev -- --host 0.0.0.0 --port 4173 --clearScreen false`
- `pnpm --filter @ara/showcase build`


------
https://chatgpt.com/codex/tasks/task_e_6903141c6b04832293705658d04c434c