### PR TITLE
T-000023: 라이브러리 exports 계약 정비

### DIFF
--- a/docs/exports-map-contract.md
+++ b/docs/exports-map-contract.md
@@ -1,0 +1,37 @@
+# 빌드 산출물 Exports 계약 (T-000023)
+
+`packages/*` 라이브러리가 배포하는 ESM 번들과 타입 선언의 엔트리 포인트를 고정해 소비자 애플리케이션이 일관된 방식으로 모듈을 로딩할 수 있도록 한다.
+
+## 공통 규칙
+
+- `package.json` 필드
+  - `type = "module"`
+  - `main`, `module`, `types` 는 모두 `dist/` 산출물을 가리킨다.
+  - `sideEffects = false` 로 트리쉐이킹이 안전함을 명시한다.
+  - `exports` 에는 기본 엔트리(`.`)와 문서화된 서브패스를 모두 선언한다.
+  - `typesVersions` 는 `dist/*.d.ts` 파일과 서브패스를 연결해 오래된 TypeScript 모듈 해상 모드에서도 타입을 찾을 수 있도록 한다.
+  - `./package.json` 은 항상 `exports` 에 노출해 도구가 메타데이터를 읽을 수 있게 한다.
+- Rollup 빌드는 `preserveModules` + 선언 파일 생성을 사용하여 `dist/` 경로가 `src/` 구조와 1:1 로 매핑되도록 유지한다.
+
+## 패키지별 엔트리 포인트
+
+| 패키지 | 기본 엔트리 | 추가 엔트리 |
+| --- | --- | --- |
+| `@ara/tokens` | `.` | `./colors`, `./typography`, `./tokens.json`, `./package.json` |
+| `@ara/core` | `.` | `./theme`, `./package.json` |
+| `@ara/icons` | `.` | `./icons/arrow-right`, `./types`, `./package.json` |
+| `@ara/react` | `.` | `./theme`, `./components`, `./components/button`, `./button`, `./package.json` |
+
+각 엔트리는 `types + import(default)` 페어를 제공한다. CJS 번들을 제공하지 않으므로 `require` 조건은 노출하지 않는다.
+
+## 타입 선언 해상 규칙
+
+- 모든 패키지는 `typesVersions` 를 통해 `dist/*.d.ts` 산출물과 서브패스를 직접 연결한다.
+- React 패키지처럼 `components/*/index.d.ts` 구조를 사용하는 경우, `typesVersions` 에 동일한 패턴(`"components/*": ["dist/components/*/index.d.ts"]`)을 등록한다.
+- 추가 엔트리를 늘릴 때에는 `exports` 와 `typesVersions` 를 동시에 업데이트하고, 해당 경로가 `dist/` 에 생성되는지 `pnpm --filter <패키지> build` 후 확인한다.
+
+## 검증 절차
+
+1. `pnpm --filter @ara/* build` 로 모든 패키지의 산출물을 생성한다.
+2. `pnpm --filter @ara/* pack --dry-run` 을 실행해 패키지 메타데이터(`exports`, `types`, `sideEffects`)가 기대값과 일치하는지 확인한다.
+3. 샘플 소비자(예: `apps/showcase`)에서 `@ara/<패키지>` 와 서브패스 import 를 테스트한다.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,11 +9,24 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./theme": {
       "types": "./dist/theme.d.ts",
+      "import": "./dist/theme.js",
       "default": "./dist/theme.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "theme": [
