### PR TITLE
T-000045: theme-provider exports/types 계약 정리

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/components/index.js",
       "default": "./dist/components/index.js"
     },
+    "./components/theme-provider": {
+      "types": "./dist/components/theme-provider/index.d.ts",
+      "import": "./dist/components/theme-provider/index.js",
+      "default": "./dist/components/theme-provider/index.js"
+    },
     "./components/button": {
       "types": "./dist/components/button/index.d.ts",
       "import": "./dist/components/button/index.js",
@@ -31,6 +36,11 @@
       "types": "./dist/components/button/index.d.ts",
       "import": "./dist/components/button/index.js",
       "default": "./dist/components/button/index.js"
+    },
+    "./theme-provider": {
+      "types": "./dist/components/theme-provider/index.d.ts",
+      "import": "./dist/components/theme-provider/index.js",
+      "default": "./dist/components/theme-provider/index.js"
     },
     "./package.json": "./package.json"
   },
@@ -42,8 +52,14 @@
       "components/*": [
         "dist/components/*/index.d.ts"
       ],
+      "components/theme-provider": [
+        "dist/components/theme-provider/index.d.ts"
+      ],
       "button": [
         "dist/components/button/index.d.ts"
+      ],
+      "theme-provider": [
+        "dist/components/theme-provider/index.d.ts"
       ],
       "theme": [
         "dist/theme/index.d.ts"


### PR DESCRIPTION
## Summary
- [x] @ara/react 패키지에 theme-provider 서브패스 exports/typesVersions를 추가해 진입점을 명확히 했습니다.
- [x] components 경로와 별칭 모두 동일한 타입 선언을 노출하도록 매핑을 보완했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm pack --pack-destination /tmp` (packages/tokens)
- [x] `pnpm pack --pack-destination /tmp` (packages/react)

## Screenshots
- (필요 없음)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a661405088322a1196656b1f97e31)