### PR TITLE
T-000053 React 테스트 경로 안내 보완

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -71,8 +71,13 @@ return <main style={variables}>...</main>;
 - ✅ pnpm run check:manifests
 
 단일 테스트 파일만 실행하려면 `pnpm --filter @ara/react test -- <테스트 파일 경로>` 형식으로 경로를 전달한다.
+이때 경로는 **패키지 루트 기준**이어야 한다. 예를 들어 리포지토리 루트에서 `packages/react/...`를 포함한 경로를 넘기면
+Vitest가 상대 경로를 찾지 못해 `No test files found`가 발생하므로 아래 예시처럼 `src/...`부터 전달한다.
+
 예를 들어 Button 단위 테스트만 실행하려면 아래와 같이 입력한다.
 
 ```bash
 pnpm --filter @ara/react test -- src/components/button/Button.test.tsx
 ```
+
+Icon 테스트만 실행할 때도 동일하게 경로를 `src/components/icon/Icon.test.tsx` 형식으로 넘겨야 한다.


### PR DESCRIPTION
## Summary
- [x] 단일 테스트 실행 시 패키지 루트 기준으로 경로를 전달해야 한다는 안내를 README에 추가했습니다.
- [x] Icon 테스트 실행 예시를 포함해 `packages/react/...` 경로 전달 시 발생하는 오류를 예방했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] pnpm --filter @ara/react test -- src/components/icon/Icon.test.tsx


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691abdb0b3548322afd87059334831c2)