+        "dist/theme.d.ts"
+      ],
+      "*": [
+        "dist/*.d.ts"
+      ]
     }
   },
   "files": [

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -9,15 +9,32 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./icons/arrow-right": {
       "types": "./dist/icons/arrow-right.d.ts",
+      "import": "./dist/icons/arrow-right.js",
       "default": "./dist/icons/arrow-right.js"
     },
     "./types": {
       "types": "./dist/types.d.ts",
+      "import": "./dist/types.js",
       "default": "./dist/types.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "icons/*": [
+        "dist/icons/*.d.ts"
+      ],
+      "types": [
+        "dist/types.d.ts"
+      ],
+      "*": [
+        "dist/*.d.ts"
+      ]
     }
   },
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,11 +9,48 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./theme": {
+      "types": "./dist/theme/index.d.ts",
+      "import": "./dist/theme/index.js",
+      "default": "./dist/theme/index.js"
+    },
+    "./components": {
+      "types": "./dist/components/index.d.ts",
+      "import": "./dist/components/index.js",
+      "default": "./dist/components/index.js"
+    },
+    "./components/button": {
+      "types": "./dist/components/button/index.d.ts",
+      "import": "./dist/components/button/index.js",
+      "default": "./dist/components/button/index.js"
     },
     "./button": {
       "types": "./dist/components/button/index.d.ts",
+      "import": "./dist/components/button/index.js",
       "default": "./dist/components/button/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "components": [
+        "dist/components/index.d.ts"
+      ],
+      "components/*": [
+        "dist/components/*/index.d.ts"
+      ],
+      "button": [
+        "dist/components/button/index.d.ts"
+      ],
+      "theme": [
+        "dist/theme/index.d.ts"
+      ],
+      "*": [
+        "dist/*.d.ts"
+      ]
     }
   },
   "files": [

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -40,7 +40,9 @@ JSON 구조는 `color`와 `typography` 두 최상위 키로 구성되어 있으�
 
 ## 빌드 산출물
 
-`package.json` 의 `exports` 설정을 통해 기본 엔트리(`.`) 외에 `./colors`, `./typography`, `./tokens.json` 경로가 노출된다. 번들러는 `module`/`types` 필드를 이용해 ESM과 타입 선언을 자동으로 해상한다.
+- `package.json` 의 `exports` 는 기본 엔트리(`.`) 외에 `./colors`, `./typography`, `./tokens.json`, `./package.json` 경로를 고정적으로 노출한다.
+- 모든 엔트리는 `types` + `import(default)` 페어를 제공하므로 ESM 번들러와 TypeScript가 동일한 모듈 해상 결과를 갖는다.
+- `typesVersions` 는 `dist/*.d.ts` 파일과 서브패스를 직접 연결해, 오래된 TypeScript 모듈 해상 모드에서도 선언 파일을 안정적으로 찾을 수 있도록 한다.
 
 ## Testing
 

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -9,17 +9,34 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./colors": {
       "types": "./dist/colors.d.ts",
+      "import": "./dist/colors.js",
       "default": "./dist/colors.js"
     },
     "./typography": {
       "types": "./dist/typography.d.ts",
+      "import": "./dist/typography.js",
       "default": "./dist/typography.js"
     },
-    "./tokens.json": "./tokens.json"
+    "./tokens.json": "./tokens.json",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "colors": [
+        "dist/colors.d.ts"
+      ],
+      "typography": [
+        "dist/typography.d.ts"
+      ],
+      "*": [
+        "dist/*.d.ts"
+      ]
+    }
   },
   "files": [
     "dist",


### PR DESCRIPTION
## 요약
- @ara/{tokens,core,icons,react} package.json의 exports를 import/types 페어로 재정렬하고 package.json 서브패스 및 typesVersions를 추가했습니다.
- React 패키지에 theme/components 서브패스와 button 별칭을 노출해 소비자 import 경로를 명시했습니다.
- exports-map-contract 문서를 작성하고 tokens README를 최신 빌드 산출물 계약에 맞게 보강했습니다.

## 테스트
- pnpm --filter @ara/tokens build
- pnpm --filter @ara/core build
- pnpm --filter @ara/icons build
- pnpm --filter @ara/react build
- pnpm --filter @ara/tokens exec npm pack --dry-run
- pnpm --filter @ara/core exec npm pack --dry-run
- pnpm --filter @ara/icons exec npm pack --dry-run
- pnpm --filter @ara/react exec npm pack --dry-run

------
https://chatgpt.com/codex/tasks/task_e_6903f666b8648322bb2183db33c22d17