### PR TITLE
Remove unused icon import from Button story

### DIFF
--- a/apps/storybook/stories/components/Button.stories.tsx
+++ b/apps/storybook/stories/components/Button.stories.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ThemeOverrides } from "@ara/core";
-import { ArrowRight, CheckCircle, Plus } from "@ara/icons";
+import { ArrowRight, Plus } from "@ara/icons";
 import { AraProvider, AraThemeBoundary, Button, Icon, ThemeProvider } from "@ara/react";
 
 const meta = {


### PR DESCRIPTION
## Summary
- remove unused CheckCircle icon import from the Button story module
- keep storybook linting clean by avoiding unused variables

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd51168b48322bd91f703b71a5593)