### PR TITLE
[T-000039] 레이아웃 토큰 추가

### DIFF
--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,6 +1,6 @@
 # @ara/tokens
 
-Ara 디자인 시스템 전반에서 사용하는 색상·타이포그래피 토큰을 제공하는 패키지다. React/웹 앱뿐 아니라 디자인 자동화 스크립트에서도 재사용할 수 있도록 TypeScript API와 JSON 산출물을 동시에 노출한다.
+Ara 디자인 시스템 전반에서 사용하는 색상·레이아웃·타이포그래피 토큰을 제공하는 패키지다. React/웹 앱뿐 아니라 디자인 자동화 스크립트에서도 재사용할 수 있도록 TypeScript API와 JSON 산출물을 동시에 노출한다.
 
 ## 토큰 명명 규칙과 계약
 
@@ -8,7 +8,7 @@ Ara 디자인 시스템 전반에서 사용하는 색상·타이포그래피 토
 - **패키지 토큰 키는 모두 `camelCase`**로 작성하며, 범주별 네임스페이스를 유지한다.
   - 색상: `color.<역할>.<단계>` (예: `color.brand.500`)
   - 타이포그래피: `typography.<속성>.<스케일>` (예: `typography.fontSize.md`)
-  - 레이아웃: `layout.<속성>.<스케일>` (예: `layout.space.16`, `layout.radius.md`)
+  - 레이아웃: `layout.<속성>.<스케일>` (예: `layout.space.md`, `layout.radius.lg`)
 - **CSS 변수는 `--ara-<카테고리>-<키>`** 구조로 매핑한다. 예: `color.brand.500` → `--ara-color-brand-500`.
 - 토큰에서 파생되는 유틸리티 함수/타입 또한 `@ara/tokens` 네임스페이스 안에서 동일한 접두사를 따른다.
 
@@ -35,10 +35,11 @@ Ara 디자인 시스템 전반에서 사용하는 색상·타이포그래피 토
 ### TypeScript/JavaScript
 
 ```ts
-import { colors, typography, tokens, getColor } from "@ara/tokens";
+import { colors, layout, typography, tokens, getColor, getLayoutValue } from "@ara/tokens";
 
 const primary = getColor("brand", "500");
 const bodyFontSize = typography.fontSize.md;
+const buttonPadding = getLayoutValue("space", "md");
 ```
 
 세분화된 모듈이 필요하면 경로를 지정해 가져올 수 있다.
