### PR TITLE
fix: artist_by_album 숫자형 이름 매칭 복구 (T-000063)

### DIFF
--- a/apps/api/src/artist/artist.service.ts
+++ b/apps/api/src/artist/artist.service.ts
@@ -1,0 +1,38 @@
+export type ArtistIdentifier = string | number;
+
+export interface AlbumRecord {
+  albumId: string | number;
+  albumTitle: string;
+  artistId: string | number;
+  artistName: string;
+}
+
+const isNumericString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value));
+
+const normalizeId = (artist: ArtistIdentifier): string | null => {
+  if (typeof artist === "number") return String(artist);
+  return isNumericString(artist) ? artist.trim() : null;
+};
+
+/**
+ * 앨범 목록에서 특정 아티스트의 레코드만 필터링한다.
+ *
+ * 기존에는 아티스트 이름 문자열만 허용했지만, 이제 숫자/문자열 형태의 ID도
+ * 함께 받아 동일하게 처리한다. 숫자형 문자열(예: "42")도 ID로 취급하되,
+ * 이름이 숫자로만 구성된 아티스트도 기존처럼 매칭한다.
+ */
+export const artist_by_album = (
+  albums: AlbumRecord[],
+  artist: ArtistIdentifier,
+): AlbumRecord[] => {
+  const normalizedId = normalizeId(artist);
+  const normalizedName = String(artist).trim();
+
+  return albums.filter(({ artistId, artistName }) => {
+    const matchesId = normalizedId !== null && String(artistId) === normalizedId;
+    const matchesName = artistName === normalizedName;
+
+    return matchesId || matchesName;
+  });
+};


### PR DESCRIPTION
## Summary
- [x] artist_by_album가 숫자로만 구성된 아티스트 이름도 기존처럼 매칭하도록 ID/이름 병합 비교 로직을 추가했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (T-000063 / W-000007)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다. (해당 없음)
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.** (없음)

## Testing
- [ ] 관련 스크립트나 테스트를 실행했습니다. (`pnpm test`, `pnpm lint` 등)
- 테스트 실행하지 않음 (단순 필터 조건 수정)

## Screenshots
없음

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d15646d948322a0f9758e9e89e494)