### PR TITLE
[T-000047] canary 프리릴리스 드라이런 준비

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,17 @@
+{
+  "mode": "pre",
+  "tag": "canary",
+  "initialVersions": {
+    "@ara/showcase": "0.0.0",
+    "@ara/storybook": "0.0.0",
+    "@ara/core": "0.0.0",
+    "@ara/eslint-config": "0.0.0",
+    "@ara/icons": "0.0.0",
+    "@ara/react": "0.0.0",
+    "@ara/tokens": "0.0.0",
+    "@ara/tsconfig": "0.0.0"
+  },
+  "changesets": [
+    "button-canary-release"
+  ]
+}

--- a/apps/showcase/CHANGELOG.md
+++ b/apps/showcase/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @ara/showcase
+
+## 0.0.1-canary.0
+
+### Patch Changes
+
+- Updated dependencies [d5df83a]
+  - @ara/react@0.1.0-canary.0

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ara/showcase",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1-canary.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/storybook/CHANGELOG.md
+++ b/apps/storybook/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @ara/storybook
+
+## 0.0.1-canary.0
+
+### Patch Changes
+
+- Updated dependencies [d5df83a]
+  - @ara/react@0.1.0-canary.0

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ara/storybook",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.1-canary.0",
   "type": "module",
   "scripts": {
     "storybook": "storybook dev -p 6006",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @ara/core
+
+## 0.1.0-canary.0
+
+### Minor Changes
+
+- d5df83a: Button v0 토큰, headless 훅, React 컴포넌트를 canary 채널로 선공개합니다.
+
+### Patch Changes
+
+- Updated dependencies [d5df83a]
+  - @ara/tokens@0.1.0-canary.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ara/core",
-  "version": "0.0.0",
+  "version": "0.1.0-canary.0",
   "description": "Ara 디자인 시스템의 headless 코어 유틸리티",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @ara/react
+
+## 0.1.0-canary.0
+
+### Minor Changes
+
+- d5df83a: Button v0 토큰, headless 훅, React 컴포넌트를 canary 채널로 선공개합니다.
+
+### Patch Changes
+
+- Updated dependencies [d5df83a]
+  - @ara/tokens@0.1.0-canary.0
+  - @ara/core@0.1.0-canary.0

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ara/react",
-  "version": "0.0.0",
-  "description": "Ara \ub514\uc790\uc778 \uc2dc\uc2a4\ud15c\uc758 React \ucef4\ud3ec\ub10c\ud2b8 \ubc14\uc778\ub529",
+  "version": "0.1.0-canary.0",
+  "description": "Ara 디자인 시스템의 React 컴포넌트 바인딩",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/react/src/components/button/Button.test.tsx
+++ b/packages/react/src/components/button/Button.test.tsx
@@ -281,8 +281,6 @@ describe("Button", () => {
   it("asChild로 자식 요소에 속성을 전달한다", () => {
     render(
       <Button asChild href="/nested" className="custom-slot">
-        {/* Slot 테스트에서는 Button이 href를 주입하므로 lint를 비활성화한다. */}
-        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
         <a data-testid="child">중첩</a>
       </Button>
     );

--- a/packages/tokens/CHANGELOG.md
+++ b/packages/tokens/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ara/tokens
+
+## 0.1.0-canary.0
+
+### Minor Changes
+
+- d5df83a: Button v0 토큰, headless 훅, React 컴포넌트를 canary 채널로 선공개합니다.

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ara/tokens",
-  "version": "0.0.0",
+  "version": "0.1.0-canary.0",
   "description": "Ara 디자인 시스템을 위한 디자인 토큰 모음",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/tokens/src/components/button.ts
+++ b/packages/tokens/src/components/button.ts
@@ -103,8 +103,6 @@ function createOutlineVariant(palette: TonePalette): VariantToken {
 }
 
 function createGhostVariant(palette: TonePalette): VariantToken {
-  const { interaction } = palette;
-
   return {
     background: "transparent",
     foreground: palette.outlineForeground,


### PR DESCRIPTION
## Summary
- [x] Changesets canary 프리릴리스 모드 진입 후 version/changelog 갱신
- [x] core/react/tokens 및 앱 패키지를 0.1.0-canary.0 계열로 올림
- [x] lint 경고 정리 후 워크스페이스 점검 실행

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (WBS: W-000005 / Task: T-000047)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm -w workspace:check`

## Screenshots
- N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a7178e47c8322bb9953eb9d6231d2)