### PR TITLE
feat: Grid 레이아웃 컴포넌트 추가 (T-000062)

### DIFF
--- a/packages/react/src/components/layout/Grid.test.tsx
+++ b/packages/react/src/components/layout/Grid.test.tsx
@@ -1,0 +1,112 @@
+import { defaultTheme } from "@ara/core";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Grid } from "./Grid.js";
+
+describe("Grid", () => {
+  it("기본 1열 그리드로 gap과 정렬을 설정한다", () => {
+    const { getByTestId } = render(
+      <Grid data-testid="grid">
+        <span>첫째</span>
+        <span>둘째</span>
+      </Grid>
+    );
+
+    const element = getByTestId("grid");
+    const style = getComputedStyle(element);
+
+    expect(style.display).toBe("grid");
+    expect(style.gridTemplateColumns).toBe("repeat(1, minmax(0, 1fr))");
+    expect(style.gridTemplateRows).toBe("auto");
+    expect(style.gap).toBe("0px");
+    expect(style.alignItems).toBe("stretch");
+    expect(style.justifyItems).toBe("stretch");
+    expect(style.gridAutoFlow).toBe("row");
+  });
+
+  it("간격과 행/열/정렬 프롭을 해석한다", () => {
+    const { getByTestId } = render(
+      <Grid
+        columns={3}
+        rows="auto auto"
+        gap="md"
+        columnGap="lg"
+        rowGap={8}
+        align="center"
+        justify="end"
+        autoFlow="row dense"
+        data-testid="grid"
+      >
+        <span>1</span>
+        <span>2</span>
+        <span>3</span>
+      </Grid>
+    );
+
+    const style = getComputedStyle(getByTestId("grid"));
+
+    expect(style.gridTemplateColumns).toBe("repeat(3, minmax(0, 1fr))");
+    expect(style.gridTemplateRows).toBe("auto auto");
+    expect(style.gap).toBe(defaultTheme.layout.space.md);
+    expect(style.columnGap).toBe(defaultTheme.layout.space.lg);
+    expect(style.rowGap).toBe("8px");
+    expect(style.alignItems).toBe("center");
+    expect(style.justifyItems).toBe("end");
+    expect(style.gridAutoFlow).toBe("row dense");
+  });
+
+  it("반응형 프롭을 media query 규칙으로 출력한다", () => {
+    const { container } = render(
+      <Grid
+        columns={{ base: 2, md: "1fr 2fr" }}
+        rows={{ lg: 3 }}
+        gap={{ base: "sm", md: "md", lg: 24 }}
+        columnGap={{ md: "lg" }}
+        rowGap={{ lg: "xl" }}
+        align={{ md: "start" }}
+        justify={{ lg: "center" }}
+        autoFlow={{ md: "column" }}
+      >
+        <span>1</span>
+        <span>2</span>
+      </Grid>
+    );
+
+    const styleTag = container.querySelector("style");
+    const cssText = styleTag?.textContent ?? "";
+
+    expect(cssText).toContain("@media (min-width: 768px)");
+    expect(cssText).toContain("grid-template-columns:1fr 2fr");
+    expect(cssText).toContain(`gap:${defaultTheme.layout.space.md}`);
+    expect(cssText).toContain(`column-gap:${defaultTheme.layout.space.lg}`);
+    expect(cssText).toContain("grid-auto-flow:column");
+    expect(cssText).toContain("align-items:start");
+    expect(cssText).toContain("@media (min-width: 1024px)");
+    expect(cssText).toContain("grid-template-rows:repeat(3, minmax(0, auto))");
+    expect(cssText).toContain("justify-items:center");
+    expect(cssText).toContain(`row-gap:${defaultTheme.layout.space.xl}`);
+  });
+
+  it("areas와 inline 옵션을 지원한다", () => {
+    const { getByTestId } = render(
+      <Grid
+        as="section"
+        inline
+        areas={["header header", "main sidebar"]}
+        columns={2}
+        data-testid="grid"
+      >
+        <span style={{ gridArea: "header" }}>머리글</span>
+        <span style={{ gridArea: "main" }}>본문</span>
+        <span style={{ gridArea: "sidebar" }}>사이드</span>
+      </Grid>
+    );
+
+    const element = getByTestId("grid");
+    const style = getComputedStyle(element);
+
+    expect(element.tagName).toBe("SECTION");
+    expect(style.display).toBe("inline-grid");
+    expect(style.gridTemplateAreas).toBe('"header header" "main sidebar"');
+  });
+});

