### PR TITLE
fix(button): Button 접근성 보강 (T-000030)

### DIFF
--- a/packages/react/src/components/button/Button.test.tsx
+++ b/packages/react/src/components/button/Button.test.tsx
@@ -59,6 +59,29 @@ describe("Button", () => {
     expect(link).toHaveAttribute("data-variant", "primary");
   });
 
+  it("loading 상태에서 aria 속성을 적용한다", () => {
+    render(<Button loading>로딩</Button>);
+
+    const button = screen.getByRole("button", { name: "로딩" });
+
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).toHaveAttribute("aria-disabled", "true");
+    expect(button).toBeDisabled();
+  });
+
+  it("비활성 링크 모드에서 aria-disabled와 tabIndex를 설정한다", () => {
+    render(
+      <Button href="/docs" disabled>
+        문서
+      </Button>
+    );
+
+    const link = screen.getByRole("link", { name: "문서" });
+
+    expect(link).toHaveAttribute("aria-disabled", "true");
+    expect(link).toHaveProperty("tabIndex", -1);
+  });
+
   it("asChild로 자식 요소에 속성을 전달한다", () => {
     render(
       <Button asChild href="/nested" className="custom-slot">
@@ -73,6 +96,33 @@ describe("Button", () => {
     expect(child).toHaveClass("ara-button");
     expect(child).toHaveClass("custom-slot");
     expect(child).toHaveAttribute("data-variant", "primary");
+  });
+
+  it("asChild 커스텀 요소에 role과 tabIndex를 설정한다", () => {
+    render(
+      <Button asChild>
+        <span>커스텀</span>
+      </Button>
+    );
+
+    const element = screen.getByRole("button", { name: "커스텀" });
+
+    expect(element).toHaveAttribute("role", "button");
+    expect(element).toHaveProperty("tabIndex", 0);
+    expect(element).not.toHaveAttribute("aria-disabled");
+  });
+
+  it("비활성 커스텀 요소에서 aria-disabled와 tabIndex를 조정한다", () => {
+    render(
+      <Button asChild disabled>
+        <span>커스텀</span>
+      </Button>
+    );
+
+    const element = screen.getByRole("button", { name: "커스텀" });
+
+    expect(element).toHaveAttribute("aria-disabled", "true");
+    expect(element).toHaveProperty("tabIndex", -1);
   });
 
   it("ref를 실제 요소로 포워딩한다", () => {
@@ -105,6 +155,22 @@ describe("Button", () => {
 
     fireEvent.pointerUp(button, { pointerId: 1, pointerType: "mouse", button: 0 });
 
+    expect(button).not.toHaveAttribute("data-state");
+  });
+
+  it("키보드 포커스에서 focus-visible 상태를 노출한다", () => {
+    render(<Button>포커스</Button>);
+
+    const button = screen.getByRole("button", { name: "포커스" });
+
+    fireEvent.focus(button);
+
+    expect(button).toHaveAttribute("data-focus-visible");
+    expect(button).toHaveAttribute("data-state", "focus-visible");
+
+    fireEvent.blur(button);
+
+    expect(button).not.toHaveAttribute("data-focus-visible");
     expect(button).not.toHaveAttribute("data-state");
   });
 });


### PR DESCRIPTION
## Summary
- [x] Button 컴포넌트의 링크/커스텀 렌더링 경로에 aria-disabled, role, tabIndex를 조건부 적용해 상호작용 규약을 맞췄습니다.
- [x] focus-visible 감지와 포커스 링 스타일을 추가하고 관련 data-* 속성을 노출했습니다.
- [x] loading/disabled/focus-visible 시나리오를 다루는 단위 테스트를 확장했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [ ] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.

## Testing
- [x] 관련 스크립트나 테스트를 실행했습니다. (`pnpm test`, `pnpm lint` 등)
- [x] 테스트 결과를 아래에 기재했습니다.
  - `pnpm --filter @ara/react test -- --runTestsByPath packages/react/src/components/button/Button.test.tsx`

## Screenshots
- 변경 사항이 UI 스크린샷을 필요로 하지 않습니다.


------
https://chatgpt.com/codex/tasks/task_e_69082e38105883229c8382ad8b15ca8c