### PR TITLE
Fix theme token module resolution

### DIFF
--- a/packages/react/src/theme/ThemeProvider.test.tsx
+++ b/packages/react/src/theme/ThemeProvider.test.tsx
@@ -84,7 +84,6 @@ function createMatchMediaMock(initial = false) {
 
   const setMatches = (value: boolean) => {
     matches = value;
-    mediaQueryList.matches = value;
 
     if (typeof mediaQueryList.onchange === "function") {
       mediaQueryList.onchange({ matches: value, media: COLOR_SCHEME_QUERY } as MediaQueryListEvent);

--- a/packages/react/src/theme/ThemeProvider.tsx
+++ b/packages/react/src/theme/ThemeProvider.tsx
@@ -57,17 +57,16 @@ export function ThemeProvider({
 
 ThemeProvider.displayName = "ThemeProvider";
 
-interface ThemeProviderInnerProps
-  extends Pick<
-    ThemeProviderProps,
-    | "mode"
-    | "defaultMode"
-    | "storageKey"
-    | "asChild"
-    | "children"
-    | "onModeChange"
-    | "direction"
-  > {}
+type ThemeProviderInnerProps = Pick<
+  ThemeProviderProps,
+  | "mode"
+  | "defaultMode"
+  | "storageKey"
+  | "asChild"
+  | "children"
+  | "onModeChange"
+  | "direction"
+>;
 
 function ThemeProviderInner({
   mode = "system",

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -21,6 +21,22 @@
       "@ara/core/*": [
         "../core/dist/*.d.ts",
         "../core/dist/*.js"
+      ],
+      "@ara/icons": [
+        "../icons/dist/index.d.ts",
+        "../icons/dist/index.js"
+      ],
+      "@ara/icons/*": [
+        "../icons/dist/*.d.ts",
+        "../icons/dist/*.js"
+      ],
+      "@ara/tokens": [
+        "../tokens/dist/index.d.ts",
+        "../tokens/dist/index.js"
+      ],
+      "@ara/tokens/*": [
+        "../tokens/dist/*.d.ts",
+        "../tokens/dist/*.js"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- add path mappings for tokens and icons to the React package build config so TS can resolve workspace packages
- update ThemeProvider inner props to use a type alias to satisfy lint rules
- adjust ThemeProvider tests to avoid mutating readonly MediaQueryList properties

## Testing
- pnpm exec tsc -p packages/react/tsconfig.json --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a624a83248322b777f6773212ca0c)