--- a/packages/react/src/components/layout/Grid.tsx
+++ b/packages/react/src/components/layout/Grid.tsx
@@ -1,0 +1,227 @@
+import {
+  forwardRef,
+  useMemo,
+  type ComponentPropsWithoutRef,
+  type CSSProperties,
+  type ElementType,
+  type ReactNode,
+  type Ref
+} from "react";
+import { useAraTheme } from "../../theme/index.js";
+import {
+  BREAKPOINTS,
+  type Breakpoint,
+  type Responsive,
+  type SpaceScale,
+  createRule,
+  mergeClassNames,
+  normalizeResponsiveValue,
+  resolveSpaceValue,
+  toCSSValue,
+  useLayoutClassName
+} from "./shared.js";
+
+export type GridAlign = "start" | "center" | "end" | "stretch";
+export type GridJustify = GridAlign;
+export type GridAutoFlow = "row" | "column" | "dense" | "row dense" | "column dense";
+
+interface GridOwnProps<T extends ElementType = "div"> {
+  readonly as?: T;
+  readonly columns?: Responsive<number | string>;
+  readonly rows?: Responsive<number | string>;
+  readonly areas?: string[];
+  readonly gap?: Responsive<SpaceScale | string | number>;
+  readonly columnGap?: Responsive<SpaceScale | string | number>;
+  readonly rowGap?: Responsive<SpaceScale | string | number>;
+  readonly align?: Responsive<GridAlign>;
+  readonly justify?: Responsive<GridJustify>;
+  readonly autoFlow?: Responsive<GridAutoFlow>;
+  readonly inline?: boolean;
+  readonly children?: ReactNode;
+}
+
+export type GridProps<T extends ElementType = "div"> = GridOwnProps<T> &
+  Omit<ComponentPropsWithoutRef<T>, keyof GridOwnProps<T> | "as">;
+
+function mapGridAlign(value: GridAlign): CSSProperties["alignItems"] {
+  switch (value) {
+    case "start":
+      return "start";
+    case "end":
+      return "end";
+    case "center":
+      return "center";
+    default:
+      return "stretch";
+  }
+}
+
+function mapGridJustify(value: GridJustify): CSSProperties["justifyItems"] {
+  switch (value) {
+    case "start":
+      return "start";
+    case "end":
+      return "end";
+    case "center":
+      return "center";
+    default:
+      return "stretch";
+  }
+}
+
+function resolveColumns(value: number | string): string {
+  if (typeof value === "number") return `repeat(${value}, minmax(0, 1fr))`;
+  return value;
+}
+
+function resolveRows(value: number | string): string {
+  if (typeof value === "number") return `repeat(${value}, minmax(0, auto))`;
+  return value;
+}
+
+function resolveAreas(areas?: string[]): string | undefined {
+  if (!areas || areas.length === 0) return undefined;
+  return areas.map((area) => `"${area}"`).join(" ");
+}
+
+export const Grid = forwardRef<HTMLElement, GridProps>(function Grid(props, ref: Ref<HTMLElement>) {
+  const {
+    as,
+    columns: columnsProp,
+    rows: rowsProp,
+    areas,
+    gap: gapProp,
+    columnGap: columnGapProp,
+    rowGap: rowGapProp,
+    align: alignProp,
+    justify: justifyProp,
+    autoFlow: autoFlowProp,
+    inline = false,
+    className,
+    children,
+    ...restProps
+  } = props;
+
+  const Component = (as ?? "div") as ElementType;
+  const theme = useAraTheme();
+  const generatedClassName = useLayoutClassName("grid");
+
+  const columns = useMemo(
+    () => normalizeResponsiveValue<number | string>(columnsProp, 1),
+    [columnsProp]
+  );
+  const rows = useMemo(() => normalizeResponsiveValue<number | string>(rowsProp, "auto"), [rowsProp]);
+  const gap = useMemo(
+    () => normalizeResponsiveValue<SpaceScale | string | number>(gapProp, 0),
+    [gapProp]
+  );
+  const columnGap = useMemo(
+    () => normalizeResponsiveValue<SpaceScale | string | number | undefined>(columnGapProp, undefined),
+    [columnGapProp]
+  );
+  const rowGap = useMemo(
+    () => normalizeResponsiveValue<SpaceScale | string | number | undefined>(rowGapProp, undefined),
+    [rowGapProp]
+  );
+  const align = useMemo(
+    () => normalizeResponsiveValue<GridAlign>(alignProp, "stretch"),
+    [alignProp]
+  );
+  const justify = useMemo(
+    () => normalizeResponsiveValue<GridJustify>(justifyProp, "stretch"),
+    [justifyProp]
+  );
+  const autoFlow = useMemo(
+    () => normalizeResponsiveValue<GridAutoFlow>(autoFlowProp, "row"),
+    [autoFlowProp]
+  );
+
+  const resolvedAreas = useMemo(() => resolveAreas(areas), [areas]);
+  const resolvedClassName = mergeClassNames("ara-grid", generatedClassName, className);
+
+  const baseStyles = useMemo<Partial<CSSProperties>>(
+    () => ({
+      display: inline ? "inline-grid" : "grid",
+      boxSizing: "border-box",
+      gridTemplateColumns: resolveColumns(columns.base),
+      gridTemplateRows: resolveRows(rows.base),
+      gridTemplateAreas: resolvedAreas,
+      gap: resolveSpaceValue(gap.base, theme),
+      columnGap:
+        columnGap.base !== undefined
+          ? resolveSpaceValue(columnGap.base as SpaceScale | string | number, theme)
+          : undefined,
+      rowGap:
+        rowGap.base !== undefined
+          ? resolveSpaceValue(rowGap.base as SpaceScale | string | number, theme)
+          : undefined,
+      alignItems: mapGridAlign(align.base),
+      justifyItems: mapGridJustify(justify.base),
+      gridAutoFlow: autoFlow.base
+    }),
+    [
+      align.base,
+      autoFlow.base,
+      columnGap.base,
+      columns.base,
+      gap.base,
+      inline,
+      justify.base,
+      resolvedAreas,
+      rowGap.base,
+      rows.base,
+      theme
+    ]
+  );
+
+  const responsiveRules = useMemo(
+    () =>
+      (Object.keys(BREAKPOINTS) as Breakpoint[]).map((breakpoint) => {
+        const styles: Partial<CSSProperties> = {
+          gridTemplateColumns:
+            columns[breakpoint] !== undefined
+              ? resolveColumns(columns[breakpoint] as number | string)
+              : undefined,
+          gridTemplateRows:
+            rows[breakpoint] !== undefined ? resolveRows(rows[breakpoint] as number | string) : undefined,
+          gap:
+            gap[breakpoint] !== undefined
+              ? resolveSpaceValue(gap[breakpoint] as SpaceScale | string | number, theme)
+              : undefined,
+          columnGap:
+            columnGap[breakpoint] !== undefined
+              ? resolveSpaceValue(columnGap[breakpoint] as SpaceScale | string | number, theme)
+              : undefined,
+          rowGap:
+            rowGap[breakpoint] !== undefined
+              ? resolveSpaceValue(rowGap[breakpoint] as SpaceScale | string | number, theme)
+              : undefined,
+          alignItems: align[breakpoint] ? mapGridAlign(align[breakpoint] as GridAlign) : undefined,
+          justifyItems: justify[breakpoint] ? mapGridJustify(justify[breakpoint] as GridJustify) : undefined,
+          gridAutoFlow: autoFlow[breakpoint]
+        };
+
+        const rule = createRule(`.${generatedClassName}`, styles);
+        if (!rule) return "";
+
+        return `@media (min-width: ${toCSSValue(BREAKPOINTS[breakpoint])}px){${rule}}`;
+      }),
+    [align, autoFlow, columnGap, columns, generatedClassName, gap, justify, rowGap, rows, theme]
+  );
+
+  const cssText = useMemo(
+    () => [createRule(`.${generatedClassName}`, baseStyles), ...responsiveRules].filter(Boolean).join(""),
+    [baseStyles, generatedClassName, responsiveRules]
+  );
+
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: cssText }} />
+      <Component ref={ref} className={resolvedClassName} {...restProps}>
+        {children}
+      </Component>
+    </>
+  );
+});
+
+Grid.displayName = "Grid";

