### PR TITLE
[T-000056] Icon 통합 스토리 누락 임포트 수정

### DIFF
--- a/apps/storybook/stories/components/Button.stories.tsx
+++ b/apps/storybook/stories/components/Button.stories.tsx
@@ -1,20 +1,8 @@
 import type { CSSProperties } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ThemeOverrides } from "@ara/core";
-import { AraProvider, AraThemeBoundary, Button, ThemeProvider } from "@ara/react";
-
-const ArrowRightIcon = () => (
-  <svg
-    aria-hidden="true"
-    focusable="false"
-    viewBox="0 0 24 24"
-    width={16}
-    height={16}
-    fill="currentColor"
-  >
-    <path d="M4 11h10.17l-3.58-3.59L12 6l6 6-6 6-1.41-1.41L14.17 13H4z" />
-  </svg>
-);
+import { ArrowRight, CheckCircle, Plus } from "@ara/icons";
+import { AraProvider, AraThemeBoundary, Button, Icon, ThemeProvider } from "@ara/react";
 
 const meta = {
   title: "Components/Button",
@@ -177,8 +165,8 @@ export const Sizes: Story = {
 
 export const WithIcons: Story = {
   args: {
-    leadingIcon: <ArrowRightIcon />,
-    trailingIcon: <ArrowRightIcon />,
+    leadingIcon: <Icon icon={Plus} size="sm" aria-hidden />,
+    trailingIcon: <Icon icon={ArrowRight} size="sm" aria-hidden />,
     children: "아이콘 포함"
   }
 };
@@ -400,15 +388,15 @@ export const Accessibility: Story = {
               >
                 <Button
                   {...args}
-                  leadingIcon={<ArrowRightIcon />}
-                  trailingIcon={<ArrowRightIcon />}
+                  leadingIcon={<Icon icon={ArrowRight} size="sm" aria-hidden />}
+                  trailingIcon={<Icon icon={ArrowRight} size="sm" aria-hidden />}
                 >
                   오른쪽에서 시작
                 </Button>
                 <Button
                   {...args}
                   variant="outline"
-                  leadingIcon={<ArrowRightIcon />}
+                  leadingIcon={<Icon icon={ArrowRight} size="sm" aria-hidden />}
                 >
                   아이콘 정렬 확인
                 </Button>

--- a/apps/storybook/stories/components/Icon.docs.mdx
+++ b/apps/storybook/stories/components/Icon.docs.mdx
@@ -24,6 +24,13 @@ strokeWidth, filled 컨트롤로 공통 속성을 조절하고, 필요한 경우
 
 <Canvas of={IconStories.Gallery} />
 
+## Component Integration
+
+`Button`의 `leadingIcon`/`trailingIcon` 슬롯과 향후 `TextField` 접두/접미 아이콘 예시를 함께 확인할 수 있습니다. currentColor 규칙을
+공유하므로 부모 컴포넌트의 tone을 그대로 따라가며 토큰 크기를 유지합니다.
+
+<Canvas of={IconStories.ComponentIntegration} />
+
 ## Props
 
 <ArgsTable of={IconStories} />

--- a/apps/storybook/stories/components/Icon.stories.tsx
+++ b/apps/storybook/stories/components/Icon.stories.tsx
@@ -1,8 +1,10 @@
+import type { CSSProperties } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { icons as iconSet, type IconName } from "@ara/icons";
-import { AraProvider, AraThemeBoundary, Icon } from "@ara/react";
+import { AraProvider, AraThemeBoundary, Button, Icon } from "@ara/react";
 
 const iconOptions = Object.keys(iconSet) as IconName[];
+const { Plus, ArrowRight, CheckCircle } = iconSet;
 
 const meta = {
   title: "Components/Icon",
@@ -185,6 +187,95 @@ export const Accessibility: Story = {
             <span id={labelId}>성공 상태 아이콘</span>
           </div>
         </div>
+      </div>
+    );
+  }
+};
+
+export const ComponentIntegration: Story = {
+  parameters: {
+    controls: {
+      exclude: ["icon", "strokeWidth"]
+    }
+  },
+  render: () => {
+    const buttonIconSize = "sm";
+    const fieldStyle = {
+      display: "grid",
+      gap: "0.35rem",
+      maxWidth: "400px"
+    } satisfies CSSProperties;
+    const inputShellStyle = {
+      display: "grid",
+      gridTemplateColumns: "auto 1fr auto",
+      alignItems: "center",
+      gap: "0.5rem",
+      padding: "0.5rem 0.75rem",
+      border: "1px solid #E2E8F0",
+      borderRadius: "0.75rem",
+      background: "#FFFFFF",
+      boxShadow: "0px 1px 2px rgba(15, 23, 42, 0.05)",
+      color: "#0F172A"
+    } satisfies CSSProperties;
+    const inputStyle = {
+      width: "100%",
+      border: "none",
+      outline: "none",
+      font: "inherit",
+      color: "inherit",
+      background: "transparent"
+    } satisfies CSSProperties;
+    const helperStyle = {
+      margin: 0,
+      fontSize: "0.8125rem",
+      color: "#64748B"
+    } satisfies CSSProperties;
+
+    return (
+      <div style={{ display: "grid", gap: "1.5rem", maxWidth: "720px" }}>
+        <section style={{ display: "grid", gap: "0.5rem" }}>
+          <h4 style={{ margin: 0, color: "#0F172A" }}>Button 슬롯 연동</h4>
+          <p style={{ margin: 0, fontSize: "0.9rem", color: "#475569" }}>
+            `leadingIcon` / `trailingIcon` 슬롯에 `Icon`을 직접 넣어 토큰 크기와 currentColor 규칙을 공유합니다.
+          </p>
+          <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+            <Button leadingIcon={<Icon icon={Plus} size={buttonIconSize} aria-hidden />}>새 항목</Button>
+            <Button
+              variant="outline"
+              trailingIcon={<Icon icon={ArrowRight} size={buttonIconSize} aria-hidden />}
+            >
+              다음 단계
+            </Button>
+            <Button
+              tone="neutral"
+              variant="ghost"
+              trailingIcon={<Icon icon={CheckCircle} size={buttonIconSize} aria-hidden />}
+            >
+              검토 완료
+            </Button>
+          </div>
+        </section>
+
+        <section style={{ display: "grid", gap: "0.5rem" }}>
+          <h4 style={{ margin: 0, color: "#0F172A" }}>입력 필드 접두/접미 예시</h4>
+          <p style={{ margin: 0, fontSize: "0.9rem", color: "#475569" }}>
+            TextField 컴포넌트가 도입되면 동일한 패턴으로 prefix/suffix 아이콘을 배치할 수 있습니다.
+          </p>
+          <label style={fieldStyle}>
+            <span style={{ fontSize: "0.875rem", color: "#0F172A" }}>워크플로우 URL</span>
+            <div style={inputShellStyle}>
+              <Icon icon={CheckCircle} tone="primary" size="md" aria-hidden />
+              <input
+                type="text"
+                defaultValue="https://ara.design/workflows"
+                aria-label="워크플로우 URL"
+                style={inputStyle}
+              />
+              <Icon icon={ArrowRight} size="sm" aria-hidden />
+            </div>
+            <p style={helperStyle}>prefix/suffix 슬롯을 활용해 상태나 액션 힌트를 함께 노출합니다.</p>
+          </label>
+        </section>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Icon 통합 스토리에서 사용하는 Plus/ArrowRight/CheckCircle 아이콘을 iconSet 구조 분해로 임포트해 타입 오류를 해소했습니다.

## Testing
- pnpm --filter @ara/storybook lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bc43c7bf0832297a8748807b191b0)