### PR TITLE
docs(wbs): Button v0 Comp WBS 추가와 하위 Task 생성

### DIFF
--- a/packages/react/src/components/button/README.md
+++ b/packages/react/src/components/button/README.md
@@ -1,0 +1,166 @@
+# Button
+
+> 파일: `packages/react/src/components/button/README.md`  
+> 범위: 일반 버튼/링크 버튼. `ToggleButton(pressed)`은 **비포함**(별도 컴포넌트).
+
+## 1) 목적 / 범위
+- **목적:** tokens → core(headless) → react 바인딩 흐름을 **Button**으로 검증하고, 외부에 불변 약속(Props/동작/A11y/Exports)을 고정.
+- **성공 기준:** 테스트·스토리·빌드·Exports가 본 계약과 일치, canary 배포 가능.
+
+---
+
+## 2) Public API (Props 계약)
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **variant** | solid · outline · ghost | solid | 시각 스타일 변형. 토큰(CSS 변수)로 값 주입. |
+| **tone** | primary · neutral · danger | primary | 의미/강조 톤. 색 토큰에 매핑. |
+| **size** | sm · md · lg | md | 높이·패딩·폰트 크기 세트. |
+| **disabled** | boolean | false | 상호작용 차단. 버튼은 `disabled`, 링크는 `aria-disabled="true"`+클릭/키 이벤트 취소. |
+| **loading** | boolean | false | 상호작용 차단+스피너 슬롯, `aria-busy="true"`. |
+| **leadingIcon** | 아이콘 노드 | — | 라벨 앞 아이콘(아이콘 전용일 땐 `aria-label` 필수). |
+| **trailingIcon** | 아이콘 노드 | — | 라벨 뒤 아이콘. |
+| **fullWidth** | boolean | false | 너비 100% 확장. |
+| **asChild** | boolean | false | 폴리모픽 렌더링(예: 라우터 링크). **요구:** 자식이 `ref`·DOM props 전달 가능. |
+| **href** | 문자열(URL) | — | 존재 시 링크 모드로 렌더. 키보드/press 계약 동일 유지. |
+| **type** | button · submit · reset | button | 버튼 모드에서만 의미(링크 모드 무시). 기본값은 폼 오작동 방지 목적의 `button`. |
+| **onPress** | 이벤트 핸들러 | — | 클릭+Enter+Space 통합 “확정” 이벤트. `disabled/loading` 시 발화 없음. |
+| **onPressStart** | 이벤트 핸들러 | — | 누름 시작(마우스 다운/Space down). |
+| **onPressEnd** | 이벤트 핸들러 | — | 누름 종료(마우스 업/Space up). 영역 이탈 시 취소. |
+| **aria-label** | 문자열 | — | 아이콘만 렌더 시 **필수**. |
+| **className / style** | 문자열 / 스타일 | — | 사용자 정의 최종 병합(충돌 시 사용자 정의 우선). |
+| **ref** | 요소 참조 | — | 실제 렌더된 버튼/링크 요소로 포워딩. |
+| **기타 DOM 속성** | 표준 버튼/앵커 속성 | — | 유효한 속성은 그대로 전달(`target`, `rel`, `download` 등). `target="_blank"` 시 `rel="noopener noreferrer"` 권고. |
+
+> **Defaults:** `variant='solid'`, `tone='primary'`, `size='md'`, `type='button'`  
+> **이벤트 의미:** `onPress`는 클릭+Enter+Space **통합 확정**. `disabled | loading`이면 발화 금지.
+
+---
+
+## 3) 동작 계약 (Behavior)
+
+- **키보드:**  
+  - 버튼: Enter/Space → press( Space는 down=pressStart, up=pressEnd/press ).  
+  - 링크 모드: Enter 기본 클릭 + **Space도 press로 동작**(기본 스크롤 취소 후 클릭 합성).
+- **마우스/터치:** 누름(pressStart)→떼기(pressEnd)→press. 포인터가 영역 이탈하면 취소.
+- **Disabled:** 포커스/press 차단, hover/active 스타일 비활성.
+- **Loading:** press 차단, `aria-busy="true"`, spinner 표시(라벨 유지).
+- **폼 연동:** `type="submit"`일 때 네이티브 폼 제출 유지(중복 press 방지). 기본은 `button`.
+
+---
+
+## 4) 접근성 계약 (A11y)
+
+- 요소/역할: 기본은 `<button>`. 링크 모드여도 키보드 계약(Enter/Space) 동일.  
+- ARIA:
+  - `disabled` → 버튼: `disabled`; 링크: `aria-disabled="true"` + 상호작용 취소  
+  - `loading`  → `aria-busy="true"`(spinner는 `aria-hidden="true"`)
+- 포커스 링: 키보드 유입에서만 명확(마우스 클릭 시 최소화). `:focus-visible` 우선.
+- RTL: 아이콘 정렬, 여백, 포커스 링 방향성 확인.
+
+---
+
+## 5) 시각/토큰 계약 (Tokens → CSS Vars)
+
+- 상태별 CSS 변수(오버라이드 가능):  
+  `--ara-btn-bg`, `--ara-btn-fg`, `--ara-btn-border`, `--ara-btn-shadow`,  
+  `--ara-btn-bg-hover`, `--ara-btn-fg-hover`, `--ara-btn-border-hover`,  
+  `--ara-btn-bg-active`, `--ara-btn-fg-active`, `--ara-btn-border-active`,  
+  `--ara-btn-radius`, `--ara-btn-gap`, `--ara-btn-px`, `--ara-btn-py`,  
+  `--ara-btn-font`, `--ara-btn-font-size`, `--ara-btn-line-height`
+- 변형 매핑(예):  
+  `variant = solid|outline|ghost` → 위 변수 세트 값 주입  
+  `size = sm|md|lg` → `px/py/font-size/line-height` 조합  
+  `tone = primary|neutral|danger` → 팔레트 바인딩
+- **data-attributes(스타일 훅):**  
+  `[data-variant]`, `[data-tone]`, `[data-size]`, `[data-loading]`, `[data-disabled]`, `[data-state="hover|active|focus-visible"]`
+
+---
+
+## 6) 커스터마이징 레벨
+
+1. **Props/Variants**(variant/tone/size/slots/fullWidth/asChild)  
+2. **스타일 표면**: `className`/`style` + `data-*` + **CSS 변수 오버라이드**  
+3. **폴리모픽**: `asChild`로 임의 태그/라우터 링크 치환(Ref/props 전달 유지)  
+4. **헤드리스**: `@ara/core/useButton`으로 **UI 완전 자율 구성** 가능
+
+---
+
+## 7) 컴포지션 / 슬롯
+
+- 구조: `root` · `icon--leading` · `label` · `spinner` · `icon--trailing`  
+- 클래스 병합: 내부 기본 클래스 → 사용자 `className` **최후 우선**(충돌 시 사용자 승)
+
+---
+
+## 8) Exports 계약
+
+- **@ara/react**  
+  - `@ara/react/button` → `Button`, `ButtonProps`  
+  - `@ara/react/unstyled/button` → 스타일 없는 기저(슬롯만)
+- **@ara/core**  
+  - `@ara/core/use-button` → `useButton`, `PressEvent`
+- **package.json (react 패키지)**  
+  - `exports`: `./button`(ESM) + `types`, `sideEffects:false`  
+  - Node ≥ 22, ESM 우선, d.ts 포함
+
+---
+
+## 9) 성능/호환
+
+- SSR/StrictMode 안전, 포인터·키 이벤트 중복 억제, 불필요한 리렌더 방지(필요 시 `memo` 고려).  
+- 포커스 관리는 브라우저 기본 흐름 우선, 키보드 전용 포커스 링.
+
+---
+
+## 10) 에지 케이스
+
+- `disabled && loading` → **disabled 우선**(상호작용 완전 차단) + busy 시각 상태 병행 가능  
+- `href && disabled` → anchor 렌더 + `aria-disabled` + 클릭/키 이벤트 취소  
+- **아이콘만** 있을 때 → `aria-label` **필수**
+
+---
+
+## 11) 테스트 계획 (Vitest + RTL)
+
+- 키보드: Enter/Space press 시퀀스, focus-visible 표시  
+- 마우스/터치: pressStart/End/press 순서, 영역 이탈 취소  
+- 상태: `disabled`/`loading` 상호작용 차단 + ARIA 적용  
+- 렌더: `asChild`/`href` 브랜치, ref 포워딩, 클래스 병합  
+- 스타일 훅: `data-*`/CSS var 존재 최소 스냅  
+- **폼 제출:** `type="submit"` 네이티브 동작 유지, 중복 press 방지 검증  
+- **링크 보안:** `target="_blank"` 시 `rel` 자동·문서화 확인
+
+---
+
+## 12) Storybook/문서 (MDX)
+
+- Stories: `Playground`, `Variants`, `Tones`, `Sizes`, `WithIcons`, `Loading`, `AsLink`, `FullWidth`  
+- Docs: Props 테이블(자동), A11y 가이드, 커스터마이징 예시(CSS var override, Tailwind, asChild)
+
+---
+
+## 13) 수용 기준(AC)
+
+- [ ] 모든 Props/동작이 본 계약과 일치  
+- [ ] A11y(키보드/ARIA) 테스트 통과  
+- [ ] Storybook smoke + Controls 동작  
+- [ ] `@ara/react/button` ESM+types 정상 임포트  
+- [ ] CSS var & data-* 커스터마이징 예시 문서화  
+- [ ] Changesets canary 발행 가능
+
+---
+
+## 14) 변경 규칙(SemVer)
+
+- **Major:** Props 이름/타입 변경, ARIA/키 동작 변경, Exports 경로 변경, CSS var/data-* 키 변경  
+- **Minor:** 신규 variant/tone/size 추가, 비파괴적 시각 개선  
+- **Patch:** 버그/접근성 수정, 내부 성능 개선
+
+---
+
+## 15) 참고
+
+- 소비 경로: `import { Button } from '@ara/react/button'`  
+- 헤드리스: `import { useButton } from '@ara/core/use-button'`  
+- 비범위: `ToggleButton(pressed)`는 별도 WBS

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -95,3 +95,30 @@ T-000025,W-000003,모노레포 스캐폴딩,CI/운영 자동화,의존성 자동
 T-000026,W-000003,모노레포 스캐폴딩,문서화,README 구조 섹션 업데이트(모노레포 트리/패키지 표),계획,Medium," ● 목적: 모노레포 구조와 패키지 역할을 문서로 명확히 제시해 신규 기여자의 온보딩 시간을 단축한다.
  ● 내용: README에 디렉터리 트리, 패키지별 역할/의존 관계 표, 공통 설정 참조 절차를 추가한다. 작업 순서를 정리해 패키지 생성 흐름을 안내한다.
  ● 점검: README 개정본에서 항목이 빠짐없이 소개되고 내부 링크/코드 블록이 최신 스캐폴딩 구조와 일치하는지 검토한다.",
