### PR TITLE
feat: Stack 레이아웃 프리미티브 구현

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,6 +22,16 @@
       "import": "./dist/components/index.js",
       "default": "./dist/components/index.js"
     },
+    "./components/layout": {
+      "types": "./dist/components/layout/index.d.ts",
+      "import": "./dist/components/layout/index.js",
+      "default": "./dist/components/layout/index.js"
+    },
+    "./components/stack": {
+      "types": "./dist/components/layout/index.d.ts",
+      "import": "./dist/components/layout/index.js",
+      "default": "./dist/components/layout/index.js"
+    },
     "./components/theme-provider": {
       "types": "./dist/components/theme-provider/index.d.ts",
       "import": "./dist/components/theme-provider/index.js",
@@ -47,6 +57,11 @@
       "import": "./dist/components/icon/index.js",
       "default": "./dist/components/icon/index.js"
     },
+    "./stack": {
+      "types": "./dist/components/layout/index.d.ts",
+      "import": "./dist/components/layout/index.js",
+      "default": "./dist/components/layout/index.js"
+    },
     "./theme-provider": {
       "types": "./dist/components/theme-provider/index.d.ts",
       "import": "./dist/components/theme-provider/index.js",
@@ -62,6 +77,12 @@
       "components/*": [
         "dist/components/*/index.d.ts"
       ],
+      "layout": [
+        "dist/components/layout/index.d.ts"
+      ],
+      "components/layout": [
+        "dist/components/layout/index.d.ts"
+      ],
       "components/theme-provider": [
         "dist/components/theme-provider/index.d.ts"
       ],
@@ -70,6 +91,9 @@
       ],
       "icon": [
         "dist/components/icon/index.d.ts"
+      ],
+      "stack": [
+        "dist/components/layout/index.d.ts"
       ],
       "theme-provider": [
         "dist/components/theme-provider/index.d.ts"

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from "./button/index.js";
 export * from "./icon/index.js";
+export * from "./layout/index.js";
 export * from "./theme-provider/index.js";

--- a/packages/react/src/components/layout/Stack.test.tsx
+++ b/packages/react/src/components/layout/Stack.test.tsx
@@ -1,0 +1,89 @@
+import { defaultTheme } from "@ara/core";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Stack } from "./Stack.js";
+
+describe("Stack", () => {
+  it("기본 column 스택으로 gap과 정렬을 설정한다", () => {
+    const { getByTestId } = render(
+      <Stack data-testid="stack">
+        <span>첫째</span>
+        <span>둘째</span>
+      </Stack>
+    );
+
+    const element = getByTestId("stack");
+    const style = getComputedStyle(element);
+
+    expect(style.display).toBe("flex");
+    expect(style.flexDirection).toBe("column");
+    expect(style.gap).toBe("0px");
+    expect(style.alignItems).toBe("stretch");
+    expect(style.justifyContent).toBe("flex-start");
+    expect(style.flexWrap).toBe("nowrap");
+  });
+
+  it("간격과 정렬 토큰을 CSS 값으로 매핑한다", () => {
+    const { getByTestId } = render(
+      <Stack gap="lg" align="center" justify="between" data-testid="stack">
+        <span>왼쪽</span>
+        <span>오른쪽</span>
+      </Stack>
+    );
+
+    const style = getComputedStyle(getByTestId("stack"));
+
+    expect(style.gap).toBe(defaultTheme.layout.space.lg);
+    expect(style.alignItems).toBe("center");
+    expect(style.justifyContent).toBe("space-between");
+  });
+
+  it("divider를 자식 사이에 삽입한다", () => {
+    const { getAllByTestId } = render(
+      <Stack divider={<span data-testid="divider" />}>
+        <span>1</span>
+        <span>2</span>
+        <span>3</span>
+      </Stack>
+    );
+
+    expect(getAllByTestId("divider")).toHaveLength(2);
+  });
+
+  it("반응형 프롭을 media query 규칙으로 출력한다", () => {
+    const { container } = render(
+      <Stack
+        direction={{ base: "column", md: "row-reverse" }}
+        gap={{ base: "sm", lg: 10 }}
+        align={{ md: "center" }}
+        justify={{ lg: "evenly" }}
+        wrap={{ md: "wrap" }}
+      >
+        <span>하나</span>
+        <span>둘</span>
+      </Stack>
+    );
+
+    const styleTag = container.querySelector("style");
+    const cssText = styleTag?.textContent ?? "";
+
+    expect(cssText).toContain("@media (min-width: 768px)");
+    expect(cssText).toContain("flex-direction:row-reverse");
+    expect(cssText).toContain("gap:10px");
+    expect(cssText).toContain("justify-content:space-evenly");
+    expect(cssText).toContain("flex-wrap:wrap");
+  });
+
+  it("as prop과 inline 옵션을 지원한다", () => {
+    const { getByTestId } = render(
+      <Stack as="section" inline data-testid="stack">
+        <span>본문</span>
+      </Stack>
+    );
+
+    const element = getByTestId("stack");
+
+    expect(element.tagName).toBe("SECTION");
+    expect(getComputedStyle(element).display).toBe("inline-flex");
+  });
+});