--- a/packages/react/src/components/layout/index.ts
+++ b/packages/react/src/components/layout/index.ts
@@ -1,2 +1,3 @@
 export { Flex, type FlexProps } from "./Flex.js";
+export { Grid, type GridProps } from "./Grid.js";
 export { Stack, type StackProps } from "./Stack.js";

--- a/packages/react/src/components/layout/shared.ts
+++ b/packages/react/src/components/layout/shared.ts
@@ -123,7 +123,7 @@ export function resolveSpaceValue(value: SpaceScale | string | number, theme: Th
   return "0px";
 }
 
-export function useLayoutClassName(component: "stack" | "flex"): string {
+export function useLayoutClassName(component: "stack" | "flex" | "grid"): string {
   const reactId = useId();
 
   return useMemo(() => {


### PR DESCRIPTION
## Summary
- [x] W-000007 / T-000062: Grid 레이아웃 컴포넌트를 추가해 컬럼/로우/areas/auto-flow 및 간격 토큰을 처리했습니다.
- [x] 반응형 프롭을 media query로 변환하고 grid 네임스페이스를 포함하도록 클래스 네임 생성기를 확장했습니다.
- [x] Grid 동작과 토큰 매핑을 검증하는 테스트를 추가했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/react test -- src/components/layout/Grid.test.tsx` (엔진 버전 경고: 현재 Node v20.19.5)

## Screenshots
해당 사항 없음.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d129acee8832288d2648e2ddcf652)