### PR TITLE
Fix Storybook package alias resolution path

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -14,7 +14,8 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     config.resolve = config.resolve ?? {};
     const aliases = config.resolve.alias ?? [];
-    const resolvePackages = (pkg: string) => path.resolve(__dirname, `../../packages/${pkg}/src`);
+    const resolvePackages = (pkg: string) =>
+      path.resolve(__dirname, "..", "..", "..", "packages", pkg, "src");
     config.resolve.alias = [
       ...(Array.isArray(aliases) ? aliases : Object.entries(aliases).map(([find, replacement]) => ({ find, replacement }))),
       { find: "@ara/react", replacement: resolvePackages("react") },


### PR DESCRIPTION
## Summary
- fix the Storybook Vite alias helper to resolve workspace packages from the repository root

## Testing
- pnpm --filter @ara/storybook storybook:smoke

------
https://chatgpt.com/codex/tasks/task_e_6909424f14d48322a1233b2de1f593c1