### PR TITLE
feat: T-000040 토큰 CSS 변수 테이블과 ThemeProvider 확장

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -83,6 +83,7 @@
   },
   "dependencies": {
     "@ara/core": "workspace:*",
+    "@ara/tokens": "workspace:*",
     "@radix-ui/react-slot": "^1.1.0"
   },
   "peerDependencies": {

--- a/packages/react/src/theme/AraProvider.test.tsx
+++ b/packages/react/src/theme/AraProvider.test.tsx
@@ -4,6 +4,7 @@ import { defaultTheme } from "@ara/core";
 import {
   AraProvider,
   AraThemeBoundary,
+  useAraThemeVariableTable,
   useAraThemeVariables
 } from "./AraProvider.js";
 
@@ -33,7 +34,7 @@ describe("AraThemeBoundary", () => {
     const host = screen.getByTestId("host");
 
     expect(container.firstElementChild?.tagName).toBe("DIV");
-    expect(container.firstElementChild).toHaveAttribute("data-ara-theme");
+    expect(container.firstElementChild).toHaveAttribute("data-ara-theme", "light");
     expect(host).toHaveTextContent("content");
   });
 
@@ -49,17 +50,54 @@ describe("AraThemeBoundary", () => {
     const host = screen.getByTestId("host");
 
     expect(container.firstElementChild).toBe(host);
-    expect(host).toHaveAttribute("data-ara-theme");
+    expect(host).toHaveAttribute("data-ara-theme", "light");
     expect(host.style.getPropertyValue("--ara-btn-radius")).toBe(
       defaultTheme.component.button.radius
     );
+    expect(host.style.getPropertyValue("--ara-color-brand-500")).toBe(
+      defaultTheme.color.palette.brand["500"]
+    );
+    expect(host.style.getPropertyValue("--ara-space-md")).toBe(
+      defaultTheme.layout.space.md
+    );
+    expect(
+      host.style.getPropertyValue(
+        "--ara-color-role-light-interactive-primary-default-bg"
+      )
+    ).toBe(defaultTheme.color.role.light.interactive.primary.default.background);
+  });
+
+  it("mode prop으로 지정한 테마 변수를 적용한다", () => {
+    const { container } = render(
+      <AraProvider>
+        <AraThemeBoundary mode="dark">
+          <section data-testid="host">content</section>
+        </AraThemeBoundary>
+      </AraProvider>
+    );
+
+    const host = screen.getByTestId("host");
+    const boundary = container.firstElementChild as HTMLElement | null;
+
+    expect(boundary).toHaveAttribute("data-ara-theme", "dark");
+    expect(boundary?.style.getPropertyValue("--ara-color-role-dark-surface-canvas")).toBe(
+      defaultTheme.color.role.dark.surface.canvas
+    );
+    expect(host.getAttribute("style")).toBeFalsy();
   });
 
   it("hook으로 CSS 변수를 노출한다", () => {
     function Reader() {
       const variables = useAraThemeVariables();
       return (
-        <output data-testid="vars" data-radius={variables["--ara-btn-radius"]} />
+        <output
+          data-testid="vars"
+          data-radius={variables["--ara-btn-radius"]}
+          data-space-lg={variables["--ara-space-lg"]}
+          data-role-surface={
+            variables["--ara-color-role-light-surface-canvas"]
+          }
+        />
       );
     }
 
@@ -72,5 +110,63 @@ describe("AraThemeBoundary", () => {
     const vars = screen.getByTestId("vars");
 
     expect(vars.dataset.radius).toBe(defaultTheme.component.button.radius);
+    expect(vars.dataset.spaceLg).toBe(defaultTheme.layout.space.lg);
+    expect(vars.dataset.roleSurface).toBe(
+      defaultTheme.color.role.light.surface.canvas
+    );
+  });
+
+  it("hook으로 테마별 맵을 구분해 제공한다", () => {
+    function Reader() {
+      const table = useAraThemeVariableTable();
+
+      return (
+        <output
+          data-testid="table"
+          data-root-space-lg={table.root["--ara-space-lg"]}
+          data-dark-surface={
+            table.themes.dark["--ara-color-role-dark-surface-elevated"]
+          }
+        />
+      );
+    }
+
+    render(
+      <AraProvider>
+        <Reader />
+      </AraProvider>
+    );
+
+    const table = screen.getByTestId("table");
+
+    expect(table.dataset.rootSpaceLg).toBe(defaultTheme.layout.space.lg);
+    expect(table.dataset.darkSurface).toBe(
+      defaultTheme.color.role.dark.surface.elevated
+    );
+  });
+
+  it("특정 모드로 훅을 호출하면 해당 테마 변수를 병합한다", () => {
+    function Reader() {
+      const variables = useAraThemeVariables("dark");
+
+      return (
+        <output
+          data-testid="vars"
+          data-surface={variables["--ara-color-role-dark-surface-surface"]}
+        />
+      );
+    }
+
+    render(
+      <AraProvider>
+        <Reader />
+      </AraProvider>
+    );
+
+    const vars = screen.getByTestId("vars");
+
+    expect(vars.dataset.surface).toBe(
+      defaultTheme.color.role.dark.surface.surface
+    );
   });
 });

--- a/packages/react/src/theme/AraProvider.tsx
+++ b/packages/react/src/theme/AraProvider.tsx
@@ -6,207 +6,37 @@ import {
   useMemo
 } from "react";
 import { createTheme, defaultTheme, type Theme, type ThemeOverrides } from "@ara/core";
-import type { CSSProperties } from "react";
-
-type ThemeCSSVariableName = `--${string}`;
-type ThemeCSSVariables = CSSProperties & Record<ThemeCSSVariableName, string>;
-
-function assignVariable(
-  variables: ThemeCSSVariables,
-  name: ThemeCSSVariableName,
-  value: string
-) {
-  variables[name] = value;
-}
+import type { ColorThemeName } from "@ara/tokens/colors";
+import {
+  createCSSVariableTable,
+  mergeCSSVariableMaps,
+  type CSSVariableMap,
+  type ThemeCSSVariableTable
+} from "@ara/tokens/css-vars";
 
 const ThemeContext = createContext<Theme>(defaultTheme);
+const DEFAULT_COLOR_THEME: ColorThemeName = "light";
+
+function resolveThemeVariables(
+  table: ThemeCSSVariableTable,
+  mode: ColorThemeName
+): CSSVariableMap {
+  const themeVariables =
+    table.themes[mode] ??
+    table.themes[DEFAULT_COLOR_THEME] ??
+    Object.values(table.themes)[0];
+
+  if (!themeVariables) {
+    return mergeCSSVariableMaps(table.root);
+  }
+
+  return mergeCSSVariableMaps(table.root, themeVariables);
+}
 
 export interface AraProviderProps {
   readonly theme?: ThemeOverrides;
   readonly asChild?: boolean;
   readonly children: ReactNode;
-}
-
-function createThemeVariables(theme: Theme): ThemeCSSVariables {
-  const variables: ThemeCSSVariables = {} as ThemeCSSVariables;
-
-  for (const [rampName, ramp] of Object.entries(theme.color)) {
-    for (const [shade, value] of Object.entries(ramp)) {
-      assignVariable(
-        variables,
-        `--ara-color-${rampName}-${shade}` as ThemeCSSVariableName,
-        value
-      );
-    }
-  }
-
-  for (const [familyName, value] of Object.entries(theme.typography.fontFamily)) {
-    assignVariable(
-      variables,
-      `--ara-font-family-${familyName}` as ThemeCSSVariableName,
-      value
-    );
-  }
-
-  for (const [sizeName, value] of Object.entries(theme.typography.fontSize)) {
-    assignVariable(
-      variables,
-      `--ara-font-size-${sizeName}` as ThemeCSSVariableName,
-      value
-    );
-  }
-
-  for (const [weightName, value] of Object.entries(theme.typography.fontWeight)) {
-    assignVariable(
-      variables,
-      `--ara-font-weight-${weightName}` as ThemeCSSVariableName,
-      String(value)
-    );
-  }
-
-  for (const [spacingName, value] of Object.entries(theme.typography.letterSpacing)) {
-    assignVariable(
-      variables,
-      `--ara-letter-spacing-${spacingName}` as ThemeCSSVariableName,
-      value
-    );
-  }
-
-  for (const [lineHeightName, value] of Object.entries(theme.typography.lineHeight)) {
-    assignVariable(
-      variables,
-      `--ara-line-height-${lineHeightName}` as ThemeCSSVariableName,
-      value
-    );
-  }
-
-  const button = theme.component.button;
-
-  assignVariable(variables, "--ara-btn-radius", button.radius);
-  assignVariable(variables, "--ara-btn-border-width", button.borderWidth);
-  assignVariable(variables, "--ara-btn-font", button.font.family);
-  assignVariable(
-    variables,
-    "--ara-btn-font-weight",
-    String(button.font.weight)
-  );
-  assignVariable(
-    variables,
-    "--ara-btn-disabled-opacity",
-    String(button.disabled.opacity)
-  );
-  assignVariable(
-    variables,
-    "--ara-btn-focus-outline",
-    `${button.focus.outlineWidth} solid ${button.focus.outlineColor}`
-  );
-  assignVariable(
-    variables,
-    "--ara-btn-focus-outline-offset",
-    button.focus.outlineOffset
-  );
-  assignVariable(
-    variables,
-    "--ara-btn-focus-ring",
-    `0 0 0 ${button.focus.ringSize} ${button.focus.ringColor}`
-  );
-
-  for (const [variantName, tones] of Object.entries(button.variant)) {
-    for (const [toneName, token] of Object.entries(tones)) {
-      const prefix = `--ara-btn-variant-${variantName}-${toneName}`;
-      assignVariable(
-        variables,
-        `${prefix}-bg` as ThemeCSSVariableName,
-        token.background
-      );
-      assignVariable(
-        variables,
-        `${prefix}-fg` as ThemeCSSVariableName,
-        token.foreground
-      );
-      assignVariable(
-        variables,
-        `${prefix}-border` as ThemeCSSVariableName,
-        token.border
-      );
-      assignVariable(
-        variables,
-        `${prefix}-bg-hover` as ThemeCSSVariableName,
-        token.backgroundHover
-      );
-      assignVariable(
-        variables,
-        `${prefix}-fg-hover` as ThemeCSSVariableName,
-        token.foregroundHover
-      );
-      assignVariable(
-        variables,
-        `${prefix}-border-hover` as ThemeCSSVariableName,
-        token.borderHover
-      );
-      assignVariable(
-        variables,
-        `${prefix}-bg-active` as ThemeCSSVariableName,
-        token.backgroundActive
-      );
-      assignVariable(
-        variables,
-        `${prefix}-fg-active` as ThemeCSSVariableName,
-        token.foregroundActive
-      );
-      assignVariable(
-        variables,
-        `${prefix}-border-active` as ThemeCSSVariableName,
-        token.borderActive
-      );
-      assignVariable(
-        variables,
-        `${prefix}-shadow` as ThemeCSSVariableName,
-        token.shadow ?? "none"
-      );
-    }
-  }
-
-  for (const [sizeName, token] of Object.entries(button.size)) {
-    const prefix = `--ara-btn-size-${sizeName}`;
-    assignVariable(
-      variables,
-      `${prefix}-gap` as ThemeCSSVariableName,
-      token.gap
-    );
-    assignVariable(
-      variables,
-      `${prefix}-px` as ThemeCSSVariableName,
-      token.paddingInline
-    );
-    assignVariable(
-      variables,
-      `${prefix}-py` as ThemeCSSVariableName,
-      token.paddingBlock
-    );
-    assignVariable(
-      variables,
-      `${prefix}-font-size` as ThemeCSSVariableName,
-      token.fontSize
-    );
-    assignVariable(
-      variables,
-      `${prefix}-line-height` as ThemeCSSVariableName,
-      token.lineHeight
-    );
-    assignVariable(
-      variables,
-      `${prefix}-min-height` as ThemeCSSVariableName,
-      token.minHeight
-    );
-    assignVariable(
-      variables,
-      `${prefix}-spinner` as ThemeCSSVariableName,
-      token.spinnerSize
-    );
-  }
-
-  return variables;
 }
 
 export function AraProvider({ theme, asChild = false, children }: AraProviderProps) {
@@ -233,20 +63,32 @@ export function useAraTheme(): Theme {
 
 export interface AraThemeBoundaryProps {
   readonly asChild?: boolean;
+  readonly mode?: ColorThemeName;
   readonly children: ReactNode;
 }
 
-export function useAraThemeVariables(): ThemeCSSVariables {
+export function useAraThemeVariableTable(): ThemeCSSVariableTable {
   const theme = useAraTheme();
-  return useMemo(() => createThemeVariables(theme), [theme]);
+  return useMemo(() => createCSSVariableTable(theme), [theme]);
 }
 
-export function AraThemeBoundary({ asChild = false, children }: AraThemeBoundaryProps) {
-  const style = useAraThemeVariables();
+export function useAraThemeVariables(
+  mode: ColorThemeName = DEFAULT_COLOR_THEME
+): CSSVariableMap {
+  const table = useAraThemeVariableTable();
+  return useMemo(() => resolveThemeVariables(table, mode), [table, mode]);
+}
+
+export function AraThemeBoundary({
+  asChild = false,
+  mode = DEFAULT_COLOR_THEME,
+  children
+}: AraThemeBoundaryProps) {
+  const style = useAraThemeVariables(mode);
   const Container = asChild ? Slot : "div";
 
   return (
-    <Container data-ara-theme="" style={style}>
+    <Container data-ara-theme={mode} style={style}>
       {children}
     </Container>
   );

--- a/packages/react/src/theme/index.ts
+++ b/packages/react/src/theme/index.ts
@@ -5,5 +5,6 @@ export {
   type AraThemeBoundaryProps,
   ThemeContext,
   useAraTheme,
+  useAraThemeVariableTable,
   useAraThemeVariables
 } from "./AraProvider.js";

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/layout.js",
       "default": "./dist/layout.js"
     },
+    "./css-vars": {
+      "types": "./dist/css-vars.d.ts",
+      "import": "./dist/css-vars.js",
+      "default": "./dist/css-vars.js"
+    },
     "./typography": {
       "types": "./dist/typography.d.ts",
       "import": "./dist/typography.js",
@@ -38,6 +43,9 @@
       "layout": [
         "dist/layout.d.ts"
       ],
+      "css-vars": [
+        "dist/css-vars.d.ts"
+      ],
       "typography": [
         "dist/typography.d.ts"
       ],
@@ -53,7 +61,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "pnpm exec rollup -c"
+    "build": "pnpm exec rollup -c",
+    "generate:css-vars": "node ./scripts/generate-css-vars.mjs"
   },
   "keywords": [
     "design tokens",

--- a/packages/tokens/scripts/generate-css-vars.mjs
+++ b/packages/tokens/scripts/generate-css-vars.mjs
@@ -1,0 +1,51 @@
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageDir = path.resolve(__dirname, "..");
+const distDir = path.join(packageDir, "dist");
+
+const indexPath = path.join(distDir, "index.js");
+const cssVarsPath = path.join(distDir, "css-vars.js");
+
+if (!existsSync(indexPath) || !existsSync(cssVarsPath)) {
+  console.error(
+    "@ara/tokens build 산출물을 찾을 수 없습니다. 먼저 `pnpm --filter @ara/tokens build`를 실행해 주세요."
+  );
+  process.exit(1);
+}
+
+const { tokens } = await import(indexPath);
+const { createCSSVariableTable } = await import(cssVarsPath);
+
+function formatBlock(selector, variables) {
+  const lines = Object.entries(variables)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, value]) => `  ${name}: ${value};`)
+    .join("\n");
+
+  return `${selector} {\n${lines}\n}`;
+}
+
+const table = createCSSVariableTable(tokens);
+const rootBlock = formatBlock(":root", table.root);
+const themeBlocks = Object.entries(table.themes).map(([themeName, vars]) =>
+  formatBlock(`[data-ara-theme="${themeName}"]`, vars)
+);
+
+const css = [rootBlock, ...themeBlocks].join("\n\n");
+
+const outputArg = process.argv[2];
+
+if (outputArg) {
+  const outputPath = path.isAbsolute(outputArg)
+    ? outputArg
+    : path.resolve(process.cwd(), outputArg);
+
+  await writeFile(outputPath, css, "utf8");
+} else {
+  process.stdout.write(css);
+}

--- a/packages/tokens/src/css-vars.ts
+++ b/packages/tokens/src/css-vars.ts
@@ -1,0 +1,314 @@
+import type { Tokens } from "./index.js";
+import type { ColorThemeName } from "./colors.js";
+
+export type CSSVariableName = `--ara-${string}`;
+export type CSSVariableValue = string | number;
+export type CSSVariableMap = Record<CSSVariableName, string>;
+
+export interface ThemeCSSVariableTable {
+  readonly root: CSSVariableMap;
+  readonly themes: Record<ColorThemeName, CSSVariableMap>;
+}
+
+function assignVariable(
+  variables: CSSVariableMap,
+  name: CSSVariableName,
+  value: CSSVariableValue
+) {
+  variables[name] = typeof value === "string" ? value : String(value);
+}
+
+function createPaletteVariables(theme: Tokens): CSSVariableMap {
+  const variables: CSSVariableMap = {} as CSSVariableMap;
+
+  for (const [rampName, ramp] of Object.entries(theme.color.palette)) {
+    for (const [shade, value] of Object.entries(ramp)) {
+      assignVariable(
+        variables,
+        `--ara-color-${rampName}-${shade}` as CSSVariableName,
+        value
+      );
+    }
+  }
+
+  return variables;
+}
+
+function createTypographyVariables(theme: Tokens): CSSVariableMap {
+  const variables: CSSVariableMap = {} as CSSVariableMap;
+
+  for (const [familyName, value] of Object.entries(theme.typography.fontFamily)) {
+    assignVariable(
+      variables,
+      `--ara-font-family-${familyName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [sizeName, value] of Object.entries(theme.typography.fontSize)) {
+    assignVariable(
+      variables,
+      `--ara-font-size-${sizeName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [weightName, value] of Object.entries(theme.typography.fontWeight)) {
+    assignVariable(
+      variables,
+      `--ara-font-weight-${weightName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [spacingName, value] of Object.entries(theme.typography.letterSpacing)) {
+    assignVariable(
+      variables,
+      `--ara-letter-spacing-${spacingName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [lineHeightName, value] of Object.entries(theme.typography.lineHeight)) {
+    assignVariable(
+      variables,
+      `--ara-line-height-${lineHeightName}` as CSSVariableName,
+      value
+    );
+  }
+
+  return variables;
+}
+
+function createLayoutVariables(theme: Tokens): CSSVariableMap {
+  const variables: CSSVariableMap = {} as CSSVariableMap;
+
+  for (const [spaceName, value] of Object.entries(theme.layout.space)) {
+    assignVariable(
+      variables,
+      `--ara-space-${spaceName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [radiusName, value] of Object.entries(theme.layout.radius)) {
+    assignVariable(
+      variables,
+      `--ara-radius-${radiusName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [elevationName, value] of Object.entries(theme.layout.elevation)) {
+    assignVariable(
+      variables,
+      `--ara-elevation-${elevationName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [zIndexName, value] of Object.entries(theme.layout.zIndex)) {
+    assignVariable(
+      variables,
+      `--ara-z-index-${zIndexName}` as CSSVariableName,
+      value
+    );
+  }
+
+  return variables;
+}
+
+function createButtonVariables(theme: Tokens): CSSVariableMap {
+  const variables: CSSVariableMap = {} as CSSVariableMap;
+  const button = theme.component.button;
+
+  assignVariable(variables, "--ara-btn-radius", button.radius);
+  assignVariable(variables, "--ara-btn-border-width", button.borderWidth);
+  assignVariable(variables, "--ara-btn-font", button.font.family);
+  assignVariable(variables, "--ara-btn-font-weight", button.font.weight);
+  assignVariable(variables, "--ara-btn-disabled-opacity", button.disabled.opacity);
+  assignVariable(
+    variables,
+    "--ara-btn-focus-outline",
+    `${button.focus.outlineWidth} solid ${button.focus.outlineColor}`
+  );
+  assignVariable(
+    variables,
+    "--ara-btn-focus-outline-offset",
+    button.focus.outlineOffset
+  );
+  assignVariable(
+    variables,
+    "--ara-btn-focus-ring",
+    `0 0 0 ${button.focus.ringSize} ${button.focus.ringColor}`
+  );
+
+  for (const [variantName, tones] of Object.entries(button.variant)) {
+    for (const [toneName, token] of Object.entries(tones)) {
+      const prefix = `--ara-btn-variant-${variantName}-${toneName}`;
+
+      assignVariable(variables, `${prefix}-bg` as CSSVariableName, token.background);
+      assignVariable(variables, `${prefix}-fg` as CSSVariableName, token.foreground);
+      assignVariable(variables, `${prefix}-border` as CSSVariableName, token.border);
+      assignVariable(
+        variables,
+        `${prefix}-bg-hover` as CSSVariableName,
+        token.backgroundHover
+      );
+      assignVariable(
+        variables,
+        `${prefix}-fg-hover` as CSSVariableName,
+        token.foregroundHover
+      );
+      assignVariable(
+        variables,
+        `${prefix}-border-hover` as CSSVariableName,
+        token.borderHover
+      );
+      assignVariable(
+        variables,
+        `${prefix}-bg-active` as CSSVariableName,
+        token.backgroundActive
+      );
+      assignVariable(
+        variables,
+        `${prefix}-fg-active` as CSSVariableName,
+        token.foregroundActive
+      );
+      assignVariable(
+        variables,
+        `${prefix}-border-active` as CSSVariableName,
+        token.borderActive
+      );
+      assignVariable(
+        variables,
+        `${prefix}-shadow` as CSSVariableName,
+        token.shadow ?? "none"
+      );
+    }
+  }
+
+  for (const [sizeName, token] of Object.entries(button.size)) {
+    const prefix = `--ara-btn-size-${sizeName}`;
+
+    assignVariable(variables, `${prefix}-gap` as CSSVariableName, token.gap);
+    assignVariable(
+      variables,
+      `${prefix}-px` as CSSVariableName,
+      token.paddingInline
+    );
+    assignVariable(
+      variables,
+      `${prefix}-py` as CSSVariableName,
+      token.paddingBlock
+    );
+    assignVariable(
+      variables,
+      `${prefix}-font-size` as CSSVariableName,
+      token.fontSize
+    );
+    assignVariable(
+      variables,
+      `${prefix}-line-height` as CSSVariableName,
+      token.lineHeight
+    );
+    assignVariable(
+      variables,
+      `${prefix}-min-height` as CSSVariableName,
+      token.minHeight
+    );
+    assignVariable(
+      variables,
+      `${prefix}-spinner` as CSSVariableName,
+      token.spinnerSize
+    );
+  }
+
+  return variables;
+}
+
+function createColorRoleVariables(
+  theme: Tokens,
+  themeName: ColorThemeName
+): CSSVariableMap {
+  const variables: CSSVariableMap = {} as CSSVariableMap;
+  const role = theme.color.role[themeName];
+
+  for (const [surfaceName, value] of Object.entries(role.surface)) {
+    assignVariable(
+      variables,
+      `--ara-color-role-${themeName}-surface-${surfaceName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [textName, value] of Object.entries(role.text)) {
+    assignVariable(
+      variables,
+      `--ara-color-role-${themeName}-text-${textName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [borderName, value] of Object.entries(role.border)) {
+    assignVariable(
+      variables,
+      `--ara-color-role-${themeName}-border-${borderName}` as CSSVariableName,
+      value
+    );
+  }
+
+  for (const [roleName, states] of Object.entries(role.interactive)) {
+    for (const [stateName, tokens] of Object.entries(states)) {
+      const prefix = `--ara-color-role-${themeName}-interactive-${roleName}-${stateName}`;
+
+      assignVariable(
+        variables,
+        `${prefix}-bg` as CSSVariableName,
+        tokens.background
+      );
+      assignVariable(
+        variables,
+        `${prefix}-fg` as CSSVariableName,
+        tokens.foreground
+      );
+      assignVariable(
+        variables,
+        `${prefix}-border` as CSSVariableName,
+        tokens.border
+      );
+    }
+  }
+
+  return variables;
+}
+
+function mergeVariableMaps(...maps: CSSVariableMap[]): CSSVariableMap {
+  return Object.assign({}, ...maps) as CSSVariableMap;
+}
+
+export function mergeCSSVariableMaps(...maps: CSSVariableMap[]): CSSVariableMap {
+  return mergeVariableMaps(...maps);
+}
+
+export function createThemeCSSVariables(theme: Tokens): Record<ColorThemeName, CSSVariableMap> {
+  const entries = Object.keys(theme.color.role).map((themeName) => {
+    const name = themeName as ColorThemeName;
+    return [name, createColorRoleVariables(theme, name)] as const;
+  });
+
+  return Object.fromEntries(entries) as Record<ColorThemeName, CSSVariableMap>;
+}
+
+export function createCSSVariableTable(theme: Tokens): ThemeCSSVariableTable {
+  const root = mergeVariableMaps(
+    createPaletteVariables(theme),
+    createTypographyVariables(theme),
+    createLayoutVariables(theme),
+    createButtonVariables(theme)
+  );
+
+  const themes = createThemeCSSVariables(theme);
+
+  return { root, themes } satisfies ThemeCSSVariableTable;
+}

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -7,6 +7,7 @@ export * from "./colors.js";
 export * from "./typography.js";
 export * from "./layout.js";
 export * from "./components/button.js";
+export * from "./css-vars.js";
 
 export const tokens = {
   color: colors,

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -135,9 +135,9 @@ T-000038,W-000005,Tokens & ThemeProvider v1,토큰(타이포),타이포그래피
 T-000039,W-000005,Tokens & ThemeProvider v1,토큰(레이아웃),간격/반지름/섀도 스케일,완료,Medium," ● 내용: space(px), radius, elevation(shadow), z-index 스케일과 키 고정
  ● 산출물: packages/tokens/src/layout.ts
  ● 점검: Button v0에 적용 시 기대 치수/모양 재현",확인
-T-000040,W-000005,Tokens & ThemeProvider v1,CSS 변수 매핑,CSS Vars 생성 및 주입 규칙,계획,High," ● 내용: 토큰→CSS 변수(--ara-*) 변환 테이블 정의, :root와 테마별 변수 세트 구성
+T-000040,W-000005,Tokens & ThemeProvider v1,CSS 변수 매핑,CSS Vars 생성 및 주입 규칙,완료,High," ● 내용: 토큰→CSS 변수(--ara-*) 변환 테이블 정의, :root와 테마별 변수 세트 구성
  ● 산출물: packages/tokens/src/css-vars.ts, 생성 스크립트
- ● 점검: 변수 이름 충돌 없음, d.ts 생성 확인", 
+ ● 점검: 변수 이름 충돌 없음, d.ts 생성 확인",확인 
 T-000041,W-000005,Tokens & ThemeProvider v1,ThemeProvider,API 설계 및 기본 구현,계획,High," ● 내용: ThemeProvider 컴포넌트 설계(컨텍스트, 변수 주입, data-theme 또는 class 전략, override API)
  ● 산출물: packages/react/src/components/theme-provider/index.tsx 및 README.md
  ● 점검: 중첩 Provider, SSR/StrictMode 스모크 통과", 

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -29,7 +29,7 @@ W-000004,T1,Button v0 Comp,완료,100,"Button v0
  ● canary 프리릴리스 포함
  ● 범위: 일반 버튼/링크(토글 제외)
  ● AC: CI 통과·Tests 통과·Storybook build·ESM+types import·canary 발행·디자인 승인",--
-W-000005,T1,Tokens & ThemeProvider v1,진행중,33,"Tokens v1 & ThemeProvider
+W-000005,T1,Tokens & ThemeProvider v1,진행중,50,"Tokens v1 & ThemeProvider
  ● 설계문서
           - root/packages/tokens/README.md 
           - root/packages/react/src/components/theme-provider/README.md

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       '@ara/core':
         specifier: workspace:*
         version: link:../core
+      '@ara/tokens':
+        specifier: workspace:*
+        version: link:../tokens
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.2.3(@types/react@18.3.26)(react@18.3.1)


### PR DESCRIPTION
## Summary
- [x] @ara/tokens에 CSS 변수 테이블 생성기와 출력 스크립트를 추가해 토큰을 :root/테마별 세트로 변환합니다.
- [x] ThemeProvider 훅과 경계가 새 테이블을 사용해 모드별 변수 병합과 테이블 조회를 지원하도록 갱신했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/react test`

## Screenshots
- 해당 없음


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117992a9a88322b80a65a347ed6009)