--- a/packages/react/src/components/layout/Stack.tsx
+++ b/packages/react/src/components/layout/Stack.tsx
@@ -60,12 +60,25 @@ function mergeClassNames(...values: Array<string | undefined | null | false>): s
 }
 
 function normalizeResponsiveValue<T>(value: Responsive<T> | undefined, fallback: T): ResponsiveMap<T> {
-  if (value && typeof value === "object" && !Array.isArray(value)) {
+  if (
+    value !== undefined &&
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    ("base" in value || "sm" in value || "md" in value || "lg" in value)
+  ) {
+    const responsiveValue = value as {
+      base?: T;
+      sm?: T;
+      md?: T;
+      lg?: T;
+    };
+
     return {
-      base: value.base ?? fallback,
-      sm: value.sm,
-      md: value.md,
-      lg: value.lg
+      base: responsiveValue.base ?? fallback,
+      sm: responsiveValue.sm,
+      md: responsiveValue.md,
+      lg: responsiveValue.lg
     };
   }
 
@@ -195,16 +208,25 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, r
   const generatedClassName = useStackClassName();
 
   const direction = useMemo(
-    () => normalizeResponsiveValue(directionProp, "column"),
+    () => normalizeResponsiveValue<StackDirection>(directionProp, "column"),
     [directionProp]
   );
-  const gap = useMemo(() => normalizeResponsiveValue(gapProp, 0), [gapProp]);
-  const align = useMemo(() => normalizeResponsiveValue(alignProp, "stretch"), [alignProp]);
+  const gap = useMemo(
+    () => normalizeResponsiveValue<SpaceScale | string | number>(gapProp, 0),
+    [gapProp]
+  );
+  const align = useMemo(
+    () => normalizeResponsiveValue<StackAlign>(alignProp, "stretch"),
+    [alignProp]
+  );
   const justify = useMemo(
-    () => normalizeResponsiveValue(justifyProp, "start"),
+    () => normalizeResponsiveValue<StackJustify>(justifyProp, "start"),
     [justifyProp]
   );
-  const wrap = useMemo(() => normalizeResponsiveValue(wrapProp, false), [wrapProp]);
+  const wrap = useMemo(
+    () => normalizeResponsiveValue<StackWrap>(wrapProp, false),
+    [wrapProp]
+  );
 
   const resolvedClassName = mergeClassNames("ara-stack", generatedClassName, className);
 

--- a/packages/react/src/components/layout/Stack.tsx
+++ b/packages/react/src/components/layout/Stack.tsx
@@ -1,0 +1,263 @@
+import {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useMemo,
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+  type ElementType,
+  type ReactElement,
+  type ReactNode,
+  type Ref
+} from "react";
+import type { Theme } from "@ara/core";
+import type { LayoutKey } from "@ara/tokens/layout";
+import { useAraTheme } from "../../theme/index.js";
+
+const BREAKPOINTS = {
+  sm: 640,
+  md: 768,
+  lg: 1024
+} as const;
+
+type Breakpoint = keyof typeof BREAKPOINTS;
+
+type Responsive<T> =
+  | T
+  | {
+      base?: T;
+      sm?: T;
+      md?: T;
+      lg?: T;
+    };
+
+type ResponsiveMap<T> = { base: T; sm?: T; md?: T; lg?: T };
+
+type StackDirection = "row" | "row-reverse" | "column" | "column-reverse";
+type StackAlign = "start" | "center" | "end" | "stretch" | "baseline";
+type StackJustify = "start" | "center" | "end" | "between" | "around" | "evenly";
+type StackWrap = false | "wrap" | "wrap-reverse";
+type SpaceScale = LayoutKey<"space">;
+
+interface StackOwnProps<T extends ElementType = "div"> {
+  readonly as?: T;
+  readonly direction?: Responsive<StackDirection>;
+  readonly gap?: Responsive<SpaceScale | string | number>;
+  readonly align?: Responsive<StackAlign>;
+  readonly justify?: Responsive<StackJustify>;
+  readonly wrap?: Responsive<StackWrap>;
+  readonly divider?: ReactNode;
+  readonly inline?: boolean;
+  readonly children?: ReactNode;
+}
+
+export type StackProps<T extends ElementType = "div"> = StackOwnProps<T> &
+  Omit<ComponentPropsWithoutRef<T>, keyof StackOwnProps<T> | "as">;
+
+function mergeClassNames(...values: Array<string | undefined | null | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+function normalizeResponsiveValue<T>(value: Responsive<T> | undefined, fallback: T): ResponsiveMap<T> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return {
+      base: value.base ?? fallback,
+      sm: value.sm,
+      md: value.md,
+      lg: value.lg
+    };
+  }
+
+  return { base: (value ?? fallback) as T };
+}
+
+function toCSSValue(value: string | number | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === "number" ? `${value}` : value;
+}
+
+function toKebabCase(value: string): string {
+  return value.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+}
+
+function createRule(selector: string, styles: Partial<CSSProperties>): string {
+  const declarations = Object.entries(styles)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([property, value]) => `${toKebabCase(property)}:${toCSSValue(value)};`)
+    .join("");
+
+  if (!declarations) return "";
+
+  return `${selector}{${declarations}}`;
+}
+
+function mapAlign(value: StackAlign): CSSProperties["alignItems"] {
+  switch (value) {
+    case "start":
+      return "flex-start";
+    case "end":
+      return "flex-end";
+    case "center":
+      return "center";
+    case "baseline":
+      return "baseline";
+    default:
+      return "stretch";
+  }
+}
+
+function mapJustify(value: StackJustify): CSSProperties["justifyContent"] {
+  switch (value) {
+    case "start":
+      return "flex-start";
+    case "end":
+      return "flex-end";
+    case "between":
+      return "space-between";
+    case "around":
+      return "space-around";
+    case "evenly":
+      return "space-evenly";
+    default:
+      return "flex-start";
+  }
+}
+
+function mapWrap(value: StackWrap): CSSProperties["flexWrap"] {
+  return value === false ? "nowrap" : value;
+}
+
+function resolveSpaceValue(value: SpaceScale | string | number, theme: Theme): string {
+  if (typeof value === "number") return `${value}px`;
+  if (typeof value === "string") {
+    const tokenValue = theme.layout.space[value as SpaceScale];
+    return tokenValue ?? value;
+  }
+
+  return "0px";
+}
+
+function cloneDividerNode(divider: ReactNode, index: number): ReactNode {
+  if (isValidElement(divider)) {
+    const element = divider as ReactElement;
+    const key = element.key ?? `divider-${index}`;
+    return cloneElement(element, { key });
+  }
+
+  return (
+    <span aria-hidden key={`divider-${index}`}>
+      {divider}
+    </span>
+  );
+}
+
+function withDividers(children: ReactNode, divider: ReactNode | undefined): ReactNode[] {
+  const items = Children.toArray(children);
+  if (!divider || items.length <= 1) return items;
+
+  const spaced: ReactNode[] = [];
+  items.forEach((child, index) => {
+    spaced.push(child);
+    if (index < items.length - 1) {
+      spaced.push(cloneDividerNode(divider, index));
+    }
+  });
+
+  return spaced;
+}
+
+let stackId = 0;
+function useStackClassName(): string {
+  return useMemo(() => {
+    stackId += 1;
+    return `ara-stack-${stackId}`;
+  }, []);
+}
+
+export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, ref: Ref<HTMLElement>) {
+  const {
+    as,
+    direction: directionProp,
+    gap: gapProp,
+    align: alignProp,
+    justify: justifyProp,
+    wrap: wrapProp,
+    divider,
+    inline = false,
+    className,
+    children,
+    ...restProps
+  } = props;
+
+  const Component = (as ?? "div") as ElementType;
+  const theme = useAraTheme();
+  const generatedClassName = useStackClassName();
+
+  const direction = useMemo(
+    () => normalizeResponsiveValue(directionProp, "column"),
+    [directionProp]
+  );
+  const gap = useMemo(() => normalizeResponsiveValue(gapProp, 0), [gapProp]);
+  const align = useMemo(() => normalizeResponsiveValue(alignProp, "stretch"), [alignProp]);
+  const justify = useMemo(
+    () => normalizeResponsiveValue(justifyProp, "start"),
+    [justifyProp]
+  );
+  const wrap = useMemo(() => normalizeResponsiveValue(wrapProp, false), [wrapProp]);
+
+  const resolvedClassName = mergeClassNames("ara-stack", generatedClassName, className);
+
+  const baseStyles = useMemo<Partial<CSSProperties>>(
+    () => ({
+      display: inline ? "inline-flex" : "flex",
+      boxSizing: "border-box",
+      flexDirection: direction.base,
+      gap: resolveSpaceValue(gap.base, theme),
+      alignItems: mapAlign(align.base),
+      justifyContent: mapJustify(justify.base),
+      flexWrap: mapWrap(wrap.base)
+    }),
+    [align.base, direction.base, gap.base, inline, justify.base, theme, wrap.base]
+  );
+
+  const responsiveRules = useMemo(
+    () =>
+      (Object.keys(BREAKPOINTS) as Breakpoint[]).map((breakpoint) => {
+        const styles: Partial<CSSProperties> = {
+          flexDirection: direction[breakpoint],
+          gap:
+            gap[breakpoint] !== undefined
+              ? resolveSpaceValue(gap[breakpoint] as SpaceScale | string | number, theme)
+              : undefined,
+          alignItems: align[breakpoint] ? mapAlign(align[breakpoint] as StackAlign) : undefined,
+          justifyContent: justify[breakpoint] ? mapJustify(justify[breakpoint] as StackJustify) : undefined,
+          flexWrap: wrap[breakpoint] !== undefined ? mapWrap(wrap[breakpoint] as StackWrap) : undefined
+        };
+
+        const rule = createRule(`.${generatedClassName}`, styles);
+        if (!rule) return "";
+
+        return `@media (min-width: ${BREAKPOINTS[breakpoint]}px){${rule}}`;
+      }),
+    [align, direction, gap, generatedClassName, justify, theme, wrap]
+  );
+
+  const cssText = useMemo(
+    () => [createRule(`.${generatedClassName}`, baseStyles), ...responsiveRules].filter(Boolean).join(""),
+    [baseStyles, generatedClassName, responsiveRules]
+  );
+
+  const content = withDividers(children, divider);
+
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: cssText }} />
+      <Component ref={ref} className={resolvedClassName} {...restProps}>
+        {content}
+      </Component>
+    </>
+  );
+});
+
+Stack.displayName = "Stack";

--- a/packages/react/src/components/layout/index.ts
+++ b/packages/react/src/components/layout/index.ts
@@ -1,0 +1,1 @@
+export { Stack, type StackProps } from "./Stack.js";


### PR DESCRIPTION
## Summary
- flex 기반 Stack 컴포넌트를 추가하여 gap, 정렬, wrap을 반응형으로 제어
- divider, as, inline 프롭을 지원하고 media query로 스타일을 생성
- 패키지 exports/타입 정의를 갱신하고 Stack 유닛 테스트를 추가

## Testing
- pnpm --filter @ara/react test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d068cc90c8322878c8ddab58e0a4f)