### PR TITLE
feat: Flex 레이아웃 컴포넌트 추가

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/components/layout/index.js",
       "default": "./dist/components/layout/index.js"
     },
+    "./components/flex": {
+      "types": "./dist/components/layout/index.d.ts",
+      "import": "./dist/components/layout/index.js",
+      "default": "./dist/components/layout/index.js"
+    },
     "./components/stack": {
       "types": "./dist/components/layout/index.d.ts",
       "import": "./dist/components/layout/index.js",
@@ -62,6 +67,11 @@
       "import": "./dist/components/layout/index.js",
       "default": "./dist/components/layout/index.js"
     },
+    "./flex": {
+      "types": "./dist/components/layout/index.d.ts",
+      "import": "./dist/components/layout/index.js",
+      "default": "./dist/components/layout/index.js"
+    },
     "./theme-provider": {
       "types": "./dist/components/theme-provider/index.d.ts",
       "import": "./dist/components/theme-provider/index.js",
@@ -83,6 +93,9 @@
       "components/layout": [
         "dist/components/layout/index.d.ts"
       ],
+      "components/flex": [
+        "dist/components/layout/index.d.ts"
+      ],
       "components/theme-provider": [
         "dist/components/theme-provider/index.d.ts"
       ],
@@ -91,6 +104,9 @@
       ],
       "icon": [
         "dist/components/icon/index.d.ts"
+      ],
+      "flex": [
+        "dist/components/layout/index.d.ts"
       ],
       "stack": [
         "dist/components/layout/index.d.ts"

--- a/packages/react/src/components/flex/index.ts
+++ b/packages/react/src/components/flex/index.ts
@@ -1,0 +1,1 @@
+export { Flex, type FlexProps } from "../layout/Flex.js";

--- a/packages/react/src/components/layout/Flex.test.tsx
+++ b/packages/react/src/components/layout/Flex.test.tsx
@@ -1,0 +1,77 @@
+import { defaultTheme } from "@ara/core";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Flex } from "./Flex.js";
+
+describe("Flex", () => {
+  it("기본 row 플렉스로 gap과 정렬을 설정한다", () => {
+    const { getByTestId } = render(
+      <Flex data-testid="flex">
+        <span>첫째</span>
+        <span>둘째</span>
+      </Flex>
+    );
+
+    const element = getByTestId("flex");
+    const style = getComputedStyle(element);
+
+    expect(style.display).toBe("flex");
+    expect(style.flexDirection).toBe("row");
+    expect(style.gap).toBe("0px");
+    expect(style.alignItems).toBe("stretch");
+    expect(style.justifyContent).toBe("flex-start");
+    expect(style.flexWrap).toBe("nowrap");
+  });
+
+  it("간격과 정렬 토큰을 CSS 값으로 매핑한다", () => {
+    const { getByTestId } = render(
+      <Flex gap="lg" align="center" justify="between" data-testid="flex">
+        <span>왼쪽</span>
+        <span>오른쪽</span>
+      </Flex>
+    );
+
+    const style = getComputedStyle(getByTestId("flex"));
+
+    expect(style.gap).toBe(defaultTheme.layout.space.lg);
+    expect(style.alignItems).toBe("center");
+    expect(style.justifyContent).toBe("space-between");
+  });
+
+  it("반응형 프롭을 media query 규칙으로 출력한다", () => {
+    const { container } = render(
+      <Flex
+        direction={{ base: "row", md: "column-reverse" }}
+        gap={{ base: "sm", lg: 10 }}
+        align={{ md: "center" }}
+        justify={{ lg: "evenly" }}
+        wrap={{ md: "wrap" }}
+      >
+        <span>하나</span>
+        <span>둘</span>
+      </Flex>
+    );
+
+    const styleTag = container.querySelector("style");
+    const cssText = styleTag?.textContent ?? "";
+
+    expect(cssText).toContain("@media (min-width: 768px)");
+    expect(cssText).toContain("flex-direction:column-reverse");
+    expect(cssText).toContain("gap:10px");
+    expect(cssText).toContain("justify-content:space-evenly");
+    expect(cssText).toContain("flex-wrap:wrap");
+  });
+
+  it("as prop과 inline 옵션을 지원한다", () => {
+    const { getByTestId } = render(
+      <Flex as="section" inline data-testid="flex">
+        <span>본문</span>
+      </Flex>
+    );
+
+    const element = getByTestId("flex");
+
+    expect(element.tagName).toBe("SECTION");
+    expect(getComputedStyle(element).display).toBe("inline-flex");
+  });
+});

--- a/packages/react/src/components/layout/Flex.tsx
+++ b/packages/react/src/components/layout/Flex.tsx
@@ -1,13 +1,9 @@
 import {
-  Children,
-  cloneElement,
   forwardRef,
-  isValidElement,
   useMemo,
   type ComponentPropsWithoutRef,
   type CSSProperties,
   type ElementType,
-  type ReactElement,
   type ReactNode,
   type Ref
 } from "react";
@@ -31,56 +27,21 @@ import {
   useLayoutClassName
 } from "./shared.js";
 
