### PR TITLE
[T-000038] 타이포그래피 토큰 스케일 확장

### DIFF
--- a/packages/tokens/src/typography.ts
+++ b/packages/tokens/src/typography.ts
@@ -13,28 +13,39 @@ export const typography = {
     sm: "0.875rem",  // 14px
     md: "1rem",      // 16px
     lg: "1.25rem",   // 20px
-    xl: "1.5rem"     // 24px
+    xl: "1.5rem",    // 24px
+    "2xl": "1.875rem", // 30px
+    "3xl": "2.25rem",  // 36px
+    "4xl": "3rem"      // 48px
   },
 
   // 줄 높이(line-height) 스케일
   lineHeight: {
-    tight: "1.25",   // 조밀한 행간
-    normal: "1.5",   // 일반 행간
-    relaxed: "1.75"  // 넉넉한 행간
+    tightest: "1.1",   // 극도로 조밀한 행간 (대형 헤드라인)
+    tighter: "1.25",   // 조밀한 행간 (헤드라인)
+    tight: "1.35",     // 타이틀/부제목
+    normal: "1.5",     // 기본 본문
+    relaxed: "1.65",   // 설명/캡션
+    loose: "1.8"       // 넉넉한 행간 (읽기 중심)
   },
 
   // 글자 굵기(weight)
   fontWeight: {
-    regular: 400, // 기본
-    medium: 500,  // 중간(버튼, 헤드라인 등)
-    bold: 700     // 굵게
+    light: 300,    // 보조 본문
+    regular: 400,  // 기본
+    medium: 500,   // 중간(버튼, 헤드라인 등)
+    semibold: 600, // 강조 타이틀
+    bold: 700      // 굵게
   },
 
   // 자간(letter-spacing)
   letterSpacing: {
-    tighter: "-0.01em", // 약간 좁힘
-    normal: "0",
-    wider: "0.05em"     // 넓힘
+    tightest: "-0.02em", // 헤드라인 대문자
+    tighter: "-0.01em",  // 약간 좁힘
+    tight: "-0.005em",   // 소제목
+    normal: "0",         // 기본
+    wide: "0.02em",      // 넓힘
+    wider: "0.05em"      // 크게 넓힘
   }
 } as const; // as const → 리터럴 고정 (readonly, 타입 추론 강화)
 

--- a/packages/tokens/tokens.json
+++ b/packages/tokens/tokens.json
@@ -46,21 +46,32 @@
       "sm": "0.875rem",
       "md": "1rem",
       "lg": "1.25rem",
-      "xl": "1.5rem"
+      "xl": "1.5rem",
+      "2xl": "1.875rem",
+      "3xl": "2.25rem",
+      "4xl": "3rem"
     },
     "lineHeight": {
-      "tight": "1.25",
+      "tightest": "1.1",
+      "tighter": "1.25",
+      "tight": "1.35",
       "normal": "1.5",
-      "relaxed": "1.75"
+      "relaxed": "1.65",
+      "loose": "1.8"
     },
     "fontWeight": {
+      "light": 300,
       "regular": 400,
       "medium": 500,
+      "semibold": 600,
       "bold": 700
     },
     "letterSpacing": {
+      "tightest": "-0.02em",
       "tighter": "-0.01em",
+      "tight": "-0.005em",
       "normal": "0",
+      "wide": "0.02em",
       "wider": "0.05em"
     }
   },


### PR DESCRIPTION
## Summary
- 본문과 헤드라인 전반을 커버하도록 글자 크기 스케일을 2xl~4xl 단계까지 확장했습니다.
- line-height와 letter-spacing 스케일을 세분화해 용도별 라벨을 명확히 했습니다.
- light·semibold 등 추가 굵기를 정의하고 JSON 산출물과 동기화했습니다.

## Testing
- pnpm --filter @ara/tokens build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116a95655c8322ab9eba860dc1b255)