### PR TITLE
T-000064: 레이아웃 RTL 접근성 보강

### DIFF
--- a/packages/react/src/components/layout/Flex.test.tsx
+++ b/packages/react/src/components/layout/Flex.test.tsx
@@ -74,4 +74,22 @@ describe("Flex", () => {
     expect(element.tagName).toBe("SECTION");
     expect(getComputedStyle(element).display).toBe("inline-flex");
   });
+
+  it("RTL 방향에서도 논리적 정렬과 간격을 유지한다", () => {
+    const { getByTestId } = render(
+      <Flex direction="row" gap="md" justify="end" align="start" dir="rtl" data-testid="flex">
+        <span>왼쪽</span>
+        <span>오른쪽</span>
+      </Flex>
+    );
+
+    const element = getByTestId("flex");
+    const style = getComputedStyle(element);
+
+    expect(element.getAttribute("dir")).toBe("rtl");
+    expect(style.flexDirection).toBe("row");
+    expect(style.gap).toBe(defaultTheme.layout.space.md);
+    expect(style.justifyContent).toBe("flex-end");
+    expect(style.alignItems).toBe("flex-start");
+  });
 });

--- a/packages/react/src/components/layout/Grid.test.tsx
+++ b/packages/react/src/components/layout/Grid.test.tsx
@@ -109,4 +109,22 @@ describe("Grid", () => {
     expect(style.display).toBe("inline-grid");
     expect(style.gridTemplateAreas).toBe('"header header" "main sidebar"');
   });
+
+  it("RTL 방향에서도 간격과 정렬을 유지한다", () => {
+    const { getByTestId } = render(
+      <Grid columns={2} gap="sm" justify="end" align="start" dir="rtl" data-testid="grid">
+        <span>1</span>
+        <span>2</span>
+      </Grid>
+    );
+
+    const element = getByTestId("grid");
+    const style = getComputedStyle(element);
+
+    expect(element.getAttribute("dir")).toBe("rtl");
+    expect(style.gridTemplateColumns).toBe("repeat(2, minmax(0, 1fr))");
+    expect(style.gap).toBe(defaultTheme.layout.space.sm);
+    expect(style.justifyItems).toBe("end");
+    expect(style.alignItems).toBe("start");
+  });
 });

--- a/packages/react/src/components/layout/Stack.test.tsx
+++ b/packages/react/src/components/layout/Stack.test.tsx
@@ -47,7 +47,32 @@ describe("Stack", () => {
       </Stack>
     );
 
-    expect(getAllByTestId("divider")).toHaveLength(2);
+    const dividers = getAllByTestId("divider");
+
+    expect(dividers).toHaveLength(2);
+    dividers.forEach((element) => {
+      expect(element).toHaveAttribute("aria-hidden", "true");
+      expect(element).toHaveAttribute("role", "presentation");
+      expect(element).toHaveAttribute("tabindex", "-1");
+    });
+  });
+
+  it("RTL 방향에서도 논리적 정렬과 간격을 유지한다", () => {
+    const { getByTestId } = render(
+      <Stack direction="row" gap="md" justify="start" align="end" dir="rtl" data-testid="stack">
+        <span>왼쪽</span>
+        <span>오른쪽</span>
+      </Stack>
+    );
+
+    const element = getByTestId("stack");
+    const style = getComputedStyle(element);
+
+    expect(element.getAttribute("dir")).toBe("rtl");
+    expect(style.flexDirection).toBe("row");
+    expect(style.gap).toBe(defaultTheme.layout.space.md);
+    expect(style.justifyContent).toBe("flex-start");
+    expect(style.alignItems).toBe("flex-end");
   });
 
   it("반응형 프롭을 media query 규칙으로 출력한다", () => {

--- a/packages/react/src/components/layout/Stack.tsx
+++ b/packages/react/src/components/layout/Stack.tsx
@@ -55,7 +55,12 @@ function cloneDividerNode(divider: ReactNode, index: number): ReactNode {
   if (isValidElement(divider)) {
     const element = divider as ReactElement;
     const key = element.key ?? `divider-${index}`;
-    return cloneElement(element, { key });
+    return cloneElement(element, {
+      key,
+      role: element.props.role ?? "presentation",
+      tabIndex: element.props.tabIndex ?? -1,
+      "aria-hidden": element.props["aria-hidden"] ?? true
+    });
   }
 
   return (


### PR DESCRIPTION
## Summary
- [x] Stack divider에 aria-hidden/role/tabIndex 기본값을 설정해 포커스 흐름을 보호했습니다.
- [x] Stack/Flex/Grid에서 RTL 방향에서도 논리적 간격과 정렬이 유지되는지 검증하는 테스트를 추가했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (WBS: W-000007 / Task: T-000064)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.** (변경 없음)

## Testing
- [x] `pnpm --filter @ara/react test -- --runInBand`

## Screenshots
해당 사항 없음


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d300c48b08322b92c6a40ded456f3)