### PR TITLE
feat: add optional asChild support to AraProvider

### DIFF
--- a/apps/storybook/stories/components/Button.docs.mdx
+++ b/apps/storybook/stories/components/Button.docs.mdx
@@ -57,7 +57,7 @@ import * as ButtonStories from "./Button.stories";
 
 ## Tokens &amp; CSS 변수
 
-`AraProvider`는 `data-ara-theme` 컨테이너에 디자인 토큰을 CSS 변수로 노출합니다. Button 컴포넌트는 아래 구조를 사용합니다.
+`AraProvider`는 기본적으로 `data-ara-theme` 컨테이너에 디자인 토큰을 CSS 변수로 노출합니다. `asChild`를 사용하면 기존 요소를 재사용하면서 동일한 토큰을 주입할 수 있습니다. Button 컴포넌트는 아래 구조를 사용합니다.
 
 ### Variant &amp; Tone
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -32,6 +32,20 @@ function App() {
 </AraProvider>
 ```
 
+기본적으로 `AraProvider`는 자식 트리를 `<div data-ara-theme>`로 감싸 CSS 변수를 노출한다. 이미 존재하는 요소를 재사용해야 하거나 테이블과 같이 `div`를 허용하지 않는 문맥에서는 `asChild`를 사용해 외부 래퍼 없이 테마 변수를 주입할 수 있다.
+
+```tsx
+<AraProvider asChild>
+  <tbody>
+    <tr>
+      <td>
+        <Button>표 안의 버튼</Button>
+      </td>
+    </tr>
+  </tbody>
+</AraProvider>
+```
+
 ## 개발 스크립트
 
 - `pnpm build` : 타입 선언과 번들 산출물을 생성한다.

--- a/packages/react/src/components/button/README.md
+++ b/packages/react/src/components/button/README.md
@@ -67,7 +67,7 @@
 
 ## 5) 시각/토큰 계약 (Tokens → CSS Vars)
 
-- `AraProvider`는 자식 subtree를 `<div data-ara-theme>`로 감싸며 토큰을 CSS 변수로 노출한다.
+- `AraProvider`는 기본적으로 자식 subtree를 `<div data-ara-theme>`로 감싸며 토큰을 CSS 변수로 노출한다. `asChild`를 사용하면 외부 래퍼 없이 기존 요소에 `data-ara-theme`와 CSS 변수를 주입할 수 있다.
 - Button은 토큰을 **두 단계**로 소비한다.
   1. 전역 토큰: `--ara-btn-font`, `--ara-btn-font-weight`, `--ara-btn-radius`, `--ara-btn-border-width`,
      `--ara-btn-disabled-opacity`, `--ara-btn-focus-outline`, `--ara-btn-focus-outline-offset`, `--ara-btn-focus-ring`

--- a/packages/react/src/theme/AraProvider.test.tsx
+++ b/packages/react/src/theme/AraProvider.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { defaultTheme } from "@ara/core";
+import { AraProvider } from "./AraProvider.js";
+
+describe("AraProvider", () => {
+  it("기본적으로 div 컨테이너를 렌더링한다", () => {
+    const { container } = render(
+      <AraProvider>
+        <span>child</span>
+      </AraProvider>
+    );
+
+    const wrapper = container.firstElementChild;
+
+    expect(wrapper?.tagName).toBe("DIV");
+    expect(wrapper).toHaveAttribute("data-ara-theme");
+    expect(wrapper?.querySelector("span")).toHaveTextContent("child");
+  });
+
+  it("asChild prop으로 기존 요소를 재사용한다", () => {
+    const { container } = render(
+      <AraProvider asChild>
+        <section data-testid="host">content</section>
+      </AraProvider>
+    );
+
+    const host = screen.getByTestId("host");
+
+    expect(container.firstElementChild).toBe(host);
+    expect(host).toHaveAttribute("data-ara-theme");
+    expect(host.style.getPropertyValue("--ara-btn-radius")).toBe(
+      defaultTheme.component.button.radius
+    );
+  });
+});

--- a/packages/react/src/theme/AraProvider.tsx
+++ b/packages/react/src/theme/AraProvider.tsx
@@ -1,3 +1,4 @@
+import { Slot } from "@radix-ui/react-slot";
 import { createContext, type ReactNode, useContext, useMemo } from "react";
 import { createTheme, defaultTheme, type Theme, type ThemeOverrides } from "@ara/core";
 import type { CSSProperties } from "react";
@@ -6,6 +7,7 @@ const ThemeContext = createContext<Theme>(defaultTheme);
 
 export interface AraProviderProps {
   readonly theme?: ThemeOverrides;
+  readonly asChild?: boolean;
   readonly children: ReactNode;
 }
 
@@ -79,7 +81,7 @@ function createThemeVariables(theme: Theme): CSSProperties {
   return variables;
 }
 
-export function AraProvider({ theme, children }: AraProviderProps) {
+export function AraProvider({ theme, asChild = false, children }: AraProviderProps) {
   const value = useMemo(() => {
     if (!theme) {
       return defaultTheme;
@@ -90,11 +92,13 @@ export function AraProvider({ theme, children }: AraProviderProps) {
 
   const style = useMemo(() => createThemeVariables(value), [value]);
 
+  const Container = asChild ? Slot : "div";
+
   return (
     <ThemeContext.Provider value={value}>
-      <div data-ara-theme style={style}>
+      <Container data-ara-theme="" style={style}>
         {children}
-      </div>
+      </Container>
     </ThemeContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- add an optional `asChild` prop so `AraProvider` can reuse an existing host element instead of injecting a `<div>`
- document the new behavior across package and storybook docs
- cover the provider with unit tests for default and `asChild` rendering

## Testing
- pnpm --filter @ara/react test

------
https://chatgpt.com/codex/tasks/task_e_690949aa59748322bb2f897cf0f96978