### PR TITLE
feat(theme): add RTL direction controls

### DIFF
--- a/apps/storybook/stories/components/Button.docs.mdx
+++ b/apps/storybook/stories/components/Button.docs.mdx
@@ -55,6 +55,14 @@ import * as ButtonStories from "./Button.stories";
 
 <Canvas of={ButtonStories.ThemeSamples} />
 
+## RTL &amp; Focus Ring
+
+`ThemeProvider` 또는 `AraThemeBoundary`의 `direction="rtl"` 속성으로 아랍어·히브리어 등 우→좌 언어 흐름을 지원할 수 있습니다.
+버튼은 플렉스 기반 레이아웃과 CSS 논리 프로퍼티를 사용해 아이콘과 여백이 자동으로 재정렬됩니다. 포커스 시각은
+`--ara-btn-focus-outline`, `--ara-btn-focus-ring` CSS 변수를 덮어써서 키보드 사용자에게 더 두드러지게 표시할 수 있습니다.
+
+<Canvas of={ButtonStories.Accessibility} />
+
 ## Tokens &amp; CSS 변수
 
 `AraProvider`는 컨텍스트만 제공해 DOM 구조를 바꾸지 않습니다. CSS 변수 기반 토큰이 필요하면 `AraThemeBoundary` 또는 `useAraThemeVariables`로 원하는 요소에 `data-ara-theme`와 스타일을 주입하세요. Button 컴포넌트는 아래 구조를 사용합니다.

--- a/apps/storybook/stories/components/Button.stories.tsx
+++ b/apps/storybook/stories/components/Button.stories.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ThemeOverrides } from "@ara/core";
 import { AraProvider, AraThemeBoundary, Button } from "@ara/react";
@@ -257,5 +258,65 @@ export const ThemeSamples: Story = {
   ),
   parameters: {
     controls: { exclude: ["tone", "variant", "size"] }
+  }
+};
+
+export const Accessibility: Story = {
+  render: (args) => {
+    const focusOverride = {
+      "--ara-btn-focus-outline": "3px solid var(--ara-color-brand-500)",
+      "--ara-btn-focus-ring": "0 0 0 6px rgba(37, 99, 235, 0.3)"
+    } as CSSProperties;
+
+    return (
+      <div style={{ display: "grid", gap: "1.5rem", maxWidth: "520px" }}>
+        <section>
+          <h4 style={{ margin: "0 0 0.75rem", fontSize: "0.875rem", color: "#475569" }}>
+            RTL 방향
+          </h4>
+          <AraProvider>
+            <AraThemeBoundary asChild direction="rtl">
+              <div
+                style={{
+                  display: "flex",
+                  gap: "0.75rem",
+                  flexWrap: "wrap",
+                  justifyContent: "flex-start"
+                }}
+              >
+                <Button
+                  {...args}
+                  leadingIcon={<ArrowRightIcon />}
+                  trailingIcon={<ArrowRightIcon />}
+                >
+                  오른쪽에서 시작
+                </Button>
+                <Button
+                  {...args}
+                  variant="outline"
+                  leadingIcon={<ArrowRightIcon />}
+                >
+                  아이콘 정렬 확인
+                </Button>
+              </div>
+            </AraThemeBoundary>
+          </AraProvider>
+        </section>
+        <section>
+          <h4 style={{ margin: "0 0 0.75rem", fontSize: "0.875rem", color: "#475569" }}>
+            포커스 링 커스터마이징
+          </h4>
+          <p style={{ margin: "0 0 0.75rem", fontSize: "0.8125rem", color: "#64748B" }}>
+            CSS 변수로 `--ara-btn-focus-outline`과 `--ara-btn-focus-ring`을 덮어써 시각을 조정합니다.
+          </p>
+          <Button {...args} style={focusOverride}>
+            포커스 스타일
+          </Button>
+        </section>
+      </div>
+    );
+  },
+  parameters: {
+    controls: { exclude: ["leadingIcon", "trailingIcon"] }
   }
 };

--- a/packages/react/src/components/button/README.md
+++ b/packages/react/src/components/button/README.md
@@ -59,9 +59,11 @@
 - ARIA:
   - `disabled` → 버튼: `disabled`; 링크: `aria-disabled="true"` + 상호작용 취소
   - `loading`  → `aria-busy="true"`(spinner는 `aria-hidden="true"`)
-- 포커스 링: 키보드 유입에서만 명확(마우스 클릭 시 최소화). `:focus-visible` 우선.
+- 포커스 링: 키보드 유입에서만 명확(마우스 클릭 시 최소화). `:focus-visible` 우선. CSS 변수 `--ara-btn-focus-outline`,
+  `--ara-btn-focus-ring`으로 색상·두께를 조정해 키보드 사용자가 명확히 인지하도록 한다.
 - 레이블: 아이콘만 있는 경우 `aria-label` 또는 `aria-labelledby` 필수. `children` 문자열/요소가 제공되면 별도 레이블 불필요.