-type StackDirection = FlexDirection;
-type StackAlign = FlexAlign;
-type StackJustify = FlexJustify;
-type StackWrap = FlexWrap;
-
-interface StackOwnProps<T extends ElementType = "div"> {
+interface FlexOwnProps<T extends ElementType = "div"> {
   readonly as?: T;
-  readonly direction?: Responsive<StackDirection>;
+  readonly direction?: Responsive<FlexDirection>;
   readonly gap?: Responsive<SpaceScale | string | number>;
-  readonly align?: Responsive<StackAlign>;
-  readonly justify?: Responsive<StackJustify>;
-  readonly wrap?: Responsive<StackWrap>;
-  readonly divider?: ReactNode;
+  readonly align?: Responsive<FlexAlign>;
+  readonly justify?: Responsive<FlexJustify>;
+  readonly wrap?: Responsive<FlexWrap>;
   readonly inline?: boolean;
   readonly children?: ReactNode;
 }
 
-export type StackProps<T extends ElementType = "div"> = StackOwnProps<T> &
-  Omit<ComponentPropsWithoutRef<T>, keyof StackOwnProps<T> | "as">;
+export type FlexProps<T extends ElementType = "div"> = FlexOwnProps<T> &
+  Omit<ComponentPropsWithoutRef<T>, keyof FlexOwnProps<T> | "as">;
 
-function cloneDividerNode(divider: ReactNode, index: number): ReactNode {
-  if (isValidElement(divider)) {
-    const element = divider as ReactElement;
-    const key = element.key ?? `divider-${index}`;
-    return cloneElement(element, { key });
-  }
-
-  return (
-    <span aria-hidden key={`divider-${index}`}>
-      {divider}
-    </span>
-  );
-}
-
-function withDividers(children: ReactNode, divider: ReactNode | undefined): ReactNode[] {
-  const items = Children.toArray(children);
-  if (!divider || items.length <= 1) return items;
-
-  const spaced: ReactNode[] = [];
-  items.forEach((child, index) => {
-    spaced.push(child);
-    if (index < items.length - 1) {
-      spaced.push(cloneDividerNode(divider, index));
-    }
-  });
-
-  return spaced;
-}
-
-export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, ref: Ref<HTMLElement>) {
+export const Flex = forwardRef<HTMLElement, FlexProps>(function Flex(props, ref: Ref<HTMLElement>) {
   const {
     as,
     direction: directionProp,
@@ -88,7 +49,6 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, r
     align: alignProp,
     justify: justifyProp,
     wrap: wrapProp,
-    divider,
     inline = false,
     className,
     children,
@@ -97,10 +57,10 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, r
 
   const Component = (as ?? "div") as ElementType;
   const theme = useAraTheme();
-  const generatedClassName = useLayoutClassName("stack");
+  const generatedClassName = useLayoutClassName("flex");
 
   const direction = useMemo(
-    () => normalizeResponsiveValue<StackDirection>(directionProp, "column"),
+    () => normalizeResponsiveValue<FlexDirection>(directionProp, "row"),
     [directionProp]
   );
   const gap = useMemo(
@@ -108,19 +68,19 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, r
     [gapProp]
   );
   const align = useMemo(
-    () => normalizeResponsiveValue<StackAlign>(alignProp, "stretch"),
+    () => normalizeResponsiveValue<FlexAlign>(alignProp, "stretch"),
     [alignProp]
   );
   const justify = useMemo(
-    () => normalizeResponsiveValue<StackJustify>(justifyProp, "start"),
+    () => normalizeResponsiveValue<FlexJustify>(justifyProp, "start"),
     [justifyProp]
   );
   const wrap = useMemo(
-    () => normalizeResponsiveValue<StackWrap>(wrapProp, false),
+    () => normalizeResponsiveValue<FlexWrap>(wrapProp, false),
     [wrapProp]
   );
 
-  const resolvedClassName = mergeClassNames("ara-stack", generatedClassName, className);
+  const resolvedClassName = mergeClassNames("ara-flex", generatedClassName, className);
 
   const baseStyles = useMemo<Partial<CSSProperties>>(
     () => ({
@@ -144,11 +104,11 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, r
             gap[breakpoint] !== undefined
               ? resolveSpaceValue(gap[breakpoint] as SpaceScale | string | number, theme)
               : undefined,
-          alignItems: align[breakpoint] ? mapAlign(align[breakpoint] as StackAlign) : undefined,
+          alignItems: align[breakpoint] ? mapAlign(align[breakpoint] as FlexAlign) : undefined,
           justifyContent: justify[breakpoint]
-            ? mapJustify(justify[breakpoint] as StackJustify)
+            ? mapJustify(justify[breakpoint] as FlexJustify)
             : undefined,
-          flexWrap: wrap[breakpoint] !== undefined ? mapWrap(wrap[breakpoint] as StackWrap) : undefined
+          flexWrap: wrap[breakpoint] !== undefined ? mapWrap(wrap[breakpoint] as FlexWrap) : undefined
         };
 
         const rule = createRule(`.${generatedClassName}`, styles);
@@ -164,16 +124,14 @@ export const Stack = forwardRef<HTMLElement, StackProps>(function Stack(props, r
     [baseStyles, generatedClassName, responsiveRules]
   );
 
-  const content = withDividers(children, divider);
-
   return (
     <>
       <style dangerouslySetInnerHTML={{ __html: cssText }} />
       <Component ref={ref} className={resolvedClassName} {...restProps}>
-        {content}
+        {children}
       </Component>
     </>
   );
 });
 
-Stack.displayName = "Stack";
+Flex.displayName = "Flex";

--- a/packages/react/src/components/layout/index.ts
+++ b/packages/react/src/components/layout/index.ts
@@ -1,1 +1,2 @@
+export { Flex, type FlexProps } from "./Flex.js";
 export { Stack, type StackProps } from "./Stack.js";

--- a/packages/react/src/components/layout/shared.ts
+++ b/packages/react/src/components/layout/shared.ts
@@ -1,0 +1,133 @@
+import { useId, useMemo, type CSSProperties } from "react";
+import type { Theme } from "@ara/core";
+import type { LayoutKey } from "@ara/tokens/layout";
+
+export const BREAKPOINTS = {
+  sm: 640,
+  md: 768,
+  lg: 1024
+} as const;
+
+export type Breakpoint = keyof typeof BREAKPOINTS;
+
+export type Responsive<T> =
+  | T
+  | {
+      base?: T;
+      sm?: T;
+      md?: T;
+      lg?: T;
+    };
+
+export type ResponsiveMap<T> = { base: T; sm?: T; md?: T; lg?: T };
+
+export type FlexDirection = "row" | "row-reverse" | "column" | "column-reverse";
+export type FlexAlign = "start" | "center" | "end" | "stretch" | "baseline";
+export type FlexJustify = "start" | "center" | "end" | "between" | "around" | "evenly";
+export type FlexWrap = false | "wrap" | "wrap-reverse";
+export type SpaceScale = LayoutKey<"space">;
+
+export function mergeClassNames(...values: Array<string | undefined | null | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+export function normalizeResponsiveValue<T>(value: Responsive<T> | undefined, fallback: T): ResponsiveMap<T> {
+  if (
+    value !== undefined &&
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    ("base" in value || "sm" in value || "md" in value || "lg" in value)
+  ) {
+    const responsiveValue = value as {
+      base?: T;
+      sm?: T;
+      md?: T;
+      lg?: T;
+    };
+
+    return {
+      base: responsiveValue.base ?? fallback,
+      sm: responsiveValue.sm,
+      md: responsiveValue.md,
+      lg: responsiveValue.lg
+    };
+  }
+
+  return { base: (value ?? fallback) as T };
+}
+
+export function toCSSValue(value: string | number | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === "number" ? `${value}` : value;
+}
+
+export function toKebabCase(value: string): string {
+  return value.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`);
+}
+
+export function createRule(selector: string, styles: Partial<CSSProperties>): string {
+  const declarations = Object.entries(styles)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([property, value]) => `${toKebabCase(property)}:${toCSSValue(value)};`)
+    .join("");
+
+  if (!declarations) return "";
+
+  return `${selector}{${declarations}}`;
+}
+
+export function mapAlign(value: FlexAlign): CSSProperties["alignItems"] {
+  switch (value) {
+    case "start":
+      return "flex-start";
+    case "end":
+      return "flex-end";
+    case "center":
+      return "center";
+    case "baseline":
+      return "baseline";
+    default:
+      return "stretch";
+  }
+}
+
+export function mapJustify(value: FlexJustify): CSSProperties["justifyContent"] {
+  switch (value) {
+    case "start":
+      return "flex-start";
+    case "end":
+      return "flex-end";
+    case "between":
+      return "space-between";
+    case "around":
+      return "space-around";
+    case "evenly":
+      return "space-evenly";
+    default:
+      return "flex-start";
+  }
+}
+
+export function mapWrap(value: FlexWrap): CSSProperties["flexWrap"] {
+  return value === false ? "nowrap" : value;
+}
+
+export function resolveSpaceValue(value: SpaceScale | string | number, theme: Theme): string {
+  if (typeof value === "number") return `${value}px`;
+  if (typeof value === "string") {
+    const tokenValue = theme.layout.space[value as SpaceScale];
+    return tokenValue ?? value;
+  }
+
+  return "0px";
+}
+
+export function useLayoutClassName(component: "stack" | "flex"): string {
+  const reactId = useId();
+
+  return useMemo(() => {
+    const sanitizedId = reactId.replace(/:/g, "-");
+    return `ara-${component}-${sanitizedId}`;
+  }, [component, reactId]);
+}


### PR DESCRIPTION
## Summary
- Flex 컨테이너 컴포넌트를 추가하고 gap/정렬/wrap 등의 반응형 스타일을 지원했습니다.
- Stack과 공유하는 레이아웃 유틸리티를 분리해 코드 중복을 줄였습니다.
- 패키지 export 및 타입 매핑에 flex 엔트리를 추가하고 전용 re-export 파일을 만들었습니다.

## Testing
- pnpm --filter @ara/react test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d0bfa49e883229e780a816efd88cb)