### PR TITLE
T-000055: Icon 토큰 매핑 가이드와 ThemeProvider 우선순위 테스트

### DIFF
--- a/packages/react/src/components/icon/Icon.test.tsx
+++ b/packages/react/src/components/icon/Icon.test.tsx
@@ -37,6 +37,17 @@ describe("Icon", () => {
     expect(getByTestId("icon")).toHaveStyle({ color: defaultTheme.component.icon.tone.danger });
   });
 
+  it("size 토큰 키를 테마 값으로 매핑한다", () => {
+    const { getByTestId } = render(
+      <Icon icon={FilledIcon} size="lg" data-testid="icon" aria-label="크기" />
+    );
+
+    const icon = getByTestId("icon");
+
+    expect(icon).toHaveAttribute("width", defaultTheme.component.icon.size.lg);
+    expect(icon).toHaveAttribute("height", defaultTheme.component.icon.size.lg);
+  });
+
   it("제목이나 라벨이 없으면 장식용으로 aria-hidden을 설정한다", () => {
     const { getByTestId } = render(<Icon icon={FilledIcon} data-testid="icon" />);
 
@@ -172,6 +183,33 @@ describe("Icon", () => {
     expect(icon).toHaveAttribute("height", "3rem");
     expect(icon).toHaveStyle({ color: "#123456" });
     expect(strokeValues.every((value) => value === "1.5" || value === null)).toBe(true);
+  });
+
+  it("ThemeProvider 토큰이 상위 currentColor 상속보다 우선한다", () => {
+    const customTheme: ThemeOverrides = {
+      component: {
+        icon: {
+          size: { sm: "0.875rem" },
+          tone: {
+            primary: "#13579B"
+          }
+        }
+      }
+    };
+
+    const { getByTestId } = render(
+      <ThemeProvider theme={customTheme}>
+        <div style={{ color: "rgb(10, 20, 30)" }}>
+          <Icon icon={FilledIcon} size="sm" tone="primary" data-testid="icon" />
+        </div>
+      </ThemeProvider>
+    );
+
+    const icon = getByTestId("icon");
+
+    expect(icon).toHaveAttribute("width", "0.875rem");
+    expect(icon).toHaveAttribute("height", "0.875rem");
+    expect(icon).toHaveStyle({ color: "#13579B" });
   });
 
   it("ref를 최종 SVG 엘리먼트로 포워딩한다", () => {

--- a/packages/react/src/components/icon/README.md
+++ b/packages/react/src/components/icon/README.md
@@ -25,6 +25,20 @@ function Example() {
 }
 ```
 
+## Tokens 매핑
+
+아이콘 크기·색상은 `ThemeProvider` 로 전달되는 아이콘 토큰(`tokens.component.icon`)과 매핑된다.
+
+| 항목 | 토큰 키 | 값 예시 | 설명 |
+| --- | --- | --- | --- |
+| **size** | `sm` \| `md` \| `lg` | `1rem` · `1.25rem` · `1.5rem` | 크기를 토큰 스케일에 맞춰 설정한다. 커스텀 문자열/숫자를 전달하면 그대로 사용한다. |
+| **tone** | `primary` \| `neutral` \| `danger` | 브랜드·중립·위험 계열 색상 | `color` 프롭이 비어 있을 때 `currentColor` 로 주입할 색상을 토큰에서 가져온다. |
+| **strokeWidth** | `default` | `2` | 스트로크 기반 아이콘의 두께 기본값. |
+
+- 색상 우선순위: `color` 프롭 → `style.color` → `tone` 토큰 → 상위 `currentColor` 상속.
+- 크기 우선순위: `size` 프롭이 토큰 키면 토큰 값을, 문자열/숫자면 그대로 사용한다. 프롭이 없으면 `md` 토큰 값을 사용한다.
+- `ThemeProvider` 로 전달한 토큰이 기본 토큰보다 우선한다. 토큰을 커스터마이즈하면 위 우선순위 내에서 적용된다.
+
 ## 접근성
 
 - 제목(`title`)이나 라벨(`aria-label`/`aria-labelledby`)이 없으면 기본으로 `aria-hidden="true"` 로 처리해 장식용 아이콘으로 숨긴다.


### PR DESCRIPTION
## Summary
- [x] Icon README에 size/tone/stroke 토큰 매핑과 색상/크기 우선순위 설명을 추가했습니다.
- [x] size 토큰 매핑과 ThemeProvider 토큰 우선순위를 검증하는 테스트를 보강했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/react test`

## Screenshots
- 해당 없음.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bbe4c57088322a4c8465119833db8)