+T-000027,W-000004,Button v0 Comp,계약/설계,API 계약 정의(Button),계획,High," ● 목적: Props 목록과 기본값, 이벤트 의미(onPress 계열), 폴리모픽(asChild) 및 링크 모드 범위 확정
+ ● 산출물: packages/react/src/components/button/README.md 계약 섹션 확정
+ ● 점검: 리뷰 승인 후 범위 동결(변경은 후속 이슈로)", 
+T-000028,W-000004,Button v0 Comp,코어(headless),useButton 로직 구현,계획,High," ● 내용: press 시작/종료/확정 시퀀스, disabled 및 loading 차단, Enter 및 Space 키 매핑
+ ● 산출물: packages/core/use-button 구현 및 유닛 테스트 골격
+ ● 점검: pnpm --filter @ara/core test 통과", 
+T-000029,W-000004,Button v0 Comp,React 바인딩,React Button 구현,계획,High," ● 내용: forwardRef, className 병합, data-* 상태 표식, href 및 asChild 처리, ref 전달
+ ● 산출물: packages/react/button 컴포넌트 기본 구현
+ ● 점검: 샘플 임포트 및 렌더 스모크 테스트", 
+T-000030,W-000004,Button v0 Comp,접근성,A11y 규정 적용,계획,High," ● 내용: role 및 aria 적용(aria-disabled, aria-busy), focus-visible 링, 링크 모드 일관 키보드 동작
+ ● 산출물: 접근성 가이드 요약 및 테스트 케이스
+ ● 점검: 키보드 시나리오와 ARIA 기대값 통과", 
+T-000031,W-000004,Button v0 Comp,테스트,Vitest+RTL 상호작용 테스트,계획,High," ● 내용: 키보드(Enter 및 Space), 마우스/터치, 영역 이탈 취소, disabled 및 loading 차단 검증
+ ● 산출물: 테스트 스위트 및 스냅 최소화
+ ● 점검: pnpm --filter @ara/react test 통과", 
+T-000032,W-000004,Button v0 Comp,문서/스토리북,Storybook 스토리 및 MDX,계획,Medium," ● 내용: Playground, Variants, Tones, Sizes, WithIcons, Loading, AsLink, FullWidth 시나리오
+ ● 산출물: stories 및 MDX 문서
+ ● 점검: build-storybook 스모크 테스트 통과", 
+T-000033,W-000004,Button v0 Comp,테마/토큰,Tokens 연결 및 CSS 변수 표면,계획,Medium," ● 내용: 토큰 매핑과 CSS 변수(--ara-btn-bg 등) 정의, light 및 dark 테마 샘플
+ ● 산출물: tokens 소비 예 및 오버라이드 가이드
+ ● 점검: 토큰 변경 시 스타일 반영 확인", 
+T-000034,W-000004,Button v0 Comp,빌드/출하,Exports 및 타입 계약 점검,계획,High," ● 내용: exports 및 types 및 module 및 sideEffects 계약 검증, showcase 임포트 스모크
+ ● 산출물: package.json exports 맵 정리와 소비 앱 확인
+ ● 점검: pnpm --filter @ara/react pack --dry-run 결과 검토", 
+T-000035,W-000004,Button v0 Comp,릴리스,Changesets 프리릴리스(canary),계획,High," ● 내용: changeset 추가 및 프리릴리스 채널 배포 드라이런
+ ● 산출물: canary 태그 및 설치 확인 메모
+ ● 점검: 설치 및 임포트 성공과 간단 사용 예 검증", 

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -21,3 +21,10 @@ W-000003,T1,모노레포 스캐폴딩,진행중,85,"pnpm 모노레포 기준선�
  ● 핵심 UI 패키지 및 앱 골격
  ● 빌드·테스트 스크립트 공유
  ● README 구조 업데이트까지 일괄 정비.",--
