### PR TITLE
refactor: expose AraThemeBoundary for scoped CSS variables

### DIFF
--- a/apps/showcase/src/main.tsx
+++ b/apps/showcase/src/main.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { StrictMode } from "react";
 import App from "./App.tsx";
-import { AraProvider } from "@ara/react";
+import { AraProvider, AraThemeBoundary } from "@ara/react";
 
 const container = document.getElementById("root");
 
@@ -14,7 +14,9 @@ const root = createRoot(container);
 root.render(
   <StrictMode>
     <AraProvider>
-      <App />
+      <AraThemeBoundary>
+        <App />
+      </AraThemeBoundary>
     </AraProvider>
   </StrictMode>
 );

--- a/apps/storybook/stories/components/Button.docs.mdx
+++ b/apps/storybook/stories/components/Button.docs.mdx
@@ -57,7 +57,7 @@ import * as ButtonStories from "./Button.stories";
 
 ## Tokens &amp; CSS 변수
 
-`AraProvider`는 `data-ara-theme` 컨테이너에 디자인 토큰을 CSS 변수로 노출합니다. Button 컴포넌트는 아래 구조를 사용합니다.
+`AraProvider`는 컨텍스트만 제공해 DOM 구조를 바꾸지 않습니다. CSS 변수 기반 토큰이 필요하면 `AraThemeBoundary` 또는 `useAraThemeVariables`로 원하는 요소에 `data-ara-theme`와 스타일을 주입하세요. Button 컴포넌트는 아래 구조를 사용합니다.
 
 ### Variant &amp; Tone
 

