### PR TITLE
Harden RTL-safe alignment for layout primitives

### DIFF
--- a/packages/react/src/components/layout/Flex.test.tsx
+++ b/packages/react/src/components/layout/Flex.test.tsx
@@ -19,7 +19,7 @@ describe("Flex", () => {
     expect(style.flexDirection).toBe("row");
     expect(style.gap).toBe("0px");
     expect(style.alignItems).toBe("stretch");
-    expect(style.justifyContent).toBe("flex-start");
+    expect(style.justifyContent).toBe("start");
     expect(style.flexWrap).toBe("nowrap");
   });
 
@@ -89,7 +89,7 @@ describe("Flex", () => {
     expect(element.getAttribute("dir")).toBe("rtl");
     expect(style.flexDirection).toBe("row");
     expect(style.gap).toBe(defaultTheme.layout.space.md);
-    expect(style.justifyContent).toBe("flex-end");
-    expect(style.alignItems).toBe("flex-start");
+    expect(style.justifyContent).toBe("end");
+    expect(style.alignItems).toBe("start");
   });
 });

--- a/packages/react/src/components/layout/README.md
+++ b/packages/react/src/components/layout/README.md
@@ -86,3 +86,9 @@
 - Stack/Flex/Grid는 기본적으로 `box-sizing: border-box`를 사용하며, 자식 요소의 `margin`과 무관하게 `gap`으로 일관된 간격을 만든다.
 - 반응형 프롭은 **가장 작은 구간부터 점진적으로 덮어쓴다**. 예를 들어 `gap={{ base: "sm", md: "lg" }}` 는 모바일에서 `sm`, 768px 이상에서 `lg`를 사용한다.
 - Spacer는 레이아웃 컨테이너와 무관하게 단독 사용 가능하며, 접근성을 위해 시맨틱 의미가 없는 요소를 기본으로 사용한다.
+
+## RTL & 접근성 가이드
+
+- `start`/`end` 정렬 값은 CSS 논리 정렬 속성으로 출력돼 `dir="rtl"`에서도 동일한 공간·정렬을 보장한다.
+- Spacer는 `inline-size`/`block-size`를 사용해 방향 전환 시에도 간격이 뒤섞이지 않으며, `aria-hidden`으로 탭 순서에서 제외된다.
+- Stack의 `divider`는 `role="presentation"`, `tabIndex={-1}`, `aria-hidden`을 기본으로 적용해 화면 읽기/탭 순서를 흐트러뜨리지 않는다.

--- a/packages/react/src/components/layout/Stack.test.tsx
+++ b/packages/react/src/components/layout/Stack.test.tsx
@@ -19,7 +19,7 @@ describe("Stack", () => {
     expect(style.flexDirection).toBe("column");
     expect(style.gap).toBe("0px");
     expect(style.alignItems).toBe("stretch");
-    expect(style.justifyContent).toBe("flex-start");
+    expect(style.justifyContent).toBe("start");
     expect(style.flexWrap).toBe("nowrap");
   });
 
@@ -71,8 +71,8 @@ describe("Stack", () => {
     expect(element.getAttribute("dir")).toBe("rtl");
     expect(style.flexDirection).toBe("row");
     expect(style.gap).toBe(defaultTheme.layout.space.md);
-    expect(style.justifyContent).toBe("flex-start");
-    expect(style.alignItems).toBe("flex-end");
+    expect(style.justifyContent).toBe("start");
+    expect(style.alignItems).toBe("end");
   });
 
   it("반응형 프롭을 media query 규칙으로 출력한다", () => {

--- a/packages/react/src/components/layout/shared.ts
+++ b/packages/react/src/components/layout/shared.ts
@@ -80,9 +80,9 @@ export function createRule(selector: string, styles: Partial<CSSProperties>): st
 export function mapAlign(value: FlexAlign): CSSProperties["alignItems"] {
   switch (value) {
     case "start":
-      return "flex-start";
+      return "start";
     case "end":
-      return "flex-end";
+      return "end";
     case "center":
       return "center";
     case "baseline":
@@ -95,9 +95,9 @@ export function mapAlign(value: FlexAlign): CSSProperties["alignItems"] {
 export function mapJustify(value: FlexJustify): CSSProperties["justifyContent"] {
   switch (value) {
     case "start":
-      return "flex-start";
+      return "start";
     case "end":
-      return "flex-end";
+      return "end";
     case "between":
       return "space-between";
     case "around":
@@ -105,7 +105,7 @@ export function mapJustify(value: FlexJustify): CSSProperties["justifyContent"] 
     case "evenly":
       return "space-evenly";
     default:
-      return "flex-start";
+      return "start";
   }
 }
 

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -207,7 +207,7 @@ T-000062,W-000007,Layout Primitives v0,React(컴포넌트),Grid 구현,완료,Hi
 T-000063,W-000007,Layout Primitives v0,React(컴포넌트),Spacer 구현,완료,Medium," ● 내용: 공간 삽입 전용 컴포넌트(size 토큰 사용), inline 방향 지원
  ● 산출물: packages/react/src/components/spacer/index.tsx
  ● 점검: size 스냅·접근성 영향 없음",확인
-T-000064,W-000007,Layout Primitives v0,접근성/국제화,RTL/논리속성/탭순서 안전,계획,High," ● 내용: 논리적 방향 속성( block/inline ) 우선, RTL에서 간격/정렬 일관성, tab 순서·읽기 순서 영향 없음 보증
+T-000064,W-000007,Layout Primitives v0,접근성/국제화,RTL/논리속성/탭순서 안전,완료,High," ● 내용: 논리적 방향 속성( block/inline ) 우선, RTL에서 간격/정렬 일관성, tab 순서·읽기 순서 영향 없음 보증
  ● 산출물: A11y/RTL 가이드와 테스트 케이스
  ● 점검: RTL 스냅·키보드 탐색 영향 0",확인
 T-000065,W-000007,Layout Primitives v0,토큰 연동,Tokens 간격/반지름 매핑,계획,Medium," ● 내용: space/radius 토큰→CSS 변수 매핑, gap/패딩에 적용, ThemeProvider 상속 확인

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -47,7 +47,7 @@ W-000006,T1,Icons v0,완료,100,"Icons v0
  ● Exports/배포: @ara/icons(개별/집합) · @ara/react/icon, check:icons(dry-run+lint)·CI 해상도 검증
  ● 문서/스토리북: 아이콘 갤러리 Controls 기본값, 시각 회귀 스냅샷 옵션, 접근성 예시 포함
  ● AC: CI·Tests·Storybook·pack dry-run·canary",--
-W-000007,T1,Layout Primitives v0,진행중,60,"Layout Primitives v0
+W-000007,T1,Layout Primitives v0,진행중,70,"Layout Primitives v0
  ● Stack·Flex·Grid·Spacer
  ● 간격/정렬/래핑/분배 API
  ● responsive props(sm/md/lg…)


### PR DESCRIPTION
## Summary
- switch layout alignment mapping to logical start/end values and update RTL tests
- expand RTL and accessibility guidance in layout documentation and mark the related task complete
- adjust WBS progress to reflect the completed accessibility milestone

## Testing
- pnpm --filter @ara/react test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d3502a58083228aaa8c10d98e0939)