### PR TITLE
[T-000034] @ara/react 버튼 서브패스 계약 보강

### DIFF
--- a/apps/showcase/src/App.tsx
+++ b/apps/showcase/src/App.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
-import { Button } from "@ara/react";
+import { Button, type ButtonProps } from "@ara/react/button";
+
+const resetButtonVisuals = {
+  variant: "outline",
+  tone: "neutral"
+} satisfies Pick<ButtonProps, "variant" | "tone">;
 
 export default function App() {
   const [count, setCount] = useState(0);
@@ -19,7 +24,7 @@ export default function App() {
       <p>버튼을 클릭해 상호작용을 확인하세요.</p>
       <div style={{ display: "flex", gap: "0.75rem" }}>
         <Button onClick={() => setCount((prev) => prev + 1)}>기본 버튼</Button>
-        <Button variant="secondary" onClick={() => setCount(0)}>
+        <Button {...resetButtonVisuals} onClick={() => setCount(0)}>
           초기화
         </Button>
       </div>

--- a/apps/showcase/vite.config.ts
+++ b/apps/showcase/vite.config.ts
@@ -19,6 +19,27 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: "@ara/react/button",
+        replacement: resolve(
+          currentDir,
+          "../../packages/react/src/components/button/index.ts"
+        )
+      },
+      {
+        find: "@ara/react/components",
+        replacement: resolve(
+          currentDir,
+          "../../packages/react/src/components/index.ts"
+        )
+      },
+      {
+        find: "@ara/react/components/",
+        replacement: `${resolve(
+          currentDir,
+          "../../packages/react/src/components"
+        )}/`
+      },
+      {
         find: "@ara/react",
         replacement: resolve(currentDir, "../../packages/react/src")
       },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,18 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@ara/*": ["packages/*/src"]
+      "@ara/core": ["packages/core/src/index.ts"],
+      "@ara/core/*": ["packages/core/src/*"],
+      "@ara/react": ["packages/react/src/index.ts"],
+      "@ara/react/components": ["packages/react/src/components/index.ts"],
+      "@ara/react/components/*": ["packages/react/src/components/*"],
+      "@ara/react/button": ["packages/react/src/components/button/index.ts"],
+      "@ara/react/*": ["packages/react/src/*"],
+      "@ara/icons": ["packages/icons/src/index.ts"],
+      "@ara/icons/*": ["packages/icons/src/*"],
+      "@ara/tokens": ["packages/tokens/src/index.ts"],
+      "@ara/tokens/*": ["packages/tokens/src/*"],
+      "@ara/tsconfig/*": ["packages/tsconfig/*"]
     }
   },
   "include": [],


### PR DESCRIPTION
## Summary
- [x] @ara/react 버튼 서브패스를 쇼케이스에서 직접 사용해 T-000034의 exports/type 계약을 검증했습니다.
- [x] tsconfig 경로와 Vite alias를 보완해 소스 단계에서도 패키지 서브패스가 dist와 동일하게 해상되도록 맞췄습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.

## Testing
- [x] pnpm --filter @ara/showcase build
- [x] pnpm --filter @ara/react build

## Screenshots
- N/A

------
https://chatgpt.com/codex/tasks/task_e_6909861253208322a64851a2932362c1