--- a/apps/storybook/stories/components/Button.stories.tsx
+++ b/apps/storybook/stories/components/Button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ThemeOverrides } from "@ara/core";
-import { AraProvider, Button } from "@ara/react";
+import { AraProvider, AraThemeBoundary, Button } from "@ara/react";
 
 const ArrowRightIcon = () => (
   <svg
@@ -21,7 +21,9 @@ const meta = {
   decorators: [
     (Story) => (
       <AraProvider>
-        <Story />
+        <AraThemeBoundary>
+          <Story />
+        </AraThemeBoundary>
       </AraProvider>
     )
   ],
@@ -215,15 +217,17 @@ export const ThemeSamples: Story = {
       <section>
         <h4 style={{ margin: "0 0 0.75rem", fontSize: "0.875rem", color: "#475569" }}>라이트 (기본)</h4>
         <AraProvider>
-          <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
-            <Button {...args}>Primary</Button>
-            <Button {...args} variant="outline">
-              Outline
-            </Button>
-            <Button {...args} tone="danger">
-              Danger
-            </Button>
-          </div>
+          <AraThemeBoundary asChild>
+            <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+              <Button {...args}>Primary</Button>
+              <Button {...args} variant="outline">
+                Outline
+              </Button>
+              <Button {...args} tone="danger">
+                Danger
+              </Button>
+            </div>
+          </AraThemeBoundary>
         </AraProvider>
       </section>
       <section
@@ -236,15 +240,17 @@ export const ThemeSamples: Story = {
       >
         <h4 style={{ margin: 0, marginBottom: "0.75rem", fontSize: "0.875rem" }}>다크 (테마 오버라이드)</h4>
         <AraProvider theme={darkTheme}>
-          <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
-            <Button {...args}>Primary</Button>
-            <Button {...args} variant="outline">
-              Outline
-            </Button>
-            <Button {...args} tone="danger">
-              Danger
-            </Button>
-          </div>
+          <AraThemeBoundary asChild>
+            <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+              <Button {...args}>Primary</Button>
+              <Button {...args} variant="outline">
+                Outline
+              </Button>
+              <Button {...args} tone="danger">
+                Danger
+              </Button>
+            </div>
+          </AraThemeBoundary>
         </AraProvider>
       </section>
     </div>

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@ara/tsconfig/react-library.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
     "declaration": false,
     "declarationMap": false,
     "emitDeclarationOnly": false,
     "types": ["node", "vite/client"],
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
   },
   "include": [
     ".storybook/**/*",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -32,6 +32,33 @@ function App() {
 </AraProvider>
 ```
 
+`AraProvider`는 DOM 래퍼를 추가로 렌더링하지 않는다. CSS 변수 기반 토큰을 DOM에 주입하려면 `AraThemeBoundary` 컴포넌트나
+`useAraThemeVariables` 훅을 사용한다.
+
+```tsx
+import { AraProvider, AraThemeBoundary, Button } from "@ara/react";
+
+<AraProvider>
+  <AraThemeBoundary asChild>
+    <tbody>
+      <tr>
+        <td>
+          <Button>표 안의 버튼</Button>
+        </td>
+      </tr>
+    </tbody>
+  </AraThemeBoundary>
+</AraProvider>
+```
+
+CSS 변수 객체가 필요하다면 훅을 호출해 직접 요소에 스타일을 할당할 수 있다.
+
+```tsx
+const variables = useAraThemeVariables();
+
+return <main style={variables}>...</main>;
+```
+
 ## 개발 스크립트
 
 - `pnpm build` : 타입 선언과 번들 산출물을 생성한다.

--- a/packages/react/src/components/button/README.md
+++ b/packages/react/src/components/button/README.md
@@ -67,7 +67,7 @@
 
 ## 5) 시각/토큰 계약 (Tokens → CSS Vars)
 
-- `AraProvider`는 자식 subtree를 `<div data-ara-theme>`로 감싸며 토큰을 CSS 변수로 노출한다.
+- `AraProvider`는 DOM을 변경하지 않는다. CSS 변수 기반 토큰을 사용하려면 필요 위치에서 `AraThemeBoundary` 또는 `useAraThemeVariables` 훅을 통해 `data-ara-theme` 속성과 스타일을 직접 주입한다.
 - Button은 토큰을 **두 단계**로 소비한다.
   1. 전역 토큰: `--ara-btn-font`, `--ara-btn-font-weight`, `--ara-btn-radius`, `--ara-btn-border-width`,
      `--ara-btn-disabled-opacity`, `--ara-btn-focus-outline`, `--ara-btn-focus-outline-offset`, `--ara-btn-focus-ring`

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,11 @@
 export type { Theme, ThemeOverrides } from "@ara/core";
-export { AraProvider, type AraProviderProps, useAraTheme, ThemeContext } from "./theme/index.js";
+export {
+  AraProvider,
+  AraThemeBoundary,
+  type AraProviderProps,
+  type AraThemeBoundaryProps,
+  useAraTheme,
+  useAraThemeVariables,
+  ThemeContext
+} from "./theme/index.js";
 export * from "./components/index.js";

--- a/packages/react/src/theme/AraProvider.test.tsx
+++ b/packages/react/src/theme/AraProvider.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { defaultTheme } from "@ara/core";
+import {
+  AraProvider,
+  AraThemeBoundary,
+  useAraThemeVariables
+} from "./AraProvider.js";
+
+describe("AraProvider", () => {
+  it("추가 래퍼 없이 자식을 렌더링한다", () => {
+    const { container } = render(
+      <AraProvider>
+        <span>child</span>
+      </AraProvider>
+    );
+
+    expect(container.firstElementChild?.tagName).toBe("SPAN");
+    expect(container.firstElementChild).toHaveTextContent("child");
+  });
+});
+
+describe("AraThemeBoundary", () => {
+  it("기본적으로 div 컨테이너에 변수를 주입한다", () => {
+    const { container } = render(
+      <AraProvider>
+        <AraThemeBoundary>
+          <section data-testid="host">content</section>
+        </AraThemeBoundary>
+      </AraProvider>
+    );
+
+    const host = screen.getByTestId("host");
+
+    expect(container.firstElementChild?.tagName).toBe("DIV");
+    expect(container.firstElementChild).toHaveAttribute("data-ara-theme");
+    expect(host).toHaveTextContent("content");
+  });
+
+  it("asChild로 기존 요소를 재사용한다", () => {
+    const { container } = render(
+      <AraProvider>
+        <AraThemeBoundary asChild>
+          <section data-testid="host">content</section>
+        </AraThemeBoundary>
+      </AraProvider>
+    );
+
+    const host = screen.getByTestId("host");
+
+    expect(container.firstElementChild).toBe(host);
+    expect(host).toHaveAttribute("data-ara-theme");
+    expect(host.style.getPropertyValue("--ara-btn-radius")).toBe(
+      defaultTheme.component.button.radius
+    );
+  });
+
+  it("hook으로 CSS 변수를 노출한다", () => {
+    function Reader() {
+      const variables = useAraThemeVariables();
+      return (
+        <output data-testid="vars" data-radius={variables["--ara-btn-radius"]} />
+      );
+    }
+
+    render(
+      <AraProvider>
+        <Reader />
+      </AraProvider>
+    );
+
+    const vars = screen.getByTestId("vars");
+
+    expect(vars.dataset.radius).toBe(defaultTheme.component.button.radius);
+  });
+});

--- a/packages/react/src/theme/AraProvider.tsx
+++ b/packages/react/src/theme/AraProvider.tsx
@@ -1,4 +1,10 @@
-import { createContext, type ReactNode, useContext, useMemo } from "react";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useMemo
+} from "react";
 import { createTheme, defaultTheme, type Theme, type ThemeOverrides } from "@ara/core";
 import type { CSSProperties } from "react";
 
@@ -88,13 +94,9 @@ export function AraProvider({ theme, children }: AraProviderProps) {
     return createTheme(theme);
   }, [theme]);
 
-  const style = useMemo(() => createThemeVariables(value), [value]);
-
   return (
     <ThemeContext.Provider value={value}>
-      <div data-ara-theme style={style}>
-        {children}
-      </div>
+      {children}
     </ThemeContext.Provider>
   );
 }
@@ -103,6 +105,27 @@ AraProvider.displayName = "AraProvider";
 
 export function useAraTheme(): Theme {
   return useContext(ThemeContext);
+}
+
+export interface AraThemeBoundaryProps {
+  readonly asChild?: boolean;
+  readonly children: ReactNode;
+}
+
+export function useAraThemeVariables(): CSSProperties {
+  const theme = useAraTheme();
+  return useMemo(() => createThemeVariables(theme), [theme]);
+}
+
+export function AraThemeBoundary({ asChild = false, children }: AraThemeBoundaryProps) {
+  const style = useAraThemeVariables();
+  const Container = asChild ? Slot : "div";
+
+  return (
+    <Container data-ara-theme="" style={style}>
+      {children}
+    </Container>
+  );
 }
 
 export { ThemeContext };

--- a/packages/react/src/theme/index.ts
+++ b/packages/react/src/theme/index.ts
@@ -1,1 +1,9 @@
-export { AraProvider, type AraProviderProps, ThemeContext, useAraTheme } from "./AraProvider.js";
+export {
+  AraProvider,
+  AraThemeBoundary,
+  type AraProviderProps,
+  type AraThemeBoundaryProps,
+  ThemeContext,
+  useAraTheme,
+  useAraThemeVariables
+} from "./AraProvider.js";


### PR DESCRIPTION
## Summary
- stop rendering a div from `AraProvider` and introduce `AraThemeBoundary`/`useAraThemeVariables` for opt-in CSS variable scoping
- update tests, docs, and examples to describe and consume the new boundary component
- fix Storybook's TypeScript config so `@ara/*` path aliases resolve in stories

## Testing
- pnpm --filter @ara/react test

------
https://chatgpt.com/codex/tasks/task_e_690949aa59748322bb2f897cf0f96978