### PR TITLE
feat: ThemeProvider CSS 변수 매핑 확장

### DIFF
--- a/packages/react/src/theme/AraProvider.test.tsx
+++ b/packages/react/src/theme/AraProvider.test.tsx
@@ -53,13 +53,31 @@ describe("AraThemeBoundary", () => {
     expect(host.style.getPropertyValue("--ara-btn-radius")).toBe(
       defaultTheme.component.button.radius
     );
+    expect(host.style.getPropertyValue("--ara-color-brand-500")).toBe(
+      defaultTheme.color.palette.brand["500"]
+    );
+    expect(host.style.getPropertyValue("--ara-space-md")).toBe(
+      defaultTheme.layout.space.md
+    );
+    expect(
+      host.style.getPropertyValue(
+        "--ara-color-role-light-interactive-primary-default-bg"
+      )
+    ).toBe(defaultTheme.color.role.light.interactive.primary.default.background);
   });
 
   it("hook으로 CSS 변수를 노출한다", () => {
     function Reader() {
       const variables = useAraThemeVariables();
       return (
-        <output data-testid="vars" data-radius={variables["--ara-btn-radius"]} />
+        <output
+          data-testid="vars"
+          data-radius={variables["--ara-btn-radius"]}
+          data-space-lg={variables["--ara-space-lg"]}
+          data-role-surface={
+            variables["--ara-color-role-light-surface-canvas"]
+          }
+        />
       );
     }
 
@@ -72,5 +90,9 @@ describe("AraThemeBoundary", () => {
     const vars = screen.getByTestId("vars");
 
     expect(vars.dataset.radius).toBe(defaultTheme.component.button.radius);
+    expect(vars.dataset.spaceLg).toBe(defaultTheme.layout.space.lg);
+    expect(vars.dataset.roleSurface).toBe(
+      defaultTheme.color.role.light.surface.canvas
+    );
   });
 });


### PR DESCRIPTION
## 요약
- 색상 팔레트·역할, 타이포그래피, 레이아웃 토큰을 CSS 변수로 변환하는 헬퍼를 추가해 ThemeProvider 주입 범위를 확장했습니다.
- CSS 변수 훅과 AraThemeBoundary 테스트에 전역 토큰 검증을 더해 새 변수들이 노출되는지 확인했습니다.

## 테스트
- pnpm --filter @ara/react test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117992a9a88322b80a65a347ed6009)