### PR TITLE
[T-000054] Storybook 아이콘 갤러리/Docs 추가

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -22,6 +22,8 @@ const config: StorybookConfig = {
       { find: "@ara/react/", replacement: `${resolvePackages("react")}/` },
       { find: "@ara/core", replacement: resolvePackages("core") },
       { find: "@ara/core/", replacement: `${resolvePackages("core")}/` },
+      { find: "@ara/icons", replacement: resolvePackages("icons") },
+      { find: "@ara/icons/", replacement: `${resolvePackages("icons")}/` },
       { find: "@ara/tokens", replacement: resolvePackages("tokens") },
       { find: "@ara/tokens/", replacement: `${resolvePackages("tokens")}/` }
     ];

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@ara/react": "workspace:*",
+    "@ara/icons": "workspace:*",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/apps/storybook/stories/components/Icon.docs.mdx
+++ b/apps/storybook/stories/components/Icon.docs.mdx
@@ -1,0 +1,44 @@
+import { Meta, Title, Subtitle, Description, Primary, Controls, Canvas, ArgsTable } from "@storybook/blocks";
+import * as IconStories from "./Icon.stories";
+
+<Meta of={IconStories} />
+
+<Title>Icon 아이콘</Title>
+
+<Subtitle>토큰 스케일과 currentColor 규칙을 반영하는 경량 SVG 아이콘 컴포넌트입니다.</Subtitle>
+
+<Description>
+`Icon`은 `@ara/icons`가 export 하는 SVG 컴포넌트를 받아 토큰 기반 크기/색상 규칙을 자동으로 적용합니다. size, tone,
+strokeWidth, filled 컨트롤로 공통 속성을 조절하고, 필요한 경우 title·aria- 라벨링으로 접근성을 더할 수 있습니다.
+</Description>
+
+## Playground
+
+<Primary of={IconStories.Playground} />
+<Controls of={IconStories.Playground} />
+
+## Icon Gallery
+
+워크스페이스에 포함된 아이콘을 한눈에 확인할 수 있는 갤러리입니다. Controls로 size/tone/strokeWidth 기본값을 조정하며,
+filled 토글로 채움 여부를 확인하세요.
+
+<Canvas of={IconStories.Gallery} />
+
+## Props
+
+<ArgsTable of={IconStories} />
+
+## 접근성 예시
+
+`title`을 제공하면 내부 `title` 요소와 `role="img"`가 연결되어 스크린 리더에 노출됩니다. 대체 라벨이 필요할 때는 `aria-label`
+또는 `aria-labelledby`를 함께 전달하세요.
+
+<Canvas of={IconStories.Accessibility} />
+
+## 시각 회귀 옵션
+
+Chromatic을 사용하지 않는 환경에서는 스모크 용도로 `build-storybook`을 실행해 정적 빌드를 확인할 수 있습니다.
+
+```bash
+pnpm --filter @ara/storybook build-storybook
+```

