### PR TITLE
[T-000037] 색상 팔레트 역할 토큰 정의

### DIFF
--- a/packages/react/src/components/button/Button.test.tsx
+++ b/packages/react/src/components/button/Button.test.tsx
@@ -12,10 +12,10 @@ describe("Button", () => {
 
     expect(button).toBeInTheDocument();
     expect(button.style.backgroundColor).toBe(
-      "var(--ara-btn-bg, var(--ara-btn-variant-solid-primary-bg, #2F6BFF))"
+      "var(--ara-btn-bg, var(--ara-btn-variant-solid-primary-bg, #2563EB))"
     );
     expect(button.style.color).toBe(
-      "var(--ara-btn-fg, var(--ara-btn-variant-solid-primary-fg, #F8FAFC))"
+      "var(--ara-btn-fg, var(--ara-btn-variant-solid-primary-fg, #FFFFFF))"
     );
     expect(button).toHaveAttribute("data-variant", "solid");
     expect(button).toHaveAttribute("data-tone", "primary");
@@ -32,13 +32,13 @@ describe("Button", () => {
     const button = screen.getByRole("button", { name: "보조" });
 
     expect(button.style.backgroundColor).toBe(
-      "var(--ara-btn-bg, var(--ara-btn-variant-outline-primary-bg, transparent))"
+      "var(--ara-btn-bg, var(--ara-btn-variant-outline-primary-bg, #FFFFFF))"
     );
     expect(button.style.color).toBe(
-      "var(--ara-btn-fg, var(--ara-btn-variant-outline-primary-fg, #2F6BFF))"
+      "var(--ara-btn-fg, var(--ara-btn-variant-outline-primary-fg, #2563EB))"
     );
     expect(button.style.borderColor).toBe(
-      "var(--ara-btn-border, var(--ara-btn-variant-outline-primary-border, #2F6BFF))"
+      "var(--ara-btn-border, var(--ara-btn-variant-outline-primary-border, #2563EB))"
     );
     expect(button).toHaveAttribute("data-variant", "outline");
   });
@@ -49,16 +49,16 @@ describe("Button", () => {
     const button = screen.getByRole("button", { name: "토글" });
 
     expect(button.style.backgroundColor).toBe(
-      "var(--ara-btn-bg, var(--ara-btn-variant-solid-primary-bg, #2F6BFF))"
+      "var(--ara-btn-bg, var(--ara-btn-variant-solid-primary-bg, #2563EB))"
     );
 
     rerender(<Button variant="outline">토글</Button>);
 
     expect(button.style.backgroundColor).toBe(
-      "var(--ara-btn-bg, var(--ara-btn-variant-outline-primary-bg, transparent))"
+      "var(--ara-btn-bg, var(--ara-btn-variant-outline-primary-bg, #FFFFFF))"
     );
     expect(button.style.borderColor).toBe(
-      "var(--ara-btn-border, var(--ara-btn-variant-outline-primary-border, #2F6BFF))"
+      "var(--ara-btn-border, var(--ara-btn-variant-outline-primary-border, #2563EB))"
     );
   });
 
@@ -70,10 +70,10 @@ describe("Button", () => {
     const button = screen.getByRole("button", { name: "위험" });
 
     expect(button.style.backgroundColor).toBe(
-      "var(--ara-btn-bg, var(--ara-btn-variant-solid-danger-bg, #D946EF))"
+      "var(--ara-btn-bg, var(--ara-btn-variant-solid-danger-bg, #E11D48))"
     );
     expect(button.style.color).toBe(
-      "var(--ara-btn-fg, var(--ara-btn-variant-solid-danger-fg, #F8FAFC))"
+      "var(--ara-btn-fg, var(--ara-btn-variant-solid-danger-fg, #FFFFFF))"
     );
     expect(button).toHaveAttribute("data-tone", "danger");
   });
@@ -87,20 +87,20 @@ describe("Button", () => {
 
     expect(button).toHaveAttribute("data-hovered", "");
     expect(button.style.backgroundColor).toBe(
-      "var(--ara-btn-bg-hover, var(--ara-btn-variant-solid-primary-bg-hover, #1F4FCC))"
+      "var(--ara-btn-bg-hover, var(--ara-btn-variant-solid-primary-bg-hover, #1D4ED8))"
     );
     expect(button.style.color).toBe(
-      "var(--ara-btn-fg-hover, var(--ara-btn-variant-solid-primary-fg-hover, #F8FAFC))"
+      "var(--ara-btn-fg-hover, var(--ara-btn-variant-solid-primary-fg-hover, #FFFFFF))"
     );
     expect(button.style.borderColor).toBe(
-      "var(--ara-btn-border-hover, var(--ara-btn-variant-solid-primary-border-hover, #1F4FCC))"
+      "var(--ara-btn-border-hover, var(--ara-btn-variant-solid-primary-border-hover, #1D4ED8))"
     );
 
     fireEvent.pointerLeave(button, { pointerType: "mouse" });
 
     expect(button).not.toHaveAttribute("data-hovered");
     expect(button.style.backgroundColor).toBe(
-      "var(--ara-btn-bg, var(--ara-btn-variant-solid-primary-bg, #2F6BFF))"
+      "var(--ara-btn-bg, var(--ara-btn-variant-solid-primary-bg, #2563EB))"
     );
   });
 
@@ -117,13 +117,13 @@ describe("Button", () => {
 
     expect(button).toHaveAttribute("data-pressed", "");
     expect(button.style.backgroundColor).toBe(
-      "var(--ara-btn-bg-active, var(--ara-btn-variant-solid-primary-bg-active, #173CA3))"
+      "var(--ara-btn-bg-active, var(--ara-btn-variant-solid-primary-bg-active, #1E40AF))"
     );
     expect(button.style.color).toBe(
-      "var(--ara-btn-fg-active, var(--ara-btn-variant-solid-primary-fg-active, #F8FAFC))"
+      "var(--ara-btn-fg-active, var(--ara-btn-variant-solid-primary-fg-active, #FFFFFF))"
     );
     expect(button.style.borderColor).toBe(
-      "var(--ara-btn-border-active, var(--ara-btn-variant-solid-primary-border-active, #173CA3))"
+      "var(--ara-btn-border-active, var(--ara-btn-variant-solid-primary-border-active, #1E40AF))"
     );
     expect(button.style.transform).toBe("translateY(1px)");
 
@@ -196,10 +196,10 @@ describe("Button", () => {
     expect(button).toHaveAttribute("data-tone", "primary");
     expect(button).toHaveAttribute("data-size", "md");
     expect(button.style.backgroundColor).toBe(
-      "var(--ara-btn-bg, var(--ara-btn-variant-solid-primary-bg, #2F6BFF))"
+      "var(--ara-btn-bg, var(--ara-btn-variant-solid-primary-bg, #2563EB))"
     );
     expect(button.style.color).toBe(
-      "var(--ara-btn-fg, var(--ara-btn-variant-solid-primary-fg, #F8FAFC))"
+      "var(--ara-btn-fg, var(--ara-btn-variant-solid-primary-fg, #FFFFFF))"
     );
   });
 

--- a/packages/tokens/src/colors.ts
+++ b/packages/tokens/src/colors.ts
@@ -307,10 +307,12 @@ const role = {
 } as const;
 
 export const colors = {
+  ...palette,
   palette,
   role
 } as const;
 
+export type ColorTokens = typeof colors;
 export type ColorPalette = typeof palette;
 export type ColorRampName = keyof ColorPalette;
 export type ColorRamp<TName extends ColorRampName = ColorRampName> = ColorPalette[TName];

--- a/packages/tokens/src/colors.ts
+++ b/packages/tokens/src/colors.ts
@@ -1,19 +1,66 @@
-// 🎨 프로젝트 전역 색상 팔레트 (디자인 토큰 기반)
-export const colors = {
-  // 브랜드 기본 색상 (주 브랜드 컬러 ramp)
+type HexColor = `#${string}`;
+
+type InteractionState = {
+  readonly background: HexColor | "transparent";
+  readonly foreground: HexColor;
+  readonly border: HexColor | "transparent";
+};
+
+export type InteractionTokens = {
+  readonly default: InteractionState;
+  readonly hover: InteractionState;
+  readonly active: InteractionState;
+  readonly disabled: InteractionState;
+};
+
+type TextTokens = {
+  readonly primary: HexColor;
+  readonly secondary: HexColor;
+  readonly tertiary: HexColor;
+  readonly inverse: HexColor;
+  readonly link: HexColor;
+};
+
+type SurfaceTokens = {
+  readonly canvas: HexColor;
+  readonly surface: HexColor;
+  readonly elevated: HexColor;
+  readonly overlay: HexColor;
+  readonly inverse: HexColor;
+};
+
+type BorderTokens = {
+  readonly subtle: HexColor;
+  readonly default: HexColor;
+  readonly strong: HexColor;
+  readonly inverse: HexColor;
+  readonly focus: HexColor;
+};
+
+type ThemeColorRoleShape = {
+  readonly surface: SurfaceTokens;
+  readonly text: TextTokens;
+  readonly border: BorderTokens;
+  readonly interactive: {
+    readonly primary: InteractionTokens;
+    readonly neutral: InteractionTokens;
+    readonly danger: InteractionTokens;
+  };
+};
+
+const palette = {
   brand: {
-    "50": "#F5F9FF",
-    "100": "#E0EDFF",
-    "200": "#B8D5FF",
-    "300": "#8AB6FF",
-    "400": "#578DFF",
-    "500": "#2F6BFF", // 기본(Primary)
-    "600": "#1F4FCC",
-    "700": "#173CA3",
-    "800": "#102A7A",
-    "900": "#0A1C52"
+    "50": "#EFF6FF",
+    "100": "#DBEAFE",
+    "200": "#BFDBFE",
+    "300": "#93C5FD",
+    "400": "#60A5FA",
+    "500": "#3B82F6",
+    "600": "#2563EB",
+    "700": "#1D4ED8",
+    "800": "#1E40AF",
+    "900": "#1E3A8A"
   },
-  // 중립(Neutral) 계열: 배경, 텍스트, 경계선 등
   neutral: {
     "50": "#F8FAFC",
     "100": "#EEF2F6",
@@ -26,38 +73,260 @@ export const colors = {
     "800": "#1E293B",
     "900": "#0F172A"
   },
-  // 포인트 색상(보조 강조용)
-  accent: {
-    "100": "#FDF4FF",
-    "200": "#FAE8FF",
-    "300": "#F5D0FE",
-    "400": "#E879F9",
-    "500": "#D946EF",
-    "600": "#C026D3",
-    "700": "#A21CAF",
-    "800": "#86198F",
-    "900": "#701A75"
+  danger: {
+    "50": "#FFF1F2",
+    "100": "#FFE4E6",
+    "200": "#FECDD3",
+    "300": "#FDA4AF",
+    "400": "#FB7185",
+    "500": "#F43F5E",
+    "600": "#E11D48",
+    "700": "#BE123C",
+    "800": "#9F1239",
+    "900": "#881337"
+  },
+  success: {
+    "50": "#F0FDF4",
+    "100": "#DCFCE7",
+    "200": "#BBF7D0",
+    "300": "#86EFAC",
+    "400": "#4ADE80",
+    "500": "#22C55E",
+    "600": "#16A34A",
+    "700": "#15803D",
+    "800": "#166534",
+    "900": "#14532D"
+  },
+  warning: {
+    "50": "#FFFBEB",
+    "100": "#FEF3C7",
+    "200": "#FDE68A",
+    "300": "#FCD34D",
+    "400": "#FBBF24",
+    "500": "#F59E0B",
+    "600": "#D97706",
+    "700": "#B45309",
+    "800": "#92400E",
+    "900": "#78350F"
   }
-} as const; // as const로 리터럴 타입 고정 (불변)
+} as const;
 
-// 색상 객체 전체 타입
-export type ColorTokens = typeof colors;
+function createInteractionTokens(definition: {
+  readonly background: HexColor;
+  readonly foreground: HexColor;
+  readonly border: HexColor;
+  readonly hoverBackground: HexColor;
+  readonly hoverForeground: HexColor;
+  readonly hoverBorder: HexColor;
+  readonly activeBackground: HexColor;
+  readonly activeForeground: HexColor;
+  readonly activeBorder: HexColor;
+  readonly disabledBackground: HexColor;
+  readonly disabledForeground: HexColor;
+  readonly disabledBorder: HexColor;
+}): InteractionTokens {
+  return {
+    default: {
+      background: definition.background,
+      foreground: definition.foreground,
+      border: definition.border
+    },
+    hover: {
+      background: definition.hoverBackground,
+      foreground: definition.hoverForeground,
+      border: definition.hoverBorder
+    },
+    active: {
+      background: definition.activeBackground,
+      foreground: definition.activeForeground,
+      border: definition.activeBorder
+    },
+    disabled: {
+      background: definition.disabledBackground,
+      foreground: definition.disabledForeground,
+      border: definition.disabledBorder
+    }
+  } as const;
+}
 
-// 색상 ramp 이름 (brand | neutral | accent)
-export type ColorRampName = keyof ColorTokens;
+function createLightRole(): ThemeColorRoleShape {
+  const text: TextTokens = {
+    primary: palette.neutral["900"],
+    secondary: palette.neutral["700"],
+    tertiary: palette.neutral["500"],
+    inverse: palette.neutral["50"],
+    link: palette.brand["600"]
+  } as const;
 
-// 특정 ramp의 색상 단계 타입 (예: brand["500"])
-export type ColorRamp<TName extends ColorRampName = ColorRampName> = ColorTokens[TName];
+  const surface: SurfaceTokens = {
+    canvas: palette.neutral["50"],
+    surface: "#FFFFFF",
+    elevated: "#FFFFFF",
+    overlay: "#0F172A99",
+    inverse: palette.neutral["900"]
+  } as const;
 
-// ramp 내 쉐이드 key 타입 (예: "50" | "100" | ... | "900")
-export type ColorShade<TName extends ColorRampName = ColorRampName> =
-  keyof ColorTokens[TName] & string;
+  const border: BorderTokens = {
+    subtle: palette.neutral["200"],
+    default: palette.neutral["300"],
+    strong: palette.neutral["400"],
+    inverse: palette.neutral["800"],
+    focus: palette.brand["400"]
+  } as const;
 
-// 특정 ramp와 shade를 받아 해당 hex 코드 반환
-export function getColor<R extends ColorRampName, S extends ColorShade<R>>(
-  ramp: R,
-  shade: S
-): ColorTokens[R][S] {
-  return colors[ramp][shade];
-  // 예: getColor("brand", "500") → "#2F6BFF"
+  return {
+    surface,
+    text,
+    border,
+    interactive: {
+      primary: createInteractionTokens({
+        background: palette.brand["600"],
+        foreground: "#FFFFFF",
+        border: palette.brand["600"],
+        hoverBackground: palette.brand["700"],
+        hoverForeground: "#FFFFFF",
+        hoverBorder: palette.brand["700"],
+        activeBackground: palette.brand["800"],
+        activeForeground: "#FFFFFF",
+        activeBorder: palette.brand["800"],
+        disabledBackground: palette.neutral["200"],
+        disabledForeground: palette.neutral["500"],
+        disabledBorder: palette.neutral["300"]
+      }),
+      neutral: createInteractionTokens({
+        background: "#FFFFFF",
+        foreground: palette.neutral["700"],
+        border: palette.neutral["300"],
+        hoverBackground: palette.neutral["100"],
+        hoverForeground: palette.neutral["800"],
+        hoverBorder: palette.neutral["400"],
+        activeBackground: palette.neutral["200"],
+        activeForeground: palette.neutral["900"],
+        activeBorder: palette.neutral["500"],
+        disabledBackground: palette.neutral["100"],
+        disabledForeground: palette.neutral["400"],
+        disabledBorder: palette.neutral["200"]
+      }),
+      danger: createInteractionTokens({
+        background: palette.danger["600"],
+        foreground: "#FFFFFF",
+        border: palette.danger["600"],
+        hoverBackground: palette.danger["700"],
+        hoverForeground: "#FFFFFF",
+        hoverBorder: palette.danger["700"],
+        activeBackground: palette.danger["800"],
+        activeForeground: "#FFFFFF",
+        activeBorder: palette.danger["800"],
+        disabledBackground: palette.danger["100"],
+        disabledForeground: palette.danger["400"],
+        disabledBorder: palette.danger["200"]
+      })
+    }
+  } as const;
+}
+
+function createDarkRole(): ThemeColorRoleShape {
+  const text: TextTokens = {
+    primary: palette.neutral["50"],
+    secondary: palette.neutral["200"],
+    tertiary: palette.neutral["400"],
+    inverse: palette.neutral["900"],
+    link: palette.brand["300"]
+  } as const;
+
+  const surface: SurfaceTokens = {
+    canvas: palette.neutral["900"],
+    surface: "#111827",
+    elevated: "#1F2937",
+    overlay: "#0F172ACC",
+    inverse: "#FFFFFF"
+  } as const;
+
+  const border: BorderTokens = {
+    subtle: palette.neutral["700"],
+    default: palette.neutral["600"],
+    strong: palette.neutral["500"],
+    inverse: palette.neutral["200"],
+    focus: palette.brand["400"]
+  } as const;
+
+  return {
+    surface,
+    text,
+    border,
+    interactive: {
+      primary: createInteractionTokens({
+        background: palette.brand["400"],
+        foreground: palette.neutral["900"],
+        border: palette.brand["400"],
+        hoverBackground: palette.brand["300"],
+        hoverForeground: palette.neutral["900"],
+        hoverBorder: palette.brand["300"],
+        activeBackground: palette.brand["200"],
+        activeForeground: palette.neutral["900"],
+        activeBorder: palette.brand["200"],
+        disabledBackground: palette.neutral["800"],
+        disabledForeground: palette.neutral["500"],
+        disabledBorder: palette.neutral["700"]
+      }),
+      neutral: createInteractionTokens({
+        background: "#1F2937",
+        foreground: palette.neutral["100"],
+        border: palette.neutral["700"],
+        hoverBackground: palette.neutral["800"],
+        hoverForeground: palette.neutral["50"],
+        hoverBorder: palette.neutral["600"],
+        activeBackground: palette.neutral["900"],
+        activeForeground: palette.neutral["50"],
+        activeBorder: palette.neutral["500"],
+        disabledBackground: palette.neutral["800"],
+        disabledForeground: palette.neutral["500"],
+        disabledBorder: palette.neutral["800"]
+      }),
+      danger: createInteractionTokens({
+        background: palette.danger["400"],
+        foreground: palette.neutral["900"],
+        border: palette.danger["400"],
+        hoverBackground: palette.danger["300"],
+        hoverForeground: palette.neutral["900"],
+        hoverBorder: palette.danger["300"],
+        activeBackground: palette.danger["200"],
+        activeForeground: palette.neutral["900"],
+        activeBorder: palette.danger["200"],
+        disabledBackground: palette.danger["800"],
+        disabledForeground: palette.danger["400"],
+        disabledBorder: palette.danger["700"]
+      })
+    }
+  } as const;
+}
+
+const role = {
+  light: createLightRole(),
+  dark: createDarkRole()
+} as const;
+
+export const colors = {
+  palette,
+  role
+} as const;
+
+export type ColorPalette = typeof palette;
+export type ColorRampName = keyof ColorPalette;
+export type ColorRamp<TName extends ColorRampName = ColorRampName> = ColorPalette[TName];
+export type ColorShade<TName extends ColorRampName = ColorRampName> = keyof ColorPalette[TName] & string;
+
+export type ColorRoleMap = typeof role;
+export type ColorThemeName = keyof ColorRoleMap;
+export type ThemeColorRole<TTheme extends ColorThemeName = ColorThemeName> = ColorRoleMap[TTheme];
+export type InteractiveRoleName<TTheme extends ColorThemeName = ColorThemeName> = keyof ThemeColorRole<TTheme>["interactive"];
+export type InteractiveColorTokens<
+  TTheme extends ColorThemeName = ColorThemeName,
+  TRole extends InteractiveRoleName<TTheme> = InteractiveRoleName<TTheme>
+> = ThemeColorRole<TTheme>["interactive"][TRole];
+export type InteractiveColorStateName<TTheme extends ColorThemeName = ColorThemeName, TRole extends InteractiveRoleName<TTheme> = InteractiveRoleName<TTheme>> =
+  keyof InteractiveColorTokens<TTheme, TRole>;
+
+export function getColor<R extends ColorRampName, S extends ColorShade<R>>(ramp: R, shade: S): ColorPalette[R][S] {
+  return palette[ramp][shade];
 }

--- a/packages/tokens/src/components/button.ts
+++ b/packages/tokens/src/components/button.ts
@@ -2,12 +2,10 @@ import { colors } from "../colors.js";
 import { typography } from "../typography.js";
 
 type TonePalette = {
-  readonly base: string;
-  readonly emphasis: string;
-  readonly emphasisAlt: string;
-  readonly contrast: string;
-  readonly subtle: string;
-  readonly subtleAlt: string;
+  readonly interaction: import("../colors.js").InteractionTokens;
+  readonly subtleBackground: string;
+  readonly subtleBackgroundHover: string;
+  readonly subtleBackgroundActive: string;
 };
 
 type VariantToken = {
@@ -37,71 +35,73 @@ type SizeToken = {
 
 type SizeMap = Record<string, SizeToken>;
 
+const lightTheme = colors.role.light;
+
 const tonePalettes: Record<string, TonePalette> = {
   primary: {
-    base: colors.brand["500"],
-    emphasis: colors.brand["600"],
-    emphasisAlt: colors.brand["700"],
-    subtle: colors.brand["50"],
-    subtleAlt: colors.brand["100"],
-    contrast: colors.neutral["50"]
+    interaction: lightTheme.interactive.primary,
+    subtleBackground: colors.palette.brand["50"],
+    subtleBackgroundHover: colors.palette.brand["100"],
+    subtleBackgroundActive: colors.palette.brand["200"]
   },
   neutral: {
-    base: colors.neutral["100"],
-    emphasis: colors.neutral["200"],
-    emphasisAlt: colors.neutral["300"],
-    subtle: colors.neutral["50"],
-    subtleAlt: colors.neutral["100"],
-    contrast: colors.neutral["900"]
+    interaction: lightTheme.interactive.neutral,
+    subtleBackground: colors.palette.neutral["50"],
+    subtleBackgroundHover: colors.palette.neutral["100"],
+    subtleBackgroundActive: colors.palette.neutral["200"]
   },
   danger: {
-    base: colors.accent["500"],
-    emphasis: colors.accent["600"],
-    emphasisAlt: colors.accent["700"],
-    subtle: colors.accent["100"],
-    subtleAlt: colors.accent["200"],
-    contrast: colors.neutral["50"]
+    interaction: lightTheme.interactive.danger,
+    subtleBackground: colors.palette.danger["50"],
+    subtleBackgroundHover: colors.palette.danger["100"],
+    subtleBackgroundActive: colors.palette.danger["200"]
   }
 };
 
 function createSolidVariant(palette: TonePalette): VariantToken {
+  const { interaction } = palette;
+
   return {
-    background: palette.base,
-    foreground: palette.contrast,
-    border: palette.base,
-    backgroundHover: palette.emphasis,
-    foregroundHover: palette.contrast,
-    borderHover: palette.emphasis,
-    backgroundActive: palette.emphasisAlt,
-    foregroundActive: palette.contrast,
-    borderActive: palette.emphasisAlt
+    background: interaction.default.background,
+    foreground: interaction.default.foreground,
+    border: interaction.default.border,
+    backgroundHover: interaction.hover.background,
+    foregroundHover: interaction.hover.foreground,
+    borderHover: interaction.hover.border,
+    backgroundActive: interaction.active.background,
+    foregroundActive: interaction.active.foreground,
+    borderActive: interaction.active.border
   };
 }
 
 function createOutlineVariant(palette: TonePalette): VariantToken {
+  const { interaction } = palette;
+
   return {
-    background: "transparent",
-    foreground: palette.base,
-    border: palette.base,
-    backgroundHover: palette.subtle,
-    foregroundHover: palette.emphasis,
-    borderHover: palette.emphasis,
-    backgroundActive: palette.subtleAlt,
-    foregroundActive: palette.emphasisAlt,
-    borderActive: palette.emphasisAlt
+    background: lightTheme.surface.surface,
+    foreground: interaction.default.foreground,
+    border: interaction.default.border,
+    backgroundHover: palette.subtleBackground,
+    foregroundHover: interaction.hover.foreground,
+    borderHover: interaction.hover.border,
+    backgroundActive: palette.subtleBackgroundActive,
+    foregroundActive: interaction.active.foreground,
+    borderActive: interaction.active.border
   };
 }
 
 function createGhostVariant(palette: TonePalette): VariantToken {
+  const { interaction } = palette;
+
   return {
     background: "transparent",
-    foreground: palette.base,
+    foreground: interaction.default.foreground,
     border: "transparent",
-    backgroundHover: palette.subtle,
-    foregroundHover: palette.emphasis,
+    backgroundHover: palette.subtleBackground,
+    foregroundHover: interaction.hover.foreground,
     borderHover: "transparent",
-    backgroundActive: palette.subtleAlt,
-    foregroundActive: palette.emphasisAlt,
+    backgroundActive: palette.subtleBackgroundActive,
+    foregroundActive: interaction.active.foreground,
     borderActive: "transparent"
   };
 }
@@ -161,10 +161,10 @@ export const button = {
   },
   focus: {
     outlineWidth: "2px",
-    outlineColor: colors.brand["300"],
+    outlineColor: lightTheme.border.focus,
     outlineOffset: "2px",
     ringSize: "4px",
-    ringColor: colors.brand["100"]
+    ringColor: colors.palette.brand["100"]
   },
   disabled: {
     opacity: 0.6

--- a/packages/tokens/src/components/button.ts
+++ b/packages/tokens/src/components/button.ts
@@ -6,6 +6,9 @@ type TonePalette = {
   readonly subtleBackground: string;
   readonly subtleBackgroundHover: string;
   readonly subtleBackgroundActive: string;
+  readonly outlineForeground: string;
+  readonly outlineForegroundHover: string;
+  readonly outlineForegroundActive: string;
 };
 
 type VariantToken = {
@@ -42,19 +45,28 @@ const tonePalettes: Record<string, TonePalette> = {
     interaction: lightTheme.interactive.primary,
     subtleBackground: colors.palette.brand["50"],
     subtleBackgroundHover: colors.palette.brand["100"],
-    subtleBackgroundActive: colors.palette.brand["200"]
+    subtleBackgroundActive: colors.palette.brand["200"],
+    outlineForeground: colors.palette.brand["600"],
+    outlineForegroundHover: colors.palette.brand["700"],
+    outlineForegroundActive: colors.palette.brand["800"]
   },
   neutral: {
     interaction: lightTheme.interactive.neutral,
     subtleBackground: colors.palette.neutral["50"],
     subtleBackgroundHover: colors.palette.neutral["100"],
-    subtleBackgroundActive: colors.palette.neutral["200"]
+    subtleBackgroundActive: colors.palette.neutral["200"],
+    outlineForeground: colors.palette.neutral["700"],
+    outlineForegroundHover: colors.palette.neutral["800"],
+    outlineForegroundActive: colors.palette.neutral["900"]
   },
   danger: {
     interaction: lightTheme.interactive.danger,
     subtleBackground: colors.palette.danger["50"],
     subtleBackgroundHover: colors.palette.danger["100"],
-    subtleBackgroundActive: colors.palette.danger["200"]
+    subtleBackgroundActive: colors.palette.danger["200"],
+    outlineForeground: colors.palette.danger["600"],
+    outlineForegroundHover: colors.palette.danger["700"],
+    outlineForegroundActive: colors.palette.danger["800"]
   }
 };
 
@@ -79,13 +91,13 @@ function createOutlineVariant(palette: TonePalette): VariantToken {
 
   return {
     background: lightTheme.surface.surface,
-    foreground: interaction.default.foreground,
+    foreground: palette.outlineForeground,
     border: interaction.default.border,
     backgroundHover: palette.subtleBackground,
-    foregroundHover: interaction.hover.foreground,
+    foregroundHover: palette.outlineForegroundHover,
     borderHover: interaction.hover.border,
     backgroundActive: palette.subtleBackgroundActive,
-    foregroundActive: interaction.active.foreground,
+    foregroundActive: palette.outlineForegroundActive,
     borderActive: interaction.active.border
   };
 }
@@ -95,13 +107,13 @@ function createGhostVariant(palette: TonePalette): VariantToken {
 
   return {
     background: "transparent",
-    foreground: interaction.default.foreground,
+    foreground: palette.outlineForeground,
     border: "transparent",
     backgroundHover: palette.subtleBackground,
-    foregroundHover: interaction.hover.foreground,
+    foregroundHover: palette.outlineForegroundHover,
     borderHover: "transparent",
     backgroundActive: palette.subtleBackgroundActive,
-    foregroundActive: interaction.active.foreground,
+    foregroundActive: palette.outlineForegroundActive,
     borderActive: "transparent"
   };
 }


### PR DESCRIPTION
## Summary
- 라이트/다크 테마 색상 팔레트와 역할별 상호작용 토큰을 정리했습니다.
- 버튼 토큰이 역할 기반 팔레트를 참조하도록 상태 매핑을 갱신했습니다.

## Testing
- pnpm --filter @ara/tokens build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691160f54f2083228b99b7224444a07c)