### PR TITLE
chore: mark T-000047 canary release complete

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -156,6 +156,6 @@ T-000045,W-000005,Tokens & ThemeProvider v1,빌드/출하,Exports/Types 계약 �
 T-000046,W-000005,Tokens & ThemeProvider v1,통합/검증,Button v0 통합 스모크,완료,High," ● 내용: Button v0가 ThemeProvider와 토큰을 소비해 변형(variant/tone/size)과 다크 모드가 정상 반영되는지 확인
  ● 산출물: showcase 또는 story 샘플
  ● 점검: 시각/상호작용 회귀 없음",확인
-T-000047,W-000005,Tokens & ThemeProvider v1,릴리스,Changesets 프리릴리스(canary),계획,High," ● 내용: changeset 추가 및 프리릴리스 채널 배포 드라이런
+T-000047,W-000005,Tokens & ThemeProvider v1,릴리스,Changesets 프리릴리스(canary),완료,High," ● 내용: changeset 추가 및 프리릴리스 채널 배포 드라이런
  ● 산출물: canary 태그 및 설치 확인 메모
- ● 점검: 설치 및 임포트 성공과 간단 사용 예 검증",  
+ ● 점검: 설치 및 임포트 성공과 간단 사용 예 검증",확인

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -29,7 +29,7 @@ W-000004,T1,Button v0 Comp,완료,100,"Button v0
  ● canary 프리릴리스 포함
  ● 범위: 일반 버튼/링크(토글 제외)
  ● AC: CI 통과·Tests 통과·Storybook build·ESM+types import·canary 발행·디자인 승인",--
-W-000005,T1,Tokens & ThemeProvider v1,진행중,95,"Tokens v1 & ThemeProvider
+W-000005,T1,Tokens & ThemeProvider v1,완료,100,"Tokens v1 & ThemeProvider
  ● 설계문서
           - root/packages/tokens/README.md 
           - root/packages/react/src/components/theme-provider/README.md


### PR DESCRIPTION
## Summary
- mark task T-000047 as complete after canary pre-release work
- update W-000005 progress to 100% and status to complete

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a74ed5c988322b403ba48954752eb)