### PR TITLE
feat: Icon 베이스 추가

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/components/theme-provider/index.js",
       "default": "./dist/components/theme-provider/index.js"
     },
+    "./components/icon": {
+      "types": "./dist/components/icon/index.d.ts",
+      "import": "./dist/components/icon/index.js",
+      "default": "./dist/components/icon/index.js"
+    },
     "./components/button": {
       "types": "./dist/components/button/index.d.ts",
       "import": "./dist/components/button/index.js",
@@ -36,6 +41,11 @@
       "types": "./dist/components/button/index.d.ts",
       "import": "./dist/components/button/index.js",
       "default": "./dist/components/button/index.js"
+    },
+    "./icon": {
+      "types": "./dist/components/icon/index.d.ts",
+      "import": "./dist/components/icon/index.js",
+      "default": "./dist/components/icon/index.js"
     },
     "./theme-provider": {
       "types": "./dist/components/theme-provider/index.d.ts",
@@ -57,6 +67,9 @@
       ],
       "button": [
         "dist/components/button/index.d.ts"
+      ],
+      "icon": [
+        "dist/components/icon/index.d.ts"
       ],
       "theme-provider": [
         "dist/components/theme-provider/index.d.ts"

--- a/packages/react/src/components/icon/Icon.test.tsx
+++ b/packages/react/src/components/icon/Icon.test.tsx
@@ -1,0 +1,65 @@
+import { defaultTheme } from "@ara/core";
+import type { IconProps as IconSourceProps } from "@ara/icons/types";
+import { render } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it } from "vitest";
+import { Icon } from "./index.js";
+
+const FilledIcon = (props: IconSourceProps) => (
+  <svg viewBox="0 0 24 24" fill="none" {...props}>
+    <path d="M4 12h16" fill="currentColor" />
+  </svg>
+);
+
+const StrokeIcon = (props: IconSourceProps) => (
+  <svg viewBox="0 0 24 24" fill="none" {...props}>
+    <path d="M4 12h16" stroke="currentColor" strokeWidth="2" />
+    <path d="M12 4v16" stroke="currentColor" strokeWidth="2" />
+  </svg>
+);
+
+describe("Icon", () => {
+  it("토큰 기본값으로 크기와 클래스를 적용한다", () => {
+    const { getByTestId } = render(<Icon icon={FilledIcon} data-testid="icon" />);
+    const element = getByTestId("icon");
+
+    expect(element).toHaveClass("ara-icon");
+    expect(element).toHaveAttribute("width", defaultTheme.component.icon.size.md);
+    expect(element).toHaveAttribute("height", defaultTheme.component.icon.size.md);
+  });
+
+  it("tone을 currentColor 스타일로 반영한다", () => {
+    const { getByTestId } = render(<Icon icon={FilledIcon} tone="danger" data-testid="icon" />);
+
+    expect(getByTestId("icon")).toHaveStyle({ color: defaultTheme.component.icon.tone.danger });
+  });
+
+  it("strokeWidth와 filled 옵션을 아이콘 노드에 덮어쓴다", () => {
+    const { container } = render(
+      <Icon icon={StrokeIcon} strokeWidth={1.25} filled aria-label="완료" />
+    );
+
+    const paths = container.querySelectorAll("path");
+    const strokeValues = Array.from(paths).map((path) => path.getAttribute("stroke-width"));
+    const fillValues = Array.from(paths).map((path) => path.getAttribute("fill"));
+
+    expect(strokeValues.every((value) => value === "1.25" || value === null)).toBe(true);
+    expect(fillValues.some((value) => value === "currentColor")).toBe(true);
+  });
+
+  it("ref를 최종 SVG 엘리먼트로 포워딩한다", () => {
+    const ref = createRef<SVGSVGElement>();
+    render(<Icon icon={FilledIcon} ref={ref} aria-label="더하기" />);
+
+    expect(ref.current).toBeInstanceOf(SVGSVGElement);
+  });
+
+  it("사용자 className을 기본 클래스와 병합한다", () => {
+    const { getByTestId } = render(
+      <Icon icon={FilledIcon} className="custom-class" data-testid="icon" />
+    );
+
+    expect(getByTestId("icon")).toHaveClass("ara-icon");
+    expect(getByTestId("icon")).toHaveClass("custom-class");
+  });
+});

