### PR TITLE
[T-000067] Layout 프리미티브 스토리/MDX 추가

### DIFF
--- a/apps/storybook/stories/components/Layout.docs.mdx
+++ b/apps/storybook/stories/components/Layout.docs.mdx
@@ -1,0 +1,47 @@
+import { Meta, Title, Subtitle, Description, Canvas, Primary, Controls, ArgsTable } from "@storybook/blocks";
+import * as LayoutStories from "./Layout.stories";
+
+<Meta of={LayoutStories} />
+
+<Title>Layout Primitives</Title>
+
+<Subtitle>Stack, Flex, Grid, Spacer를 사용해 간격과 정렬을 토큰 기반으로 구성합니다.</Subtitle>
+
+<Description>
+`@ara/react`의 레이아웃 프리미티브는 CSS 논리 프로퍼티와 반응형 속성을 우선으로 설계되었습니다. `gap`, `padding`, `wrap` 등 대부분의 간격은
+토큰을 통해 일관되게 적용할 수 있으며, `Responsive` 타입(`{ base, sm, md, lg }`)으로 뷰포트에 따라 유연하게 변합니다. RTL 환경에서도 동일한
+간격과 정렬을 유지합니다.
+</Description>
+
+## Playground (Stack)
+
+<Primary of={LayoutStories.Playground} />
+<Controls of={LayoutStories.Playground} />
+
+## Responsive
+
+`direction`, `gap`, `align`, `justify`, `wrap`은 모두 반응형 객체를 받을 수 있습니다. 아래 예시는 모바일에서 세로 스택, 데스크톱에서 가로 스택으로
+자동 전환합니다.
+
+<Canvas of={LayoutStories.ResponsiveStack} />
+
+## Patterns
+
+툴바, 카드 그리드처럼 자주 쓰는 패턴을 Flex/Grid로 조합할 수 있습니다. 버튼·입력 등 실제 컴포넌트를 그대로 배치하면 실제 레이아웃에 가까운
+간격을 검증할 수 있습니다.
+
+<Canvas of={LayoutStories.FlexToolbar} />
+<Canvas of={LayoutStories.GridCards} />
+
+## Spacer 활용
+
+컨테이너가 아닌 요소 사이에 간격만 필요할 때 `Spacer`를 사용합니다. `direction="inline"`으로 인라인 흐름에 맞춰 넣거나, `grow`/`shrink`로
+플렉스 컨텍스트에서 남는 공간을 채우는 세퍼레이터로도 활용할 수 있습니다.
+
+<Canvas of={LayoutStories.SpacerPatterns} />
+
+## Props
+
+Stack의 공통 props를 Controls로 조정하고, Flex/Grid는 `render` 예제를 참고하세요.
+
+<ArgsTable of={LayoutStories.Playground} />