--- a/apps/storybook/stories/components/Icon.stories.tsx
+++ b/apps/storybook/stories/components/Icon.stories.tsx
@@ -1,0 +1,160 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { icons as iconSet, type IconName } from "@ara/icons";
+import { AraProvider, AraThemeBoundary, Icon } from "@ara/react";
+
+const iconOptions = Object.keys(iconSet) as IconName[];
+
+const meta = {
+  title: "Components/Icon",
+  component: Icon,
+  decorators: [
+    (Story) => (
+      <AraProvider>
+        <AraThemeBoundary>
+          <Story />
+        </AraThemeBoundary>
+      </AraProvider>
+    )
+  ],
+  args: {
+    icon: iconSet.Plus,
+    size: "md",
+    tone: null,
+    strokeWidth: undefined,
+    filled: false
+  },
+  argTypes: {
+    icon: {
+      control: { type: "select" },
+      options: iconOptions,
+      mapping: iconSet,
+      description: "@ara/icons 에서 export 된 아이콘 컴포넌트"
+    },
+    size: {
+      control: { type: "select" },
+      options: ["sm", "md", "lg", "24px", "32px"],
+      description: "토큰 스케일 또는 커스텀 크기"
+    },
+    tone: {
+      control: { type: "radio" },
+      options: ["none", "primary", "neutral", "danger"],
+      mapping: { none: null },
+      description: "토큰 색상(currentColor) 적용 여부"
+    },
+    strokeWidth: {
+      control: { type: "number", min: 0, step: 0.25 },
+      description: "스트로크 기반 아이콘의 두께 (기본값: 토큰)"
+    },
+    filled: {
+      control: { type: "boolean" },
+      description: "fill 값이 비어 있거나 none 인 노드에 currentColor 적용"
+    },
+    className: { control: false },
+    style: { control: false },
+    color: { control: false },
+    role: { control: false },
+    title: { control: "text" }
+  },
+  tags: ["autodocs"]
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {};
+
+export const Gallery: Story = {
+  parameters: {
+    controls: {
+      exclude: ["icon"]
+    }
+  },
+  render: ({ icon: _icon, ...args }) => (
+    <div style={{ display: "grid", gap: "1.25rem" }}>
+      <p style={{ margin: 0, color: "#475569", fontSize: "0.875rem" }}>
+        워크스페이스에 포함된 아이콘을 토큰 기반 스타일로 렌더링합니다. size/tone/strokeWidth 컨트롤로 공통 값을 조정하고, filled
+        로 컬러 영역을 채웁니다.
+      </p>
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))",
+          gap: "1rem",
+          alignItems: "center"
+        }}
+      >
+        {iconOptions.map((name) => {
+          const IconComponent = iconSet[name];
+
+          return (
+            <figure
+              key={name}
+              style={{
+                display: "grid",
+                gap: "0.5rem",
+                justifyItems: "center",
+                padding: "0.75rem",
+                border: "1px solid #E2E8F0",
+                borderRadius: "0.75rem",
+                background: "#FFFFFF"
+              }}
+            >
+              <Icon icon={IconComponent} aria-hidden {...args} />
+              <figcaption
+                style={{
+                  margin: 0,
+                  fontSize: "0.8125rem",
+                  color: "#475569",
+                  textAlign: "center",
+                  wordBreak: "keep-all"
+                }}
+              >
+                {name}
+              </figcaption>
+            </figure>
+          );
+        })}
+      </div>
+    </div>
+  )
+};
+
+export const Accessibility: Story = {
+  parameters: {
+    controls: {
+      exclude: ["icon"]
+    }
+  },
+  args: {
+    tone: "primary",
+    filled: true,
+    size: "md",
+    strokeWidth: 1.5,
+    title: "성공"
+  },
+  render: ({ icon: _icon, ...args }) => {
+    const labelId = "icon-title-sample";
+
+    return (
+      <div
+        style={{
+          display: "grid",
+          gap: "0.75rem",
+          maxWidth: 420,
+          fontSize: "0.9375rem",
+          color: "#334155"
+        }}
+      >
+        <p style={{ margin: 0 }}>
+          `title` 을 전달하면 내부 `title` 요소와 `role="img"` 이 생성되고, `aria-labelledby` 로 연결되어 스크린 리더가 읽을 수
+          있습니다. 추가 라벨이 필요하면 `aria-label` 또는 `aria-labelledby` 를 넘겨주세요.
+        </p>
+        <div style={{ display: "flex", gap: "0.75rem", alignItems: "center" }}>
+          <Icon {...args} aria-labelledby={labelId} />
+          <span id={labelId}>성공 상태 아이콘</span>
+        </div>
+      </div>
+    );
+  }
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
 
   apps/storybook:
     dependencies:
+      '@ara/icons':
+        specifier: workspace:*
+        version: link:../../packages/icons
       '@ara/react':
         specifier: workspace:*
         version: link:../../packages/react


### PR DESCRIPTION
## Summary
- [x] 아이콘 컨트롤이 포함된 스토리와 MDX Docs를 추가해 갤러리, 접근성 예시, 시각 회귀 안내를 제공합니다.
- [x] Storybook에서 `@ara/icons` 워크스페이스를 인식하도록 의존성과 Vite alias를 확장했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (W-000006 / T-000054)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/storybook build-storybook`

## Screenshots
- (필요 없음)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb099af248322ae524c799cb3c31d)