### PR TITLE
T-000066: 레이아웃 class/style 우선 테스트 보강

### DIFF
--- a/packages/react/src/components/layout/Flex.test.tsx
+++ b/packages/react/src/components/layout/Flex.test.tsx
@@ -107,4 +107,26 @@ describe("Flex", () => {
     expect(style.justifyContent).toBe("flex-start");
     expect(style.gap).toBe(`var(--ara-space-sm, ${defaultTheme.layout.space.sm})`);
   });
+
+  it("사용자 className과 인라인 스타일이 기본 규칙보다 우선한다", () => {
+    const { getByTestId } = render(
+      <Flex
+        data-testid="flex"
+        className="custom-flex"
+        style={{ gap: "12px", flexDirection: "column" }}
+      >
+        <span>첫째</span>
+        <span>둘째</span>
+      </Flex>
+    );
+
+    const element = getByTestId("flex");
+    const style = getComputedStyle(element);
+    const classNames = element.className.split(" ");
+
+    expect(classNames).toEqual(expect.arrayContaining(["ara-flex", "custom-flex"]));
+    expect(classNames.some((name) => /^ara-flex-[\w-]+$/.test(name))).toBe(true);
+    expect(style.gap).toBe("12px");
+    expect(style.flexDirection).toBe("column");
+  });
 });

--- a/packages/react/src/components/layout/Grid.test.tsx
+++ b/packages/react/src/components/layout/Grid.test.tsx
@@ -127,4 +127,26 @@ describe("Grid", () => {
     expect(style.justifyItems).toBe("end");
     expect(style.alignItems).toBe("start");
   });
+
+  it("className 병합과 인라인 style 우선순위를 보장한다", () => {
+    const { getByTestId } = render(
+      <Grid
+        data-testid="grid"
+        className="custom-grid"
+        style={{ gridTemplateColumns: "auto 1fr", gap: "5px" }}
+      >
+        <span>1</span>
+        <span>2</span>
+      </Grid>
+    );
+
+    const element = getByTestId("grid");
+    const style = getComputedStyle(element);
+    const classNames = element.className.split(" ");
+
+    expect(classNames).toEqual(expect.arrayContaining(["ara-grid", "custom-grid"]));
+    expect(classNames.some((name) => /^ara-grid-[\w-]+$/.test(name))).toBe(true);
+    expect(style.gridTemplateColumns).toBe("auto 1fr");
+    expect(style.gap).toBe("5px");
+  });
 });


### PR DESCRIPTION
## Summary
- [x] 레이아웃 프리미티브(Flex, Grid)에서 className 병합과 인라인 스타일 우선순위를 검증하는 테스트를 추가했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/react test -- src/components/layout/Flex.test.tsx src/components/layout/Grid.test.tsx`

## Screenshots
필요 시 UI 변경 전/후 스크린샷 또는 캡처를 첨부합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d49577c9c8322860c70f6d2fe6789)