--- a/apps/storybook/stories/components/Layout.stories.tsx
+++ b/apps/storybook/stories/components/Layout.stories.tsx
@@ -1,0 +1,190 @@
+import type { CSSProperties } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ArrowRight, Plus } from "@ara/icons";
+import { AraProvider, AraThemeBoundary, Button, Flex, Grid, Spacer, Stack } from "@ara/react";
+
+const boxStyle: CSSProperties = {
+  borderRadius: "0.75rem",
+  border: "1px solid var(--ara-color-border-weak, #e5e7eb)",
+  background: "var(--ara-color-surface-weak, #f9fafb)",
+  color: "var(--ara-color-text-strong, #0f172a)",
+  padding: "0.75rem 1rem",
+  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.7)"
+};
+
+const meta = {
+  title: "Components/Layout",
+  component: Stack,
+  subcomponents: { Flex, Grid, Spacer },
+  decorators: [
+    (Story) => (
+      <AraProvider>
+        <AraThemeBoundary>
+          <Story />
+        </AraThemeBoundary>
+      </AraProvider>
+    )
+  ],
+  parameters: {
+    layout: "padded"
+  },
+  args: {
+    direction: "column",
+    gap: "md",
+    align: "stretch",
+    justify: "start",
+    wrap: false,
+    inline: false
+  },
+  argTypes: {
+    direction: {
+      control: "select",
+      options: ["row", "row-reverse", "column", "column-reverse"]
+    },
+    gap: { control: "text" },
+    align: {
+      control: "select",
+      options: ["start", "center", "end", "stretch", "baseline"]
+    },
+    justify: {
+      control: "select",
+      options: ["start", "center", "end", "between", "around", "evenly"]
+    },
+    wrap: {
+      control: "select",
+      options: [false, "wrap", "wrap-reverse"]
+    },
+    inline: { control: "boolean" },
+    as: { control: false },
+    divider: { control: false }
+  },
+  tags: ["autodocs"]
+} satisfies Meta<typeof Stack>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const renderBoxes = (count = 4) =>
+  Array.from({ length: count }, (_, index) => (
+    <div key={index} style={boxStyle}>
+      영역 {index + 1}
+    </div>
+  ));
+
+export const Playground: Story = {
+  render: (args) => <Stack {...args}>{renderBoxes()}</Stack>
+};
+
+export const ResponsiveStack: Story = {
+  name: "Responsive Stack",
+  parameters: {
+    controls: { exclude: ["direction", "gap", "align", "justify", "wrap", "inline"] }
+  },
+  render: () => (
+    <Stack
+      direction={{ base: "column", md: "row" }}
+      gap={{ base: "md", md: "xl" }}
+      align={{ base: "stretch", md: "center" }}
+      justify={{ base: "start", md: "between" }}
+      wrap={{ base: true, md: false }}
+    >
+      {renderBoxes(3)}
+    </Stack>
+  )
+};
+
+export const FlexToolbar: Story = {
+  name: "Toolbar (Flex)",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Flex
+      align={{ base: "stretch", sm: "center" }}
+      justify="between"
+      gap="md"
+      wrap
+      style={{ border: "1px solid var(--ara-color-border-weak, #e5e7eb)", padding: "1rem", borderRadius: "0.75rem" }}
+    >
+      <Stack direction={{ base: "column", sm: "row" }} gap="sm" align={{ base: "start", sm: "center" }}>
+        <div style={{ fontWeight: 600 }}>프로젝트</div>
+        <Stack direction="row" gap="sm" align="center">
+          <div style={boxStyle}>상태 필터</div>
+          <div style={boxStyle}>정렬</div>
+        </Stack>
+      </Stack>
+      <Flex gap="sm" align="center" wrap={{ base: true, sm: false }} justify="end">
+        <Button variant="outline" tone="neutral">
+          필터 저장
+        </Button>
+        <Button leadingIcon={<Plus aria-hidden />}>
+          새 항목
+        </Button>
+      </Flex>
+    </Flex>
+  )
+};
+
+export const GridCards: Story = {
+  name: "Card Grid",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Grid columns={{ base: 1, sm: 2, md: 3 }} gap="lg" align="stretch">
+      {Array.from({ length: 6 }, (_, index) => (
+        <Stack
+          key={index}
+          gap="sm"
+          style={{
+            ...boxStyle,
+            height: "100%",
+            boxShadow: "0 10px 30px rgba(15, 23, 42, 0.08)",
+            background: "var(--ara-color-surface-strong, #fff)"
+          }}
+        >
+          <div style={{ fontSize: "1.05rem", fontWeight: 600 }}>카드 #{index + 1}</div>
+          <div style={{ color: "var(--ara-color-text-muted, #475569)" }}>
+            반응형 `columns`를 이용해 뷰포트 크기에 따라 열 수를 조절합니다. `gap`, `rowGap`, `columnGap`은
+            레이아웃 토큰을 그대로 사용합니다.
+          </div>
+          <Flex gap="sm" align="center" wrap>
+            <Button variant="ghost" size="sm" tone="neutral">
+              자세히
+            </Button>
+            <Button size="sm" trailingIcon={<ArrowRight aria-hidden />}>
+              이동
+            </Button>
+          </Flex>
+        </Stack>
+      ))}
+    </Grid>
+  )
+};
+
+export const SpacerPatterns: Story = {
+  name: "Spacer Patterns",
+  args: {
+    direction: "row",
+    gap: "sm",
+    align: "center",
+    justify: "start"
+  },
+  parameters: {
+    controls: { exclude: ["wrap", "inline", "divider", "as"] }
+  },
+  render: (args) => (
+    <Stack {...args} wrap>
+      <Button variant="outline" tone="neutral">
+        기본 액션
+      </Button>
+      <Spacer size="md" />
+      <Button tone="neutral" variant="ghost">
+        보조 액션
+      </Button>
+      <Spacer size={24} direction="inline" inline />
+      <span style={{ color: "var(--ara-color-text-muted, #475569)" }}>텍스트 사이에도 인라인 Spacer를 넣을 수 있습니다.</span>
+    </Stack>
+  )
+};


### PR DESCRIPTION
## Summary
- [x] Stack/Flex/Grid/Spacer 스토리를 추가하고 Playground/Controls를 노출했습니다.
- [x] 반응형 스택, 툴바, 카드 그리드, Spacer 활용 패턴을 MDX로 문서화했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm -C apps/storybook build-storybook`

## Screenshots
- 해당 사항 없음


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d4b9897c08322b12e78030dbec082)