--- a/packages/react/src/components/icon/README.md
+++ b/packages/react/src/components/icon/README.md
@@ -1,0 +1,26 @@
+# Icon
+
+`Icon` 컴포넌트는 `@ara/icons`에서 생성된 개별 SVG 아이콘을 토큰 기반 크기·색상 규칙에 맞춰 출력한다.
+
+## Props
+
+| 이름 | 타입 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **icon** | `ComponentType<IconProps>` | (필수) | `@ara/icons`에서 export된 아이콘 컴포넌트. |
+| **size** | `"sm" \| "md" \| "lg" \| string \| number` | `"md"` | 토큰 스케일 또는 임의 CSS/픽셀 크기. |
+| **tone** | `"primary" \| "neutral" \| "danger" \| null` | `null` | 지정 시 토큰 색상을 `currentColor` 로 주입한다. |
+| **strokeWidth** | `number` | `tokens.component.icon.strokeWidth.default` | 스트로크 기반 아이콘의 두께를 덮어쓴다. |
+| **filled** | `boolean` | `false` | `fill` 이 비어 있거나 `none` 인 노드에 `currentColor` 를 적용한다. |
+| **className** | `string` | — | 기본 클래스(`ara-icon`)와 병합된다. |
+| **기타** | `@ara/icons` `IconProps` | — | `title`, `aria-*`, `data-*` 등 SVG 속성을 그대로 전달한다. |
+
+## 사용 예시
+
+```tsx
+import { Icon } from "@ara/react";
+import { ArrowRight } from "@ara/icons/icons/arrow-right";
+
+function Example() {
+  return <Icon icon={ArrowRight} size="sm" tone="primary" aria-label="다음" />;
+}
+```

