### PR TITLE
T-000035: AraProvider CSS 변수 타입 보강

### DIFF
--- a/.changeset/button-canary-release.md
+++ b/.changeset/button-canary-release.md
@@ -1,0 +1,7 @@
+---
+"@ara/tokens": minor
+"@ara/core": minor
+"@ara/react": minor
+---
+
+Button v0 토큰, headless 훅, React 컴포넌트를 canary 채널로 선공개합니다.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ VS Code(Git Bash) · Windows · React+TypeScript · Node 22 LTS · pnpm(workspac
 - 루트에서 `pnpm -w lint`, `pnpm -w test`, `pnpm -w build`, `pnpm -w storybook:smoke` 를 실행하면 워크스페이스 전체에 동일한 명령이 순차적으로 적용된다.
 - 위 명령을 한 번에 돌리고 싶다면 `pnpm -w workspace:check` 스크립트를 사용한다. 순서는 `lint → test → build → storybook:smoke` 이며 Storybook 단계는 개발 서버 대신 스모크 테스트 플래그를 사용해 빠르게 종료된다.
 - Changesets 기반 배포 흐름(`pnpm release`)과는 별개의 사전 점검 라인이다. 배포가 필요한 경우에는 변경 사항을 Changeset으로 기록한 뒤 `pnpm release` 를 사용한다.
+- canary 프리릴리스 드라이런 순서는 [Changesets Canary 가이드](docs/releases/canary.md)를 따른다.
 
 ### 패키지별 테스트 실행 팁
 - **패키지 전체 테스트:** `pnpm --filter @ara/react test`

--- a/docs/releases/canary.md
+++ b/docs/releases/canary.md
@@ -1,0 +1,54 @@
+# Changesets Canary 프리릴리스 드라이런 가이드
+
+Button v0 컴포넌트를 canary 채널로 배포하기 위해 Changesets 프리릴리스 흐름을 연습하는 절차를 정리했습니다. 명령은 모두 워크스페이스 루트에서 실행합니다.
+
+## 1. 사전 확인
+- `pnpm install`로 의존성을 최신 상태로 맞춥니다.
+- `pnpm -w workspace:check`로 린트/테스트/빌드/스토리북 스모크를 한 번에 점검합니다.
+- `pnpm --filter @ara/react pack --dry-run`으로 패키징 산출물이 누락되지 않았는지 확인합니다. 필요한 경우 `@ara/core`, `@ara/tokens`도 동일하게 실행합니다.
+
+## 2. 프리릴리스 모드 진입
+```bash
+pnpm exec changeset status
+pnpm exec changeset pre enter canary
+```
+- `status`로 포함될 변경 로그와 버전 범위를 확인합니다.
+- `pre enter` 명령은 버전을 `-canary.x` 형태로 만들도록 Changesets에 지시합니다.
+
+## 3. 버전 산출 및 패키지 점검
+```bash
+pnpm exec changeset version
+pnpm --filter @ara/core pack --dry-run
+pnpm --filter @ara/react pack --dry-run
+pnpm --filter @ara/tokens pack --dry-run
+```
+- `changeset version`은 `package.json`과 `CHANGELOG.md`를 프리릴리스 버전으로 갱신합니다.
+- 각 패키지를 `pack --dry-run`으로 감싸 tarball에 포함될 파일과 엔트리 포인트를 검증합니다.
+
+## 4. 로컬 설치 검증
+```bash
+pnpm pack --filter @ara/react --pack-destination ./.canary
+pnpm pack --filter @ara/core --pack-destination ./.canary
+pnpm pack --filter @ara/tokens --pack-destination ./.canary
+pnpm dlx create-vite@latest canary-consumer -- --template react-ts
+cd canary-consumer
+pnpm install ../.canary/ara-react-*.tgz
+pnpm install ../.canary/ara-core-*.tgz ../.canary/ara-tokens-*.tgz
+pnpm exec vite build
+```
+- 새 샌드박스를 만들어 실제 설치 및 빌드가 성공하는지 확인합니다.
+- 검증이 끝나면 샌드박스와 `./.canary` 폴더를 제거합니다.
+
+## 5. canary 태그로 배포
+```bash
+pnpm exec changeset publish --tag canary
+pnpm exec changeset pre exit
+```
+- `publish --tag canary`로 npm에 canary 채널로 올립니다. CI 런너에서 `NPM_TOKEN`이 설정되어 있어야 합니다.
+- 배포 후 `pre exit`으로 프리릴리스 모드를 빠져나오고, 버전 변경 커밋을 리셋/되돌려서 main 브랜치를 청결하게 유지합니다.
+
+## 6. 릴리스 메모 기록
+- canary 설치에 사용한 샌드박스에서 Button을 임포트/렌더한 예시와 결과를 메모로 남깁니다.
+- 설치가 정상 동작했음을 WBS Task(T-000035) 코멘트나 PR 본문에 링크합니다.
+
+> 💡 이 가이드는 실제 배포 전 드라이런을 위한 것이며, 정식 배포 시에는 Changesets 릴리스 브랜치 전략과 CI 플로우에 맞춰 조정해야 합니다.

--- a/packages/react/src/components/button/Button.test.tsx
+++ b/packages/react/src/components/button/Button.test.tsx
@@ -3,7 +3,6 @@ import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { Button } from "./Button.js";
 import { AraProvider } from "../../theme/index.js";
-import { defaultTheme } from "@ara/core";
 
 describe("Button", () => {
   it("기본 테마에서 버튼을 렌더링한다", () => {
@@ -159,7 +158,10 @@ describe("Button", () => {
       </>
     );
 
-    const [small, large] = screen.getAllByRole("button");
+    const [small, large] = screen.getAllByRole("button") as [
+      HTMLButtonElement,
+      HTMLButtonElement
+    ];
 
     expect(small.style.fontSize).toBe(
       "var(--ara-btn-font-size, var(--ara-btn-size-sm-font-size, 0.875rem))"

--- a/packages/react/src/components/button/Button.tsx
+++ b/packages/react/src/components/button/Button.tsx
@@ -252,14 +252,14 @@ export const Button = forwardRef<ButtonElement, ButtonProps>(function Button(pro
   }, []);
 
   const handlePointerEnter: PointerEventHandler<HTMLElement> = useCallback(
-    (_event) => {
+    () => {
       if (interactionsDisabled) return;
       setHovered(true);
     },
     [interactionsDisabled]
   );
 
-  const handlePointerLeave: PointerEventHandler<HTMLElement> = useCallback((_event) => {
+  const handlePointerLeave: PointerEventHandler<HTMLElement> = useCallback(() => {
     setHovered(false);
   }, []);
 

--- a/packages/react/src/theme/AraProvider.tsx
+++ b/packages/react/src/theme/AraProvider.tsx
@@ -8,6 +8,8 @@ import {
 import { createTheme, defaultTheme, type Theme, type ThemeOverrides } from "@ara/core";
 import type { CSSProperties } from "react";
 
+type ThemeCSSVariables = CSSProperties & Record<`--${string}`, string>;
+
 const ThemeContext = createContext<Theme>(defaultTheme);
 
 export interface AraProviderProps {
@@ -16,8 +18,8 @@ export interface AraProviderProps {
   readonly children: ReactNode;
 }
 
-function createThemeVariables(theme: Theme): CSSProperties {
-  const variables: Record<string, string> = {};
+function createThemeVariables(theme: Theme): ThemeCSSVariables {
+  const variables: ThemeCSSVariables = {} as ThemeCSSVariables;
 
   for (const [rampName, ramp] of Object.entries(theme.color)) {
     for (const [shade, value] of Object.entries(ramp)) {
@@ -97,7 +99,7 @@ export function AraProvider({ theme, asChild = false, children }: AraProviderPro
 
   return (
     <ThemeContext.Provider value={value}>
-      {children}
+      {asChild ? <Slot>{children}</Slot> : children}
     </ThemeContext.Provider>
   );
 }
@@ -113,7 +115,7 @@ export interface AraThemeBoundaryProps {
   readonly children: ReactNode;
 }
 
-export function useAraThemeVariables(): CSSProperties {
+export function useAraThemeVariables(): ThemeCSSVariables {
   const theme = useAraTheme();
   return useMemo(() => createThemeVariables(theme), [theme]);
 }

--- a/packages/react/src/theme/AraProvider.tsx
+++ b/packages/react/src/theme/AraProvider.tsx
@@ -8,7 +8,16 @@ import {
 import { createTheme, defaultTheme, type Theme, type ThemeOverrides } from "@ara/core";
 import type { CSSProperties } from "react";
 
-type ThemeCSSVariables = CSSProperties & Record<`--${string}`, string>;
+type ThemeCSSVariableName = `--${string}`;
+type ThemeCSSVariables = CSSProperties & Record<ThemeCSSVariableName, string>;
+
+function assignVariable(
+  variables: ThemeCSSVariables,
+  name: ThemeCSSVariableName,
+  value: string
+) {
+  variables[name] = value;
+}
 
 const ThemeContext = createContext<Theme>(defaultTheme);
 
@@ -23,66 +32,178 @@ function createThemeVariables(theme: Theme): ThemeCSSVariables {
 
   for (const [rampName, ramp] of Object.entries(theme.color)) {
     for (const [shade, value] of Object.entries(ramp)) {
-      variables[`--ara-color-${rampName}-${shade}`] = value;
+      assignVariable(
+        variables,
+        `--ara-color-${rampName}-${shade}` as ThemeCSSVariableName,
+        value
+      );
     }
   }
 
   for (const [familyName, value] of Object.entries(theme.typography.fontFamily)) {
-    variables[`--ara-font-family-${familyName}`] = value;
+    assignVariable(
+      variables,
+      `--ara-font-family-${familyName}` as ThemeCSSVariableName,
+      value
+    );
   }
 
   for (const [sizeName, value] of Object.entries(theme.typography.fontSize)) {
-    variables[`--ara-font-size-${sizeName}`] = value;
+    assignVariable(
+      variables,
+      `--ara-font-size-${sizeName}` as ThemeCSSVariableName,
+      value
+    );
   }
 
   for (const [weightName, value] of Object.entries(theme.typography.fontWeight)) {
-    variables[`--ara-font-weight-${weightName}`] = String(value);
+    assignVariable(
+      variables,
+      `--ara-font-weight-${weightName}` as ThemeCSSVariableName,
+      String(value)
+    );
   }
 
   for (const [spacingName, value] of Object.entries(theme.typography.letterSpacing)) {
-    variables[`--ara-letter-spacing-${spacingName}`] = value;
+    assignVariable(
+      variables,
+      `--ara-letter-spacing-${spacingName}` as ThemeCSSVariableName,
+      value
+    );
   }
 
   for (const [lineHeightName, value] of Object.entries(theme.typography.lineHeight)) {
-    variables[`--ara-line-height-${lineHeightName}`] = value;
+    assignVariable(
+      variables,
+      `--ara-line-height-${lineHeightName}` as ThemeCSSVariableName,
+      value
+    );
   }
 
   const button = theme.component.button;
 
-  variables["--ara-btn-radius"] = button.radius;
-  variables["--ara-btn-border-width"] = button.borderWidth;
-  variables["--ara-btn-font"] = button.font.family;
-  variables["--ara-btn-font-weight"] = String(button.font.weight);
-  variables["--ara-btn-disabled-opacity"] = String(button.disabled.opacity);
-  variables["--ara-btn-focus-outline"] = `${button.focus.outlineWidth} solid ${button.focus.outlineColor}`;
-  variables["--ara-btn-focus-outline-offset"] = button.focus.outlineOffset;
-  variables["--ara-btn-focus-ring"] = `0 0 0 ${button.focus.ringSize} ${button.focus.ringColor}`;
+  assignVariable(variables, "--ara-btn-radius", button.radius);
+  assignVariable(variables, "--ara-btn-border-width", button.borderWidth);
+  assignVariable(variables, "--ara-btn-font", button.font.family);
+  assignVariable(
+    variables,
+    "--ara-btn-font-weight",
+    String(button.font.weight)
+  );
+  assignVariable(
+    variables,
+    "--ara-btn-disabled-opacity",
+    String(button.disabled.opacity)
+  );
+  assignVariable(
+    variables,
+    "--ara-btn-focus-outline",
+    `${button.focus.outlineWidth} solid ${button.focus.outlineColor}`
+  );
+  assignVariable(
+    variables,
+    "--ara-btn-focus-outline-offset",
+    button.focus.outlineOffset
+  );
+  assignVariable(
+    variables,
+    "--ara-btn-focus-ring",
+    `0 0 0 ${button.focus.ringSize} ${button.focus.ringColor}`
+  );
 
   for (const [variantName, tones] of Object.entries(button.variant)) {
     for (const [toneName, token] of Object.entries(tones)) {
       const prefix = `--ara-btn-variant-${variantName}-${toneName}`;
-      variables[`${prefix}-bg`] = token.background;
-      variables[`${prefix}-fg`] = token.foreground;
-      variables[`${prefix}-border`] = token.border;
-      variables[`${prefix}-bg-hover`] = token.backgroundHover;
-      variables[`${prefix}-fg-hover`] = token.foregroundHover;
-      variables[`${prefix}-border-hover`] = token.borderHover;
-      variables[`${prefix}-bg-active`] = token.backgroundActive;
-      variables[`${prefix}-fg-active`] = token.foregroundActive;
-      variables[`${prefix}-border-active`] = token.borderActive;
-      variables[`${prefix}-shadow`] = token.shadow ?? "none";
+      assignVariable(
+        variables,
+        `${prefix}-bg` as ThemeCSSVariableName,
+        token.background
+      );
+      assignVariable(
+        variables,
+        `${prefix}-fg` as ThemeCSSVariableName,
+        token.foreground
+      );
+      assignVariable(
+        variables,
+        `${prefix}-border` as ThemeCSSVariableName,
+        token.border
+      );
+      assignVariable(
+        variables,
+        `${prefix}-bg-hover` as ThemeCSSVariableName,
+        token.backgroundHover
+      );
+      assignVariable(
+        variables,
+        `${prefix}-fg-hover` as ThemeCSSVariableName,
+        token.foregroundHover
+      );
+      assignVariable(
+        variables,
+        `${prefix}-border-hover` as ThemeCSSVariableName,
+        token.borderHover
+      );
+      assignVariable(
+        variables,
+        `${prefix}-bg-active` as ThemeCSSVariableName,
+        token.backgroundActive
+      );
+      assignVariable(
+        variables,
+        `${prefix}-fg-active` as ThemeCSSVariableName,
+        token.foregroundActive
+      );
+      assignVariable(
+        variables,
+        `${prefix}-border-active` as ThemeCSSVariableName,
+        token.borderActive
+      );
+      assignVariable(
+        variables,
+        `${prefix}-shadow` as ThemeCSSVariableName,
+        token.shadow ?? "none"
+      );
     }
   }
 
   for (const [sizeName, token] of Object.entries(button.size)) {
     const prefix = `--ara-btn-size-${sizeName}`;
-    variables[`${prefix}-gap`] = token.gap;
-    variables[`${prefix}-px`] = token.paddingInline;
-    variables[`${prefix}-py`] = token.paddingBlock;
-    variables[`${prefix}-font-size`] = token.fontSize;
-    variables[`${prefix}-line-height`] = token.lineHeight;
-    variables[`${prefix}-min-height`] = token.minHeight;
-    variables[`${prefix}-spinner`] = token.spinnerSize;
+    assignVariable(
+      variables,
+      `${prefix}-gap` as ThemeCSSVariableName,
+      token.gap
+    );
+    assignVariable(
+      variables,
+      `${prefix}-px` as ThemeCSSVariableName,
+      token.paddingInline
+    );
+    assignVariable(
+      variables,
+      `${prefix}-py` as ThemeCSSVariableName,
+      token.paddingBlock
+    );
+    assignVariable(
+      variables,
+      `${prefix}-font-size` as ThemeCSSVariableName,
+      token.fontSize
+    );
+    assignVariable(
+      variables,
+      `${prefix}-line-height` as ThemeCSSVariableName,
+      token.lineHeight
+    );
+    assignVariable(
+      variables,
+      `${prefix}-min-height` as ThemeCSSVariableName,
+      token.minHeight
+    );
+    assignVariable(
+      variables,
+      `${prefix}-spinner` as ThemeCSSVariableName,
+      token.spinnerSize
+    );
   }
 
   return variables;


### PR DESCRIPTION
## Summary
- [x] CSS 변수 맵을 `ThemeCSSVariables`로 확장해 사용자 정의 속성 접근 시 타입 오류를 해소했습니다.
- [x] `AraProvider`가 `asChild` 설정을 활용해 컨텍스트 래퍼를 슬롯으로 위임하도록 조정했습니다.

## Testing
- [x] `pnpm --filter @ara/react test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d72453cb8832285019c1fc52d5af7)