### PR TITLE
Fix core tsconfig type roots for vitest

### DIFF
--- a/packages/core/src/use-button.ts
+++ b/packages/core/src/use-button.ts
@@ -50,7 +50,14 @@ interface ButtonEventHandlers<T extends HTMLElement> {
   readonly onPointerLeave: (event: ReactPointerEvent<T>) => void;
 }
 
-function createPressEvent<E extends ReactSyntheticEvent<Element, Event>>(
+type ModifiableReactEvent = ReactSyntheticEvent<Element, Event> & {
+  readonly shiftKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly altKey: boolean;
+  readonly metaKey: boolean;
+};
+
+function createPressEvent<E extends ModifiableReactEvent>(
   type: PressPhase,
   pointerType: PressPointerType,
   event: E
@@ -112,7 +119,7 @@ export function useButton<T extends HTMLElement = HTMLElement>(
   );
 
   const emitPressStart = useCallback(
-    <E extends ReactSyntheticEvent<Element, Event>>(
+    <E extends ModifiableReactEvent>(
       pointerType: PressPointerType,
       event: E
     ) => {
@@ -123,7 +130,7 @@ export function useButton<T extends HTMLElement = HTMLElement>(
   );
 
   const emitPressEnd = useCallback(
-    <E extends ReactSyntheticEvent<Element, Event>>(
+    <E extends ModifiableReactEvent>(
       pointerType: PressPointerType,
       event: E
     ) => {
@@ -138,7 +145,7 @@ export function useButton<T extends HTMLElement = HTMLElement>(
   );
 
   const emitPress = useCallback(
-    <E extends ReactSyntheticEvent<Element, Event>>(
+    <E extends ModifiableReactEvent>(
       pointerType: PressPointerType,
       event: E
     ) => {
@@ -232,7 +239,7 @@ export function useButton<T extends HTMLElement = HTMLElement>(
   );
 
   const handlePointerLeave = useCallback(
-    (event: React.PointerEvent<T>) => {
+    (event: ReactPointerEvent<T>) => {
       if (activePointerId.current !== event.pointerId) {
         return;
       }

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -11,6 +11,13 @@
     "sourceMap": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "types": ["react"],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../node_modules/.pnpm/node_modules/@types",
+      "../../node_modules/@types"
+    ],
     "paths": {
       "@ara/tokens": [
         "../tokens/dist/index.d.ts",
@@ -26,6 +33,7 @@
     "src/**/*"
   ],
   "exclude": [
-    "src/**/*.test.ts"
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
   ]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,13 +2,22 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
+    "rootDir": ".",
     "noEmit": true,
-    "types": ["vitest/globals"],
+    "types": ["vitest/globals", "react"],
+    "typeRoots": [
+      "./node_modules",
+      "./node_modules/@types",
+      "../../node_modules/.pnpm/node_modules/@types",
+      "../../node_modules/@types"
+    ],
     "jsx": "react-jsx"
   },
   "include": [
     "src/**/*.ts",
+    "src/**/*.tsx",
     "src/**/*.test.ts",
+    "src/**/*.test.tsx",
     "src/**/*.d.ts",
     "vitest.config.ts"
   ],


### PR DESCRIPTION
## Summary
- point the core tsconfig to its local node_modules so Vitest globals resolve correctly
- include the package-level @types directory in the build config to keep React typings available

## Testing
- pnpm --filter @ara/core test
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_69080905f2788322b654ee0a3235b452