--- a/packages/react/src/components/icon/index.tsx
+++ b/packages/react/src/components/icon/index.tsx
@@ -1,6 +1,7 @@
 import {
   Children,
   cloneElement,
+  createElement,
   forwardRef,
   isValidElement,
   type CSSProperties,
@@ -123,7 +124,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(props, re
     mergedStyle.color = resolvedColor;
   }
 
-  const renderedIcon = IconComponent({
+  const renderedIcon = createElement(IconComponent, {
     ...restProps,
     className: mergeClassNames("ara-icon", className),
     style: mergedStyle,

--- a/packages/react/src/components/icon/index.tsx
+++ b/packages/react/src/components/icon/index.tsx
@@ -1,0 +1,139 @@
+import {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  type CSSProperties,
+  type ComponentType,
+  type ReactElement,
+  type ReactNode,
+  type Ref
+} from "react";
+import type { Theme } from "@ara/core";
+import type { IconProps as IconSourceProps } from "@ara/icons/types";
+import { useAraTheme } from "../../theme/index.js";
+
+type IconComponent = ComponentType<IconSourceProps>;
+type IconComponentTokens = Theme["component"]["icon"];
+
+type IconSize = keyof IconComponentTokens["size"];
+type IconTone = keyof IconComponentTokens["tone"];
+
+export interface IconProps extends Omit<IconSourceProps, "width" | "height"> {
+  readonly icon: IconComponent;
+  readonly size?: IconSize | string | number;
+  readonly tone?: IconTone | null;
+  readonly strokeWidth?: number;
+  readonly filled?: boolean;
+  readonly className?: string;
+}
+
+function mergeClassNames(...values: Array<string | undefined | null | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+function getFirstRecordValue<T>(record: Record<string, T> | Readonly<Record<string, T>>): T | undefined {
+  const [firstKey] = Object.keys(record);
+  if (firstKey === undefined) return undefined;
+  return record[firstKey] as T | undefined;
+}
+
+function resolveSize(tokens: IconComponentTokens, size: IconProps["size"]): string | number {
+  if (typeof size === "number") return size;
+  if (typeof size === "string") {
+    const mappedSize = tokens.size[size as IconSize];
+    return mappedSize ?? size;
+  }
+
+  return tokens.size.md ?? getFirstRecordValue(tokens.size) ?? "1.25rem";
+}
+
+function resolveTone(tokens: IconComponentTokens, tone: IconProps["tone"]): string | null {
+  if (!tone) return null;
+  return tokens.tone[tone] ?? getFirstRecordValue(tokens.tone) ?? null;
+}
+
+function resolveStrokeWidth(tokens: IconComponentTokens, strokeWidth: IconProps["strokeWidth"]): number {
+  if (typeof strokeWidth === "number") return strokeWidth;
+  return tokens.strokeWidth.default;
+}
+
+function applyIconOverrides(
+  node: ReactNode,
+  options: { strokeWidth?: number; filled: boolean }
+): ReactNode {
+  if (!isValidElement(node)) {
+    return node;
+  }
+
+  const children = node.props.children;
+  const resolvedChildren =
+    children === undefined
+      ? children
+      : Children.map(children, (child) => applyIconOverrides(child, options));
+
+  const nextProps: Record<string, unknown> = {};
+
+  if (options.strokeWidth !== undefined) {
+    const hasStroke = node.props.stroke !== undefined || node.props.strokeWidth !== undefined;
+    if (typeof node.type === "string" && hasStroke) {
+      nextProps.strokeWidth = options.strokeWidth;
+    }
+  }
+
+  if (options.filled && (node.props.fill === undefined || node.props.fill === "none")) {
+    nextProps.fill = "currentColor";
+  }
+
+  if (resolvedChildren !== children || Object.keys(nextProps).length > 0) {
+    return cloneElement(node, nextProps, resolvedChildren);
+  }
+
+  return node;
+}
+
+export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(props, ref: Ref<SVGSVGElement>) {
+  const {
+    icon: IconComponent,
+    size: sizeProp,
+    tone: toneProp,
+    strokeWidth: strokeWidthProp,
+    filled = false,
+    className,
+    style,
+    color,
+    ...restProps
+  } = props;
+
+  const theme = useAraTheme();
+  const iconTokens = theme.component.icon;
+
+  const size = resolveSize(iconTokens, sizeProp);
+  const toneColor = resolveTone(iconTokens, toneProp);
+  const strokeWidth = resolveStrokeWidth(iconTokens, strokeWidthProp);
+
+  const mergedStyle: CSSProperties = {
+    ...style,
+    width: size,
+    height: size
+  };
+
+  const resolvedColor = color ?? style?.color ?? toneColor;
+  if (resolvedColor) {
+    mergedStyle.color = resolvedColor;
+  }
+
+  const renderedIcon = IconComponent({
+    ...restProps,
+    className: mergeClassNames("ara-icon", className),
+    style: mergedStyle,
+    width: size,
+    height: size
+  });
+
+  const enhancedIcon = applyIconOverrides(renderedIcon, { strokeWidth, filled }) as ReactElement;
+
+  return cloneElement(enhancedIcon, { ref });
+});
+
+Icon.displayName = "Icon";

--- a/packages/react/src/components/icon/index.tsx
+++ b/packages/react/src/components/icon/index.tsx
@@ -5,7 +5,9 @@ import {
   forwardRef,
   isValidElement,
   type CSSProperties,
+  type ComponentClass,
   type ComponentType,
+  type FunctionComponent,
   type ReactElement,
   type ReactNode,
   type Ref
@@ -93,6 +95,10 @@ function applyIconOverrides(
   return node;
 }
 
+function isClassComponent(component: IconComponent): component is ComponentClass<IconSourceProps> {
+  return Boolean((component as ComponentClass<IconSourceProps>).prototype?.render);
+}
+
 export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(props, ref: Ref<SVGSVGElement>) {
   const {
     icon: IconComponent,
@@ -124,15 +130,19 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(props, re
     mergedStyle.color = resolvedColor;
   }
 
-  const renderedIcon = createElement(IconComponent, {
+  const iconProps: IconSourceProps = {
     ...restProps,
     className: mergeClassNames("ara-icon", className),
     style: mergedStyle,
     width: size,
     height: size
-  });
+  };
 
-  const enhancedIcon = applyIconOverrides(renderedIcon, { strokeWidth, filled }) as ReactElement;
+  const iconNode = isClassComponent(IconComponent)
+    ? createElement(IconComponent, iconProps)
+    : (IconComponent as FunctionComponent<IconSourceProps>)(iconProps);
+
+  const enhancedIcon = applyIconOverrides(iconNode, { strokeWidth, filled }) as ReactElement;
 
   return cloneElement(enhancedIcon, { ref });
 });

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./button/index.js";
+export * from "./icon/index.js";
 export * from "./theme-provider/index.js";

--- a/packages/tokens/src/components/icon.ts
+++ b/packages/tokens/src/components/icon.ts
@@ -1,0 +1,22 @@
+import { colors } from "../colors.js";
+
+export type IconToneName = "primary" | "neutral" | "danger";
+export type IconSizeName = "sm" | "md" | "lg";
+
+export const icon = {
+  size: {
+    sm: "1rem",
+    md: "1.25rem",
+    lg: "1.5rem"
+  },
+  tone: {
+    primary: colors.palette.brand["600"],
+    neutral: colors.palette.neutral["700"],
+    danger: colors.palette.danger["600"]
+  },
+  strokeWidth: {
+    default: 2
+  }
+} as const;
+
+export type IconTokens = typeof icon;

--- a/packages/tokens/src/css-vars.ts
+++ b/packages/tokens/src/css-vars.ts
@@ -227,6 +227,29 @@ function createButtonVariables(theme: Tokens): CSSVariableMap {
   return variables;
 }
 
+function createIconVariables(theme: Tokens): CSSVariableMap {
+  const variables: CSSVariableMap = {} as CSSVariableMap;
+  const icon = theme.component.icon;
+
+  for (const [sizeName, value] of Object.entries(icon.size)) {
+    assignVariable(variables, `--ara-icon-size-${sizeName}` as CSSVariableName, value);
+  }
+
+  for (const [toneName, value] of Object.entries(icon.tone)) {
+    assignVariable(variables, `--ara-icon-tone-${toneName}` as CSSVariableName, value);
+  }
+
+  for (const [strokeName, value] of Object.entries(icon.strokeWidth)) {
+    assignVariable(
+      variables,
+      `--ara-icon-stroke-width-${strokeName}` as CSSVariableName,
+      value
+    );
+  }
+
+  return variables;
+}
+
 function createColorRoleVariables(
   theme: Tokens,
   themeName: ColorThemeName
@@ -305,7 +328,8 @@ export function createCSSVariableTable(theme: Tokens): ThemeCSSVariableTable {
     createPaletteVariables(theme),
     createTypographyVariables(theme),
     createLayoutVariables(theme),
-    createButtonVariables(theme)
+    createButtonVariables(theme),
+    createIconVariables(theme)
   );
 
   const themes = createThemeCSSVariables(theme);

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,5 +1,6 @@
 import { colors } from "./colors.js";
 import { button } from "./components/button.js";
+import { icon } from "./components/icon.js";
 import { layout } from "./layout.js";
 import { typography } from "./typography.js";
 
@@ -7,6 +8,7 @@ export * from "./colors.js";
 export * from "./typography.js";
 export * from "./layout.js";
 export * from "./components/button.js";
+export * from "./components/icon.js";
 export * from "./css-vars.js";
 
 export const tokens = {
@@ -14,7 +16,8 @@ export const tokens = {
   layout,
   typography,
   component: {
-    button
+    button,
+    icon
   }
 } as const;
 


### PR DESCRIPTION
## Summary
- Icon 토큰(size/tone/strokeWidth)과 CSS 변수에 아이콘 설정을 추가했습니다.
- @ara/react Icon 컴포넌트를 구현해 크기·톤·strokeWidth/filled를 토큰 기반으로 처리하고 ref/className을 지원합니다.
- Icon 테스트와 README를 작성하고 패키지 exports 경로를 등록했습니다.

## Testing
- pnpm --filter @ara/react test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a9e92935c83229e55d4177b428939)