@@ -55,7 +56,7 @@ import { typography } from "@ara/tokens/typography";
 import tokensJson from "@ara/tokens/tokens.json" assert { type: "json" };
 ```
 
-JSON 구조는 현재 `color`와 `typography` 두 최상위 키로 구성되어 있으며 TypeScript API와 동일한 값을 제공한다. 향후 `layout` 등 추가 범주가 도입되면 동일한 네이밍 규칙과 접두사를 따른다.
+JSON 구조는 `color`, `layout`, `typography`, `component` 네 최상위 키로 구성되어 있으며 TypeScript API와 동일한 값을 제공한다.
 
 ## 개발 스크립트
 
@@ -64,7 +65,7 @@ JSON 구조는 현재 `color`와 `typography` 두 최상위 키로 구성되어 
 
 ## 빌드 산출물
 
-- `package.json` 의 `exports` 는 기본 엔트리(`.`) 외에 `./colors`, `./typography`, `./tokens.json`, `./package.json` 경로를 고정적으로 노출한다.
+- `package.json` 의 `exports` 는 기본 엔트리(`.`) 외에 `./colors`, `./layout`, `./typography`, `./tokens.json`, `./package.json` 경로를 고정적으로 노출한다.
 - 모든 엔트리는 `types` + `import(default)` 페어를 제공하므로 ESM 번들러와 TypeScript가 동일한 모듈 해상 결과를 갖는다.
 - `typesVersions` 는 `dist/*.d.ts` 파일과 서브패스를 직접 연결해, 오래된 TypeScript 모듈 해상 모드에서도 선언 파일을 안정적으로 찾을 수 있도록 한다.
 

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/colors.js",
       "default": "./dist/colors.js"
     },
+    "./layout": {
+      "types": "./dist/layout.d.ts",
+      "import": "./dist/layout.js",
+      "default": "./dist/layout.js"
+    },
     "./typography": {
       "types": "./dist/typography.d.ts",
       "import": "./dist/typography.js",
@@ -29,6 +34,9 @@
     "*": {
       "colors": [
         "dist/colors.d.ts"
+      ],
+      "layout": [
+        "dist/layout.d.ts"
       ],
       "typography": [
         "dist/typography.d.ts"
@@ -50,6 +58,7 @@
   "keywords": [
     "design tokens",
     "colors",
+    "layout",
     "typography"
   ],
   "engines": {

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,13 +1,16 @@
 import { colors } from "./colors.js";
 import { button } from "./components/button.js";
+import { layout } from "./layout.js";
 import { typography } from "./typography.js";
 
 export * from "./colors.js";
 export * from "./typography.js";
+export * from "./layout.js";
 export * from "./components/button.js";
 
 export const tokens = {
   color: colors,
+  layout,
   typography,
   component: {
     button

--- a/packages/tokens/src/layout.ts
+++ b/packages/tokens/src/layout.ts
@@ -1,0 +1,69 @@
+// 📐 프로젝트 전역 레이아웃 토큰 정의
+export const layout = {
+  // 공통 여백·간격 스케일 (px 단위)
+  space: {
+    none: "0px",
+    "3xs": "2px",
+    "2xs": "4px",
+    xs: "8px",
+    sm: "12px",
+    md: "16px",
+    lg: "24px",
+    xl: "32px",
+    "2xl": "40px",
+    "3xl": "48px"
+  },
+
+  // 모서리 곡률(radius) 스케일
+  radius: {
+    none: "0px",
+    xs: "2px",
+    sm: "4px",
+    md: "8px",
+    lg: "12px",
+    xl: "16px",
+    pill: "9999px"
+  },
+
+  // 그림자/고도(elevation) 스케일
+  elevation: {
+    none: "none",
+    xs: "0 1px 2px 0 rgba(15, 23, 42, 0.08)",
+    sm: "0 2px 4px -1px rgba(15, 23, 42, 0.1), 0 1px 2px rgba(15, 23, 42, 0.08)",
+    md: "0 4px 6px -2px rgba(15, 23, 42, 0.12), 0 2px 4px -1px rgba(15, 23, 42, 0.1)",
+    lg: "0 10px 15px -3px rgba(15, 23, 42, 0.14), 0 4px 6px -4px rgba(15, 23, 42, 0.12)",
+    xl: "0 20px 25px -5px rgba(15, 23, 42, 0.16), 0 10px 10px -5px rgba(15, 23, 42, 0.12)"
+  },
+
+  // UI 레이어 우선순위(z-index)
+  zIndex: {
+    auto: "auto",
+    hide: "-1",
+    base: "0",
+    dropdown: "1000",
+    sticky: "1020",
+    overlay: "1040",
+    modal: "1060",
+    popover: "1080",
+    tooltip: "1100"
+  }
+} as const;
+
+export type LayoutTokens = typeof layout;
+
+export type LayoutCategory = keyof LayoutTokens;
+
+export type LayoutScale<
+  TCategory extends LayoutCategory = LayoutCategory
+> = LayoutTokens[TCategory];
+
+export type LayoutKey<
+  TCategory extends LayoutCategory = LayoutCategory
+> = keyof LayoutTokens[TCategory];
+
+export function getLayoutValue<
+  C extends LayoutCategory,
+  K extends LayoutKey<C>
+>(category: C, key: K): LayoutTokens[C][K] {
+  return layout[category][key];
+}

--- a/packages/tokens/tokens.json
+++ b/packages/tokens/tokens.json
@@ -36,6 +36,48 @@
       "900": "#701A75"
     }
   },
+  "layout": {
+    "space": {
+      "none": "0px",
+      "3xs": "2px",
+      "2xs": "4px",
+      "xs": "8px",
+      "sm": "12px",
+      "md": "16px",
+      "lg": "24px",
+      "xl": "32px",
+      "2xl": "40px",
+      "3xl": "48px"
+    },
+    "radius": {
+      "none": "0px",
+      "xs": "2px",
+      "sm": "4px",
+      "md": "8px",
+      "lg": "12px",
+      "xl": "16px",
+      "pill": "9999px"
+    },
+    "elevation": {
+      "none": "none",
+      "xs": "0 1px 2px 0 rgba(15, 23, 42, 0.08)",
+      "sm": "0 2px 4px -1px rgba(15, 23, 42, 0.1), 0 1px 2px rgba(15, 23, 42, 0.08)",
+      "md": "0 4px 6px -2px rgba(15, 23, 42, 0.12), 0 2px 4px -1px rgba(15, 23, 42, 0.1)",
+      "lg": "0 10px 15px -3px rgba(15, 23, 42, 0.14), 0 4px 6px -4px rgba(15, 23, 42, 0.12)",
+      "xl": "0 20px 25px -5px rgba(15, 23, 42, 0.16), 0 10px 10px -5px rgba(15, 23, 42, 0.12)"
+    },
+    "zIndex": {
+      "auto": "auto",
+      "hide": "-1",
+      "base": "0",
+      "dropdown": "1000",
+      "sticky": "1020",
+      "overlay": "1040",
+      "modal": "1060",
+      "popover": "1080",
+      "tooltip": "1100"
+    }
+  },
   "typography": {
     "fontFamily": {
       "sans": "'Pretendard Variable', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",


### PR DESCRIPTION
## Summary
- [x] Tokens & ThemeProvider v1 레이아웃 스케일(space/radius/elevation/zIndex)을 정의했습니다.
- [x] 패키지 exports·JSON 산출물·README를 갱신해 신규 토큰을 안내했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (W-000005 / T-000039)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.** (해당 없음)

## Testing
- [x] 관련 스크립트나 테스트를 실행했습니다. (`pnpm test`, `pnpm lint` 등)
- `pnpm --filter @ara/tokens build`

## Screenshots
- 해당 사항 없음


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117317206c8322a1347a12f56d3a94)