### PR TITLE
Fix lint failure from missing jsx-a11y plugin

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,8 +1,17 @@
 import { configs } from "@ara/eslint-config";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+
+const REACT_FILE_PATTERNS = ["packages/react/**/*.{js,jsx,ts,tsx}"];
 
 export default [
   ...configs.node,
   {
     ignores: ["**/*.md"]
+  },
+  {
+    files: REACT_FILE_PATTERNS,
+    plugins: {
+      "jsx-a11y": jsxA11y
+    }
   }
 ];

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@changesets/cli": "^2.27.8",
     "@types/node": "^24.9.2",
     "eslint": "^9.12.0",
+    "eslint-plugin-jsx-a11y": "^6.9.0",
     "prettier": "^3.3.3",
     "typescript": "^5.5.4",
     "rollup": "^4.52.5",

--- a/packages/react/src/components/button/Button.test.tsx
+++ b/packages/react/src/components/button/Button.test.tsx
@@ -278,7 +278,6 @@ describe("Button", () => {
   it("asChild로 자식 요소에 속성을 전달한다", () => {
     render(
       <Button asChild href="/nested" className="custom-slot">
-        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
         <a data-testid="child">중첩</a>
       </Button>
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       eslint:
         specifier: ^9.12.0
         version: 9.38.0
+      eslint-plugin-jsx-a11y:
+        specifier: ^6.9.0
+        version: 6.10.2(eslint@9.38.0)
       prettier:
         specifier: ^3.3.3
         version: 3.6.2


### PR DESCRIPTION
## Summary
- register the jsx-a11y plugin for React sources in the workspace ESLint flat config
- add eslint-plugin-jsx-a11y to the workspace dev dependencies and remove the unused disable comment in the button test

## Testing
- pnpm -w lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d7d5f5fbc832292db99afda4c3621)