+W-000004,T1,Button v0 Comp,계획,0,"Button v0
+ ● 설계문서 : root/packages/react/src/components/button/README.md
+ ● tokens→core→react 종단간 검증
+ ● a11y·테스트·문서·Exports 고정
+ ● canary 프리릴리스 포함
+ ● 범위: 일반 버튼/링크(토글 제외)
+ ● AC: CI 통과·Tests 통과·Storybook build·ESM+types import·canary 발행",--


### PR DESCRIPTION
WBS: W-000004
Task: T-000027
Task Name : Button v0 Comp

- Button v0 설계문서
- WBS/Task 일정 추가

- 목적: tokens → core(headless) → react 바인딩 흐름을 **Button**으로 검증하고, 외부에 불변 약속(Props/동작/A11y/Exports)을 고정.
- 성공 기준: 테스트·스토리·빌드·Exports가 본 계약과 일치, canary 배포 가능.
- 설계문서 : packages/react/src/components/button/README.md

- none

- planning/WBS, Task

## Summary
- [o] 목표/배경과 주요 변경점을 간략히 설명합니다.

## Checklist
- [o] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [o] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [o] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.

## Testing
- [o] 관련 스크립트나 테스트를 실행했습니다. (`pnpm test`, `pnpm lint` 등)
- [o] 테스트 결과를 아래에 기재했습니다.

## Screenshots
필요 시 UI 변경 전/후 스크린샷 또는 캡처를 첨부합니다.
