### PR TITLE
feat(core): useButton headless press lifecycle (T-000028)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./use-button": {
+      "types": "./dist/use-button.d.ts",
+      "import": "./dist/use-button.js",
+      "default": "./dist/use-button.js"
+    },
     "./theme": {
       "types": "./dist/theme.d.ts",
       "import": "./dist/theme.js",
@@ -24,6 +29,9 @@
       "theme": [
         "dist/theme.d.ts"
       ],
+      "use-button": [
+        "dist/use-button.d.ts"
+      ],
       "*": [
         "dist/*.d.ts"
       ]
@@ -34,6 +42,9 @@
     "README.md"
   ],
   "sideEffects": false,
+  "peerDependencies": {
+    "react": "^18.2.0"
+  },
   "scripts": {
     "pretest": "pnpm --filter @ara/tokens build",
     "prebuild": "pnpm --filter @ara/tokens build",
@@ -61,7 +72,13 @@
     "@ara/tokens": "workspace:*"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "@ara/tsconfig": "workspace:*",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "vitest": "^2.1.3"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,10 @@
 export type { Theme, ThemeOverrides } from "./theme.js";
 export { createTheme, defaultTheme } from "./theme.js";
+export type {
+  PressEvent,
+  PressHandler,
+  PressPointerType,
+  UseButtonOptions,
+  UseButtonResult
+} from "./use-button.js";
+export { useButton } from "./use-button.js";

--- a/packages/core/src/use-button.test.tsx
+++ b/packages/core/src/use-button.test.tsx
@@ -1,0 +1,153 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { forwardRef, type PropsWithChildren } from "react";
+import { useButton, type UseButtonOptions } from "./use-button.js";
+
+describe("useButton", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function TestButton({
+    options,
+    children = "button"
+  }: PropsWithChildren<{ options?: UseButtonOptions }>) {
+    const { buttonProps, isPressed } = useButton<HTMLButtonElement>(options);
+
+    return (
+      <button data-pressed={isPressed} {...buttonProps}>
+        {children}
+      </button>
+    );
+  }
+
+  it("fires press lifecycle for pointer interactions", () => {
+    const onPressStart = vi.fn();
+    const onPressEnd = vi.fn();
+    const onPress = vi.fn();
+    const { getByRole } = render(
+      <TestButton
+        options={{
+          onPressStart,
+          onPressEnd,
+          onPress
+        }}
+      />
+    );
+
+    const button = getByRole("button");
+
+    fireEvent.pointerDown(button, { pointerId: 1, pointerType: "mouse", button: 0 });
+
+    expect(onPressStart).toHaveBeenCalledTimes(1);
+    expect(onPressStart).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "pressstart", pointerType: "mouse" })
+    );
+    expect(button).toHaveAttribute("data-pressed", "true");
+
+    fireEvent.pointerUp(button, { pointerId: 1, pointerType: "mouse", button: 0 });
+
+    expect(onPressEnd).toHaveBeenCalledTimes(1);
+    expect(onPressEnd).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "pressend", pointerType: "mouse" })
+    );
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "press", pointerType: "mouse" })
+    );
+    expect(button).toHaveAttribute("data-pressed", "false");
+  });
+
+  it("cancels pointer press on leave", () => {
+    const onPress = vi.fn();
+    const onPressEnd = vi.fn();
+    const { getByRole } = render(<TestButton options={{ onPress, onPressEnd }} />);
+
+    const button = getByRole("button");
+
+    fireEvent.pointerDown(button, { pointerId: 5, pointerType: "mouse", button: 0 });
+    fireEvent.pointerLeave(button, { pointerId: 5, pointerType: "mouse" });
+    fireEvent.pointerUp(button, { pointerId: 5, pointerType: "mouse", button: 0 });
+
+    expect(onPressEnd).toHaveBeenCalledTimes(1);
+    expect(onPress).not.toHaveBeenCalled();
+    expect(button).toHaveAttribute("data-pressed", "false");
+  });
+
+  it("handles keyboard space press for links", () => {
+    const clickSpy = vi.fn();
+    const onPress = vi.fn();
+    const onPressStart = vi.fn();
+    const onPressEnd = vi.fn();
+
+    const LinkButton = forwardRef<HTMLAnchorElement, PropsWithChildren<{ options?: UseButtonOptions }>>(
+      function LinkButton({ options, children = "link" }, ref) {
+        const { buttonProps, isPressed } = useButton<HTMLAnchorElement>({
+          ...options,
+          elementType: "link"
+        });
+
+        return (
+          <a ref={ref} data-pressed={isPressed} {...buttonProps} onClick={clickSpy}>
+            {children}
+          </a>
+        );
+      }
+    );
+
+    const { getByText } = render(
+      <LinkButton
+        options={{
+          onPress,
+          onPressStart,
+          onPressEnd
+        }}
+      >
+        label
+      </LinkButton>
+    );
+
+    const anchor = getByText("label");
+
+    fireEvent.keyDown(anchor, { key: " ", code: "Space" });
+    expect(onPressStart).toHaveBeenCalledTimes(1);
+    expect(anchor).toHaveAttribute("data-pressed", "true");
+
+    fireEvent.keyUp(anchor, { key: " ", code: "Space" });
+
+    expect(onPressEnd).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(anchor).toHaveAttribute("data-pressed", "false");
+  });
+
+  it("blocks interactions when disabled or loading", () => {
+    const onPress = vi.fn();
+    const onPressStart = vi.fn();
+    const { getByRole, rerender } = render(
+      <TestButton options={{ onPress, onPressStart, disabled: true }} />
+    );
+
+    const button = getByRole("button");
+
+    fireEvent.pointerDown(button, { pointerId: 3, pointerType: "mouse", button: 0 });
+    fireEvent.pointerUp(button, { pointerId: 3, pointerType: "mouse", button: 0 });
+    fireEvent.keyDown(button, { key: "Enter" });
+    fireEvent.keyUp(button, { key: "Enter" });
+
+    expect(onPressStart).not.toHaveBeenCalled();
+    expect(onPress).not.toHaveBeenCalled();
+    expect(button).toHaveAttribute("data-pressed", "false");
+
+    rerender(
+      <TestButton options={{ onPress, onPressStart, loading: true }} />
+    );
+
+    fireEvent.pointerDown(button, { pointerId: 4, pointerType: "mouse", button: 0 });
+    fireEvent.pointerUp(button, { pointerId: 4, pointerType: "mouse", button: 0 });
+
+    expect(onPressStart).not.toHaveBeenCalled();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/use-button.ts
+++ b/packages/core/src/use-button.ts
@@ -1,0 +1,340 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type SyntheticEvent as ReactSyntheticEvent
+} from "react";
+
+export type PressPointerType = "mouse" | "touch" | "pen" | "keyboard" | "virtual";
+export type PressPhase = "pressstart" | "pressend" | "press";
+
+export interface PressEvent {
+  readonly type: PressPhase;
+  readonly pointerType: PressPointerType;
+  readonly target: EventTarget | null;
+  readonly shiftKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly altKey: boolean;
+  readonly metaKey: boolean;
+}
+
+export type PressHandler = (event: PressEvent) => void;
+
+export interface UseButtonOptions {
+  readonly disabled?: boolean;
+  readonly loading?: boolean;
+  readonly href?: string;
+  readonly elementType?: "button" | "link" | "custom";
+  readonly onPress?: PressHandler;
+  readonly onPressStart?: PressHandler;
+  readonly onPressEnd?: PressHandler;
+}
+
+export interface UseButtonResult<T extends HTMLElement = HTMLElement> {
+  readonly buttonProps: ButtonEventHandlers<T>;
+  readonly isPressed: boolean;
+}
+
+interface ButtonEventHandlers<T extends HTMLElement> {
+  readonly onClick: (event: ReactMouseEvent<T>) => void;
+  readonly onKeyDown: (event: ReactKeyboardEvent<T>) => void;
+  readonly onKeyUp: (event: ReactKeyboardEvent<T>) => void;
+  readonly onPointerDown: (event: ReactPointerEvent<T>) => void;
+  readonly onPointerUp: (event: ReactPointerEvent<T>) => void;
+  readonly onPointerCancel: (event: ReactPointerEvent<T>) => void;
+  readonly onPointerLeave: (event: ReactPointerEvent<T>) => void;
+}
+
+function createPressEvent<E extends ReactSyntheticEvent<Element, Event>>(
+  type: PressPhase,
+  pointerType: PressPointerType,
+  event: E
+): PressEvent {
+  return {
+    type,
+    pointerType,
+    target: event.currentTarget,
+    shiftKey: event.shiftKey,
+    ctrlKey: event.ctrlKey,
+    altKey: event.altKey,
+    metaKey: event.metaKey
+  };
+}
+
+function coercePointerType(pointerType: string | undefined): PressPointerType {
+  if (pointerType === "touch" || pointerType === "pen" || pointerType === "mouse") {
+    return pointerType;
+  }
+
+  return "virtual";
+}
+
+export function useButton<T extends HTMLElement = HTMLElement>(
+  options: UseButtonOptions = {}
+): UseButtonResult<T> {
+  const {
+    disabled = false,
+    loading = false,
+    href,
+    elementType,
+    onPress,
+    onPressStart,
+    onPressEnd
+  } = options;
+
+  const [isPressed, setPressed] = useState(false);
+  const isPressedRef = useRef(false);
+  const activePointerId = useRef<number | null>(null);
+  const pointerTypeRef = useRef<PressPointerType>("mouse");
+  const isKeyboardPressed = useRef(false);
+  const interactionDisabled = disabled || loading;
+  const resolvedElementType = useMemo<"button" | "link" | "custom">(() => {
+    if (elementType) {
+      return elementType;
+    }
+
+    return href ? "link" : "button";
+  }, [elementType, href]);
+
+  const setPressedState = useCallback(
+    (value: boolean) => {
+      if (isPressedRef.current !== value) {
+        isPressedRef.current = value;
+        setPressed(value);
+      }
+    },
+    [setPressed]
+  );
+
+  const emitPressStart = useCallback(
+    <E extends ReactSyntheticEvent<Element, Event>>(
+      pointerType: PressPointerType,
+      event: E
+    ) => {
+      setPressedState(true);
+      onPressStart?.(createPressEvent("pressstart", pointerType, event));
+    },
+    [onPressStart, setPressedState]
+  );
+
+  const emitPressEnd = useCallback(
+    <E extends ReactSyntheticEvent<Element, Event>>(
+      pointerType: PressPointerType,
+      event: E
+    ) => {
+      if (!isPressedRef.current) {
+        return;
+      }
+
+      setPressedState(false);
+      onPressEnd?.(createPressEvent("pressend", pointerType, event));
+    },
+    [onPressEnd, setPressedState]
+  );
+
+  const emitPress = useCallback(
+    <E extends ReactSyntheticEvent<Element, Event>>(
+      pointerType: PressPointerType,
+      event: E
+    ) => {
+      onPress?.(createPressEvent("press", pointerType, event));
+    },
+    [onPress]
+  );
+
+  const cancelPointerPress = useCallback(
+    <E extends ReactPointerEvent<Element>>(
+      event: E
+    ) => {
+      if (activePointerId.current === null) {
+        return;
+      }
+
+      if (typeof event.currentTarget.releasePointerCapture === "function") {
+        try {
+          event.currentTarget.releasePointerCapture(activePointerId.current);
+        } catch {
+          // 비지원 환경 대비.
+        }
+      }
+
+      activePointerId.current = null;
+      emitPressEnd(pointerTypeRef.current, event);
+    },
+    [emitPressEnd]
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<T>) => {
+      if (interactionDisabled) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (event.button !== 0 || activePointerId.current !== null) {
+        return;
+      }
+
+      const pointerType = coercePointerType(event.pointerType);
+      pointerTypeRef.current = pointerType;
+      activePointerId.current = event.pointerId;
+
+      if (typeof event.currentTarget.setPointerCapture === "function") {
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+          // jsdom 또는 비지원 환경에서는 setPointerCapture가 throw할 수 있다.
+        }
+      }
+
+      emitPressStart(pointerType, event);
+    },
+    [interactionDisabled, emitPressStart]
+  );
+
+  const handlePointerUp = useCallback(
+    (event: ReactPointerEvent<T>) => {
+      if (activePointerId.current !== event.pointerId) {
+        return;
+      }
+
+      const pointerType = pointerTypeRef.current;
+      activePointerId.current = null;
+
+      if (typeof event.currentTarget.releasePointerCapture === "function") {
+        try {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        } catch {
+          // 비지원 환경에 대비.
+        }
+      }
+
+      emitPressEnd(pointerType, event);
+
+      if (!interactionDisabled) {
+        emitPress(pointerType, event);
+      }
+    },
+    [emitPress, emitPressEnd, interactionDisabled]
+  );
+
+  const handlePointerCancel = useCallback(
+    (event: ReactPointerEvent<T>) => {
+      cancelPointerPress(event);
+    },
+    [cancelPointerPress]
+  );
+
+  const handlePointerLeave = useCallback(
+    (event: React.PointerEvent<T>) => {
+      if (activePointerId.current !== event.pointerId) {
+        return;
+      }
+
+      cancelPointerPress(event);
+    },
+    [cancelPointerPress]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<T>) => {
+      if (interactionDisabled || event.repeat) {
+        return;
+      }
+
+      if (event.key === " " || event.key === "Spacebar") {
+        if (resolvedElementType !== "button") {
+          event.preventDefault();
+        }
+
+        isKeyboardPressed.current = true;
+        pointerTypeRef.current = "keyboard";
+        emitPressStart("keyboard", event);
+      } else if (event.key === "Enter") {
+        isKeyboardPressed.current = true;
+        pointerTypeRef.current = "keyboard";
+        emitPressStart("keyboard", event);
+      }
+    },
+    [emitPressStart, interactionDisabled, resolvedElementType]
+  );
+
+  const handleKeyUp = useCallback(
+    (event: ReactKeyboardEvent<T>) => {
+      if (!isKeyboardPressed.current) {
+        return;
+      }
+
+      if (event.key === " " || event.key === "Spacebar" || event.key === "Enter") {
+        if (event.key === " " || event.key === "Spacebar") {
+          if (resolvedElementType !== "button") {
+            event.preventDefault();
+            if ("click" in event.currentTarget) {
+              try {
+                (event.currentTarget as unknown as { click(): void }).click();
+              } catch {
+                // noop - 사용자 정의 요소가 click을 지원하지 않는 경우.
+              }
+            }
+          }
+        }
+
+        emitPressEnd("keyboard", event);
+
+        if (!interactionDisabled) {
+          emitPress("keyboard", event);
+        }
+      }
+
+      isKeyboardPressed.current = false;
+    },
+    [emitPress, emitPressEnd, interactionDisabled, resolvedElementType]
+  );
+
+  const handleClick = useCallback(
+    (event: ReactMouseEvent<T>) => {
+      if (interactionDisabled) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    },
+    [interactionDisabled]
+  );
+
+  useEffect(() => {
+    if (interactionDisabled && isPressedRef.current) {
+      setPressedState(false);
+      isKeyboardPressed.current = false;
+      activePointerId.current = null;
+    }
+  }, [interactionDisabled, setPressedState]);
+
+  const buttonProps = useMemo<ButtonEventHandlers<T>>(
+    () => ({
+      onClick: handleClick,
+      onKeyDown: handleKeyDown,
+      onKeyUp: handleKeyUp,
+      onPointerDown: handlePointerDown,
+      onPointerUp: handlePointerUp,
+      onPointerCancel: handlePointerCancel,
+      onPointerLeave: handlePointerLeave
+    }),
+    [
+      handleClick,
+      handleKeyDown,
+      handleKeyUp,
+      handlePointerDown,
+      handlePointerUp,
+      handlePointerCancel,
+      handlePointerLeave
+    ]
+  );
+
+  return { buttonProps, isPressed };
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,7 +3,8 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "noEmit": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals"],
+    "jsx": "react-jsx"
   },
   "include": [
     "src/**/*.ts",

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    environment: "jsdom",
     coverage: {
       reporter: ["text", "html"],
       reportsDirectory: "coverage"

--- a/packages/react/src/components/button/README.md
+++ b/packages/react/src/components/button/README.md
@@ -18,6 +18,7 @@
 | **size** | sm · md · lg | md | 높이·패딩·폰트 크기 세트. |
 | **disabled** | boolean | false | 상호작용 차단. 버튼은 `disabled`, 링크는 `aria-disabled="true"`+클릭/키 이벤트 취소. |
 | **loading** | boolean | false | 상호작용 차단+스피너 슬롯, `aria-busy="true"`. |
+| **children** | ReactNode | — | 버튼 라벨. 빈 문자열/`null` 비허용(아이콘만 렌더 시 `aria-label` 필수). |
 | **leadingIcon** | 아이콘 노드 | — | 라벨 앞 아이콘(아이콘 전용일 땐 `aria-label` 필수). |
 | **trailingIcon** | 아이콘 노드 | — | 라벨 뒤 아이콘. |
 | **fullWidth** | boolean | false | 너비 100% 확장. |
@@ -32,20 +33,23 @@
 | **ref** | 요소 참조 | — | 실제 렌더된 버튼/링크 요소로 포워딩. |
 | **기타 DOM 속성** | 표준 버튼/앵커 속성 | — | 유효한 속성은 그대로 전달(`target`, `rel`, `download` 등). `target="_blank"` 시 `rel="noopener noreferrer"` 권고. |
 
-> **Defaults:** `variant='solid'`, `tone='primary'`, `size='md'`, `type='button'`  
+> **Defaults:** `variant='solid'`, `tone='primary'`, `size='md'`, `type='button'`
 > **이벤트 의미:** `onPress`는 클릭+Enter+Space **통합 확정**. `disabled | loading`이면 발화 금지.
+> **PressEvent:** `type`(`mouse | keyboard | touch | pen`), `pointerType`, `shiftKey` 등 core `PressEvent` 그대로 전달.
 
 ---
 
 ## 3) 동작 계약 (Behavior)
 
-- **키보드:**  
-  - 버튼: Enter/Space → press( Space는 down=pressStart, up=pressEnd/press ).  
+- **키보드:**
+  - 버튼: Enter/Space → press( Space는 down=pressStart, up=pressEnd/press ).
   - 링크 모드: Enter 기본 클릭 + **Space도 press로 동작**(기본 스크롤 취소 후 클릭 합성).
+  - `asChild`로 사용자 정의 요소 사용 시에도 동일 press 계약을 유지해야 하며, 필요 시 `role="button"`/`tabIndex=0`를 자식이 구현.
 - **마우스/터치:** 누름(pressStart)→떼기(pressEnd)→press. 포인터가 영역 이탈하면 취소.
 - **Disabled:** 포커스/press 차단, hover/active 스타일 비활성.
 - **Loading:** press 차단, `aria-busy="true"`, spinner 표시(라벨 유지).
 - **폼 연동:** `type="submit"`일 때 네이티브 폼 제출 유지(중복 press 방지). 기본은 `button`.
+- **포인터 캡처:** pointerdown → pointerup 사이 `pointercancel` 수신 시 press 취소.
 
 ---
 
@@ -53,9 +57,10 @@
 
 - 요소/역할: 기본은 `<button>`. 링크 모드여도 키보드 계약(Enter/Space) 동일.  
 - ARIA:
-  - `disabled` → 버튼: `disabled`; 링크: `aria-disabled="true"` + 상호작용 취소  
+  - `disabled` → 버튼: `disabled`; 링크: `aria-disabled="true"` + 상호작용 취소
   - `loading`  → `aria-busy="true"`(spinner는 `aria-hidden="true"`)
 - 포커스 링: 키보드 유입에서만 명확(마우스 클릭 시 최소화). `:focus-visible` 우선.
+- 레이블: 아이콘만 있는 경우 `aria-label` 또는 `aria-labelledby` 필수. `children` 문자열/요소가 제공되면 별도 레이블 불필요.
 - RTL: 아이콘 정렬, 여백, 포커스 링 방향성 확인.
 
 ---
@@ -88,17 +93,19 @@
 
 ## 7) 컴포지션 / 슬롯
 
-- 구조: `root` · `icon--leading` · `label` · `spinner` · `icon--trailing`  
+- 구조: `root` · `icon--leading` · `label` · `spinner` · `icon--trailing`
 - 클래스 병합: 내부 기본 클래스 → 사용자 `className` **최후 우선**(충돌 시 사용자 승)
+- 슬롯 가드: `spinner`는 `loading`일 때만 렌더, 아이콘 슬롯은 제공되지 않으면 DOM 비노출.
 
 ---
 
 ## 8) Exports 계약
 
-- **@ara/react**  
-  - `@ara/react/button` → `Button`, `ButtonProps`  
+- **@ara/react**
+  - `@ara/react/button` → `Button`, `ButtonProps`
   - `@ara/react/unstyled/button` → 스타일 없는 기저(슬롯만)
-- **@ara/core**  
+- `ButtonProps['onPress']`는 `@ara/core/use-button`이 반환하는 `PressEvent` 시그니처를 그대로 사용(React SyntheticEvent 아님).
+- **@ara/core**
   - `@ara/core/use-button` → `useButton`, `PressEvent`
 - **package.json (react 패키지)**  
   - `exports`: `./button`(ESM) + `types`, `sideEffects:false`  
@@ -116,8 +123,9 @@
 ## 10) 에지 케이스
 
 - `disabled && loading` → **disabled 우선**(상호작용 완전 차단) + busy 시각 상태 병행 가능  
-- `href && disabled` → anchor 렌더 + `aria-disabled` + 클릭/키 이벤트 취소  
+- `href && disabled` → anchor 렌더 + `aria-disabled` + 클릭/키 이벤트 취소
 - **아이콘만** 있을 때 → `aria-label` **필수**
+- `asChild` + `href` 동시 사용 시 자식 요소가 anchor 역할을 수행하고 `ref`/`className` 전달을 지원해야 함.
 
 ---
 

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -95,12 +95,12 @@ T-000025,W-000003,모노레포 스캐폴딩,CI/운영 자동화,의존성 자동
 T-000026,W-000003,모노레포 스캐폴딩,문서화,README 구조 섹션 업데이트(모노레포 트리/패키지 표),완료,Medium," ● 목적: 모노레포 구조와 패키지 역할을 문서로 명확히 제시해 신규 기여자의 온보딩 시간을 단축한다.
  ● 내용: README에 디렉터리 트리, 패키지별 역할/의존 관계 표, 공통 설정 참조 절차를 추가한다. 작업 순서를 정리해 패키지 생성 흐름을 안내한다.
  ● 점검: README 개정본에서 항목이 빠짐없이 소개되고 내부 링크/코드 블록이 최신 스캐폴딩 구조와 일치하는지 검토한다.",확인
-T-000027,W-000004,Button v0 Comp,계약/설계,API 계약 정의(Button),계획,High," ● 목적: Props 목록과 기본값, 이벤트 의미(onPress 계열), 폴리모픽(asChild) 및 링크 모드 범위 확정
+T-000027,W-000004,Button v0 Comp,계약/설계,API 계약 정의(Button),완료,High," ● 목적: Props 목록과 기본값, 이벤트 의미(onPress 계열), 폴리모픽(asChild) 및 링크 모드 범위 확정
  ● 산출물: packages/react/src/components/button/README.md 계약 섹션 확정
- ● 점검: 리뷰 승인 후 범위 동결(변경은 후속 이슈로)", 
-T-000028,W-000004,Button v0 Comp,코어(headless),useButton 로직 구현,계획,High," ● 내용: press 시작/종료/확정 시퀀스, disabled 및 loading 차단, Enter 및 Space 키 매핑
+ ● 점검: 리뷰 승인 후 범위 동결(변경은 후속 이슈로)",확인
+T-000028,W-000004,Button v0 Comp,코어(headless),useButton 로직 구현,완료,High," ● 내용: press 시작/종료/확정 시퀀스, disabled 및 loading 차단, Enter 및 Space 키 매핑
  ● 산출물: packages/core/use-button 구현 및 유닛 테스트 골격
- ● 점검: pnpm --filter @ara/core test 통과", 
+ ● 점검: pnpm --filter @ara/core test 통과",확인
 T-000029,W-000004,Button v0 Comp,React 바인딩,React Button 구현,계획,High," ● 내용: forwardRef, className 병합, data-* 상태 표식, href 및 asChild 처리, ref 전달
  ● 산출물: packages/react/button 컴포넌트 기본 구현
  ● 점검: 샘플 임포트 및 렌더 스모크 테스트", 

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -21,7 +21,7 @@ W-000003,T1,모노레포 스캐폴딩,완료,100,"pnpm 모노레포 기준선을
  ● 핵심 UI 패키지 및 앱 골격
  ● 빌드·테스트 스크립트 공유
  ● README 구조 업데이트까지 일괄 정비.",--
-W-000004,T1,Button v0 Comp,계획,0,"Button v0
+W-000004,T1,Button v0 Comp,진행중,25,"Button v0
  ● 설계문서 : root/packages/react/src/components/button/README.md
  ● tokens→core→react 종단간 검증
  ● a11y·테스트·문서·Exports 고정

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,24 @@ importers:
       '@ara/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.0.1
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.26
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.26)
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
       vitest:
         specifier: ^2.1.3
         version: 2.1.9(@types/node@24.9.2)(jsdom@27.0.1(postcss@8.5.6))


### PR DESCRIPTION
## Summary
- [x] `@ara/core`에 포인터/키보드 press 시퀀스를 통합한 `useButton` 훅과 `PressEvent` 타입을 추가했습니다.
- [x] React Testing Library 및 jest-dom 매처를 도입해 포인터 취소, Space/Enter 키 경로, disabled/loading 차단을 검증했습니다.
- [x] T-000028 완료 상태와 Button v0 WBS 진행률(25%)을 계획 문서에 반영했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.

## Testing
- [x] `pnpm --filter @ara/core test`

## Screenshots
해당 사항 없음.


------
https://chatgpt.com/codex/tasks/task_e_6907ff8749ac8322aa2520219447f983