-- RTL: 아이콘 정렬, 여백, 포커스 링 방향성 확인.
+- RTL: `ThemeProvider`/`AraThemeBoundary`의 `direction="rtl"`로 우→좌 언어를 지원한다. flex 레이아웃과 논리 속성 덕분에 아이콘과
+  여백 방향이 자동으로 반전되며 Storybook `Accessibility` 데모로 시각 상태를 검증한다.
 
 ---
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,6 +5,7 @@ export {
   ThemeProvider,
   type AraProviderProps,
   type AraThemeBoundaryProps,
+  type TextDirection,
   type ThemeProviderProps,
   useAraTheme,
   useAraThemeVariables,

--- a/packages/react/src/theme/AraProvider.test.tsx
+++ b/packages/react/src/theme/AraProvider.test.tsx
@@ -38,6 +38,20 @@ describe("AraThemeBoundary", () => {
     expect(host).toHaveTextContent("content");
   });
 
+  it("direction prop으로 텍스트 흐름을 지정할 수 있다", () => {
+    const { container } = render(
+      <AraProvider>
+        <AraThemeBoundary direction="rtl">
+          <section data-testid="host">content</section>
+        </AraThemeBoundary>
+      </AraProvider>
+    );
+
+    const boundary = container.firstElementChild as HTMLElement | null;
+
+    expect(boundary).toHaveAttribute("dir", "rtl");
+  });
+
   it("asChild로 기존 요소를 재사용한다", () => {
     const { container } = render(
       <AraProvider>
@@ -65,6 +79,20 @@ describe("AraThemeBoundary", () => {
         "--ara-color-role-light-interactive-primary-default-bg"
       )
     ).toBe(defaultTheme.color.role.light.interactive.primary.default.background);
+  });
+
+  it("direction prop은 asChild 요소에도 전달된다", () => {
+    render(
+      <AraProvider>
+        <AraThemeBoundary asChild direction="rtl">
+          <section data-testid="host">content</section>
+        </AraThemeBoundary>
+      </AraProvider>
+    );
+
+    const host = screen.getByTestId("host");
+
+    expect(host).toHaveAttribute("dir", "rtl");
   });
 
   it("mode prop으로 지정한 테마 변수를 적용한다", () => {

--- a/packages/react/src/theme/AraProvider.tsx
+++ b/packages/react/src/theme/AraProvider.tsx
@@ -18,6 +18,8 @@ import {
 const ThemeContext = createContext<Theme>(defaultTheme);
 const DEFAULT_COLOR_THEME: ColorThemeName = "light";
 
+export type TextDirection = "ltr" | "rtl" | "auto";
+
 function resolveThemeVariables(
   table: ThemeCSSVariableTable,
   mode: ColorThemeName
@@ -65,6 +67,7 @@ export function useAraTheme(): Theme {
 export interface AraThemeBoundaryProps {
   readonly asChild?: boolean;
   readonly mode?: ColorThemeName;
+  readonly direction?: TextDirection;
   readonly children: ReactNode;
 }
 
@@ -83,6 +86,7 @@ export function useAraThemeVariables(
 export function AraThemeBoundary({
   asChild = false,
   mode = DEFAULT_COLOR_THEME,
+  direction,
   children
 }: AraThemeBoundaryProps) {
   const style = useAraThemeVariables(mode);
@@ -96,7 +100,7 @@ export function AraThemeBoundary({
   const Container = asChild ? Slot : "div";
 
   return (
-    <Container data-ara-theme={mode} style={cssStyle}>
+    <Container data-ara-theme={mode} dir={direction ?? undefined} style={cssStyle}>
       {children}
     </Container>
   );

--- a/packages/react/src/theme/ThemeProvider.test.tsx
+++ b/packages/react/src/theme/ThemeProvider.test.tsx
@@ -168,6 +168,18 @@ describe("ThemeProvider", () => {
     expect(boundary?.style.colorScheme).toBe("dark");
   });
 
+  it("direction prop으로 경계 요소의 dir 속성을 지정한다", () => {
+    const { container } = render(
+      <ThemeProvider direction="rtl">
+        <section data-testid="host">content</section>
+      </ThemeProvider>
+    );
+
+    const boundary = getBoundary(container);
+
+    expect(boundary).toHaveAttribute("dir", "rtl");
+  });
+
   it("시스템 선호도에 따라 모드를 결정한다", () => {
     matchMediaControl = createMatchMediaMock(true);
     const stub = vi.fn(() => matchMediaControl.mediaQueryList);
@@ -187,6 +199,18 @@ describe("ThemeProvider", () => {
 
     expect(boundary).toHaveAttribute("data-ara-theme", "dark");
     expect(boundary?.style.colorScheme).toBe("dark");
+  });
+
+  it("direction prop은 asChild 요소로 전달된다", () => {
+    render(
+      <ThemeProvider asChild direction="rtl">
+        <section data-testid="host">content</section>
+      </ThemeProvider>
+    );
+
+    const host = screen.getByTestId("host");
+
+    expect(host).toHaveAttribute("dir", "rtl");
   });
 
   it("theme 오버라이드를 컨텍스트와 CSS 변수에 반영한다", () => {

--- a/packages/react/src/theme/ThemeProvider.tsx
+++ b/packages/react/src/theme/ThemeProvider.tsx
@@ -4,7 +4,8 @@ import type { ColorThemeName } from "@ara/tokens/colors";
 import {
   AraProvider,
   AraThemeBoundary,
-  useAraThemeVariableTable
+  useAraThemeVariableTable,
+  type TextDirection
 } from "./AraProvider.js";
 import {
   ColorModeProvider,
@@ -22,6 +23,7 @@ export interface ThemeProviderProps {
   readonly asChild?: boolean;
   readonly children: ReactNode;
   readonly onModeChange?: (mode: ColorThemeName) => void;
+  readonly direction?: TextDirection;
 }
 
 const DEFAULT_MODE: ColorThemeName = "light";
@@ -34,7 +36,8 @@ export function ThemeProvider({
   storageKey = DEFAULT_COLOR_MODE_STORAGE_KEY,
   asChild = false,
   children,
-  onModeChange
+  onModeChange,
+  direction
 }: ThemeProviderProps) {
   return (
     <AraProvider theme={theme}>
@@ -43,6 +46,7 @@ export function ThemeProvider({
         defaultMode={defaultMode}
         storageKey={storageKey}
         asChild={asChild}
+        direction={direction}
         onModeChange={onModeChange}
       >
         {children}
@@ -56,7 +60,13 @@ ThemeProvider.displayName = "ThemeProvider";
 interface ThemeProviderInnerProps
   extends Pick<
     ThemeProviderProps,
-    "mode" | "defaultMode" | "storageKey" | "asChild" | "children" | "onModeChange"
+    | "mode"
+    | "defaultMode"
+    | "storageKey"
+    | "asChild"
+    | "children"
+    | "onModeChange"
+    | "direction"
   > {}
 
 function ThemeProviderInner({
@@ -65,7 +75,8 @@ function ThemeProviderInner({
   storageKey = DEFAULT_COLOR_MODE_STORAGE_KEY,
   asChild,
   children,
-  onModeChange
+  onModeChange,
+  direction
 }: ThemeProviderInnerProps) {
   const table = useAraThemeVariableTable();
 
@@ -82,19 +93,22 @@ function ThemeProviderInner({
         storageKey={storageKey}
         table={table}
       />
-      <ResolvedThemeBoundary asChild={asChild}>{children}</ResolvedThemeBoundary>
+      <ResolvedThemeBoundary asChild={asChild} direction={direction}>
+        {children}
+      </ResolvedThemeBoundary>
     </ColorModeProvider>
   );
 }
 
 function ResolvedThemeBoundary({
   asChild,
-  children
-}: Pick<ThemeProviderProps, "asChild" | "children">) {
+  children,
+  direction
+}: Pick<ThemeProviderProps, "asChild" | "children" | "direction">) {
   const { mode } = useColorMode();
 
   return (
-    <AraThemeBoundary mode={mode} asChild={asChild}>
+    <AraThemeBoundary mode={mode} asChild={asChild} direction={direction}>
       {children}
     </AraThemeBoundary>
   );

--- a/packages/react/src/theme/index.ts
+++ b/packages/react/src/theme/index.ts
@@ -3,6 +3,7 @@ export {
   AraThemeBoundary,
   type AraProviderProps,
   type AraThemeBoundaryProps,
+  type TextDirection,
   ThemeContext,
   useAraTheme,
   useAraThemeVariableTable,


### PR DESCRIPTION
## Summary
- add `direction` support to `ThemeProvider`/`AraThemeBoundary` and expose the shared `TextDirection` type
- cover RTL propagation with new unit tests and extend public exports
- document RTL and focus-ring customization guidance with an accessibility-focused Storybook demo

## Testing
- pnpm --filter @ara/react test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912a2859b3883229c936f48d325ebec)