### PR TITLE
[T-000041] ThemeProvider 기본 구현

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,8 +2,10 @@ export type { Theme, ThemeOverrides } from "@ara/core";
 export {
   AraProvider,
   AraThemeBoundary,
+  ThemeProvider,
   type AraProviderProps,
   type AraThemeBoundaryProps,
+  type ThemeProviderProps,
   useAraTheme,
   useAraThemeVariables,
   ThemeContext

--- a/packages/react/src/theme/ThemeProvider.test.tsx
+++ b/packages/react/src/theme/ThemeProvider.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { defaultTheme, type ThemeOverrides } from "@ara/core";
+import { ThemeProvider } from "./ThemeProvider.js";
+import { useAraTheme, useAraThemeVariables } from "./AraProvider.js";
+
+function createOverride(): ThemeOverrides {
+  return {
+    component: {
+      button: {
+        radius: "999px",
+        variant: {
+          solid: {
+            primary: {
+              background: "#123456",
+              foreground: "#ffffff",
+              border: "#123456",
+              backgroundHover: "#234567",
+              foregroundHover: "#ffffff",
+              borderHover: "#234567",
+              backgroundActive: "#345678",
+              foregroundActive: "#ffffff",
+              borderActive: "#345678",
+              shadow: "none"
+            }
+          }
+        }
+      }
+    }
+  };
+}
+
+describe("ThemeProvider", () => {
+  it("기본적으로 div 경계에 data-ara-theme를 부여한다", () => {
+    const { container } = render(
+      <ThemeProvider>
+        <section data-testid="host">content</section>
+      </ThemeProvider>
+    );
+
+    const boundary = container.firstElementChild as HTMLElement | null;
+    const host = screen.getByTestId("host");
+
+    expect(boundary?.tagName).toBe("DIV");
+    expect(boundary).toHaveAttribute("data-ara-theme", "light");
+    expect(boundary?.style.getPropertyValue("--ara-space-md")).toBe(
+      defaultTheme.layout.space.md
+    );
+    expect(host).toHaveTextContent("content");
+  });
+
+  it("asChild로 전달된 요소에 CSS 변수를 주입한다", () => {
+    render(
+      <ThemeProvider asChild>
+        <section data-testid="host">content</section>
+      </ThemeProvider>
+    );
+
+    const host = screen.getByTestId("host");
+
+    expect(host).toHaveAttribute("data-ara-theme", "light");
+    expect(host.style.getPropertyValue("--ara-btn-radius")).toBe(
+      defaultTheme.component.button.radius
+    );
+  });
+
+  it("mode prop으로 지정한 테마 변수를 적용한다", () => {
+    const { container } = render(
+      <ThemeProvider mode="dark">
+        <section data-testid="host">content</section>
+      </ThemeProvider>
+    );
+
+    const boundary = container.firstElementChild as HTMLElement | null;
+
+    expect(boundary).toHaveAttribute("data-ara-theme", "dark");
+    expect(boundary?.style.getPropertyValue("--ara-color-role-dark-surface-canvas")).toBe(
+      defaultTheme.color.role.dark.surface.canvas
+    );
+  });
+
+  it("theme 오버라이드를 컨텍스트와 CSS 변수에 반영한다", () => {
+    function Reader() {
+      const theme = useAraTheme();
+      const variables = useAraThemeVariables();
+
+      return (
+        <output
+          data-testid="reader"
+          data-radius={theme.component.button.radius}
+          data-bg={variables["--ara-btn-variant-solid-primary-bg"]}
+        />
+      );
+    }
+
+    const override = createOverride();
+
+    render(
+      <ThemeProvider theme={override} asChild>
+        <section>
+          <Reader />
+        </section>
+      </ThemeProvider>
+    );
+
+    const reader = screen.getByTestId("reader");
+
+    expect(reader.dataset.radius).toBe("999px");
+    expect(reader.dataset.bg).toBe("#123456");
+  });
+});

--- a/packages/react/src/theme/ThemeProvider.tsx
+++ b/packages/react/src/theme/ThemeProvider.tsx
@@ -1,0 +1,30 @@
+import { type ReactNode } from "react";
+import type { ThemeOverrides } from "@ara/core";
+import type { ColorThemeName } from "@ara/tokens/colors";
+import { AraProvider, AraThemeBoundary } from "./AraProvider.js";
+
+export interface ThemeProviderProps {
+  readonly theme?: ThemeOverrides;
+  readonly mode?: ColorThemeName;
+  readonly asChild?: boolean;
+  readonly children: ReactNode;
+}
+
+const DEFAULT_MODE: ColorThemeName = "light";
+
+export function ThemeProvider({
+  theme,
+  mode = DEFAULT_MODE,
+  asChild = false,
+  children
+}: ThemeProviderProps) {
+  return (
+    <AraProvider theme={theme}>
+      <AraThemeBoundary mode={mode} asChild={asChild}>
+        {children}
+      </AraThemeBoundary>
+    </AraProvider>
+  );
+}
+
+ThemeProvider.displayName = "ThemeProvider";

--- a/packages/react/src/theme/index.ts
+++ b/packages/react/src/theme/index.ts
@@ -8,3 +8,4 @@ export {
   useAraThemeVariableTable,
   useAraThemeVariables
 } from "./AraProvider.js";
+export { ThemeProvider, type ThemeProviderProps } from "./ThemeProvider.js";

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,8 +1,29 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const tokensRoot = path.resolve(__dirname, "../tokens/src");
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      {
+        find: "@ara/tokens/css-vars",
+        replacement: path.resolve(tokensRoot, "css-vars.ts")
+      },
+      {
+        find: "@ara/tokens/colors",
+        replacement: path.resolve(tokensRoot, "colors.ts")
+      },
+      {
+        find: "@ara/tokens",
+        replacement: path.resolve(tokensRoot, "index.ts")
+      }
+    ]
+  },
   test: {
     environment: "jsdom",
     setupFiles: "./vitest.setup.ts",


### PR DESCRIPTION
## Summary
- [x] Ara 테마 컨텍스트와 CSS 변수 경계를 통합하는 `ThemeProvider` 컴포넌트를 추가하고 노출했습니다.
- [x] Vitest가 토큰 워크스페이스 소스를 직접 참조하도록 별칭을 구성했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/react test`
  - 모든 단위 테스트가 통과했습니다.

## Screenshots
- 해당 사항 없음.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911854068d48322854760d4b737764a)