### PR TITLE
[T-000067] 레이아웃 direction 직관화(orientation) 추가

### DIFF
--- a/apps/storybook/stories/components/Layout.docs.mdx
+++ b/apps/storybook/stories/components/Layout.docs.mdx
@@ -1,0 +1,63 @@
+import { Meta, Title, Subtitle, Description, Canvas, Primary, Controls, ArgsTable } from "@storybook/blocks";
+import * as LayoutStories from "./Layout.stories";
+
+<Meta of={LayoutStories} />
+
+<Title>Layout Primitives</Title>
+
+<Subtitle>Stack, Flex, Grid, Spacer를 사용해 간격과 정렬을 토큰 기반으로 구성합니다.</Subtitle>
+
+<Description>
+`@ara/react`의 레이아웃 프리미티브는 CSS 논리 프로퍼티와 반응형 속성을 우선으로 설계되었습니다. `gap`, `padding`, `wrap` 등 대부분의 간격은
+토큰을 통해 일관되게 적용할 수 있으며, `Responsive` 타입(`{ base, sm, md, lg }`)으로 뷰포트에 따라 유연하게 변합니다. RTL 환경에서도 동일한
+간격과 정렬을 유지합니다.
+
+`orientation` prop에서 **horizontal / vertical**처럼 직관적인 이름을 선택하거나, CSS Flexbox 명칭을 그대로 쓸 때는 `direction`으로 `row` / `column`을 전달할
+ 수 있습니다. 두 prop은 동일하게 동작하며, 논리 축(inline/block) 기준으로 스타일을 계산합니다.
+
+- orientation: `horizontal`(row), `horizontal-reverse`(row-reverse), `vertical`(column), `vertical-reverse`(column-reverse)
+- direction: Flexbox 명칭 그대로(`row`, `column` 등). 예상한 방향과 다르면 페이지의 `writing-mode`(세로쓰기인지)나 RTL 여부를 확인해주세요.
+
+### Row vs Column
+
+- `row`: 가로(인라인) 축 정렬. LTR 기준 좌→우 순서로 나란히 배치됩니다.
+- `column`: 세로(블록) 축 정렬. 위→아래로 쌓이며, 상단 영역이 첫 번째 아이템입니다.
+
+Canvas 기본 예제의 `direction="column"` 상태는 세로 스택(위→아래)이며, `row`로 바꾸면 가로 스택(좌→우)으로 바뀝니다. 논리 축을 사용하므로 RTL에서는 `row`가 우→좌로, `column`은 동일하게 위→아래로 정렬됩니다.
+</Description>
+
+<Canvas of={LayoutStories.DirectionShowcase} />
+<Canvas of={LayoutStories.LogicalAxisLegend} />
+
+## Playground (Stack)
+
+<Primary of={LayoutStories.Playground} />
+<Controls of={LayoutStories.Playground} />
+
+## Responsive
+
+`direction`, `gap`, `align`, `justify`, `wrap`은 모두 반응형 객체를 받을 수 있습니다. 아래 예시는 모바일에서 세로 스택, 데스크톱에서 가로 스택으로
+자동 전환합니다.
+
+<Canvas of={LayoutStories.ResponsiveStack} />
+
+## Patterns
+
+툴바, 카드 그리드처럼 자주 쓰는 패턴을 Flex/Grid로 조합할 수 있습니다. 버튼·입력 등 실제 컴포넌트를 그대로 배치하면 실제 레이아웃에 가까운
+간격을 검증할 수 있습니다.
+
+<Canvas of={LayoutStories.FlexToolbar} />
+<Canvas of={LayoutStories.GridCards} />
+
+## Spacer 활용
+
+컨테이너가 아닌 요소 사이에 간격만 필요할 때 `Spacer`를 사용합니다. `direction="inline"`으로 인라인 흐름에 맞춰 넣거나, `grow`/`shrink`로
+플렉스 컨텍스트에서 남는 공간을 채우는 세퍼레이터로도 활용할 수 있습니다.
+
+<Canvas of={LayoutStories.SpacerPatterns} />
+
+## Props
+
+Stack의 공통 props를 Controls로 조정하고, Flex/Grid는 `render` 예제를 참고하세요.
+
+<ArgsTable of={LayoutStories.Playground} />

--- a/apps/storybook/stories/components/Layout.stories.tsx
+++ b/apps/storybook/stories/components/Layout.stories.tsx
@@ -1,0 +1,255 @@
+import type { CSSProperties } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ArrowRight, Plus } from "@ara/icons";
+import { AraProvider, AraThemeBoundary, Button, Flex, Grid, Spacer, Stack } from "@ara/react";
+
+const boxStyle: CSSProperties = {
+  borderRadius: "0.75rem",
+  border: "1px solid var(--ara-color-border-weak, #e5e7eb)",
+  background: "var(--ara-color-surface-weak, #f9fafb)",
+  color: "var(--ara-color-text-strong, #0f172a)",
+  padding: "0.75rem 1rem",
+  boxShadow: "inset 0 1px 0 rgba(255,255,255,0.7)"
+};
+
+const meta = {
+  title: "Components/Layout",
+  component: Stack,
+  subcomponents: { Flex, Grid, Spacer },
+  decorators: [
+    (Story) => (
+      <AraProvider>
+        <AraThemeBoundary>
+          <Story />
+        </AraThemeBoundary>
+      </AraProvider>
+    )
+  ],
+  parameters: {
+    layout: "padded"
+  },
+  args: {
+    orientation: "vertical",
+    gap: "md",
+    align: "stretch",
+    justify: "start",
+    wrap: false,
+    inline: false
+  },
+  argTypes: {
+    orientation: {
+      control: "select",
+      options: ["horizontal", "horizontal-reverse", "vertical", "vertical-reverse"]
+    },
+    direction: { control: false },
+    gap: { control: "text" },
+    align: {
+      control: "select",
+      options: ["start", "center", "end", "stretch", "baseline"]
+    },
+    justify: {
+      control: "select",
+      options: ["start", "center", "end", "between", "around", "evenly"]
+    },
+    wrap: {
+      control: "select",
+      options: [false, "wrap", "wrap-reverse"]
+    },
+    inline: { control: "boolean" },
+    as: { control: false },
+    divider: { control: false }
+  },
+  tags: ["autodocs"]
+} satisfies Meta<typeof Stack>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const renderBoxes = (count = 4) =>
+  Array.from({ length: count }, (_, index) => (
+    <div key={index} style={boxStyle}>
+      영역 {index + 1}
+    </div>
+  ));
+
+const axisCardStyle: CSSProperties = {
+  borderRadius: "0.75rem",
+  border: "1px dashed var(--ara-color-border-weak, #e5e7eb)",
+  background: "var(--ara-color-surface-weak, #f8fafc)",
+  padding: "0.75rem 1rem",
+  width: "100%",
+  minWidth: "220px"
+};
+
+export const Playground: Story = {
+  render: (args) => <Stack {...args}>{renderBoxes()}</Stack>
+};
+
+export const DirectionShowcase: Story = {
+  name: "Orientation (직관 이름)",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack gap="lg">
+      <Stack gap="xs">
+        <div style={{ fontWeight: 600 }}>orientation="horizontal"</div>
+        <Stack orientation="horizontal" gap="sm" align="center">
+          {renderBoxes()}
+        </Stack>
+      </Stack>
+      <Stack gap="xs">
+        <div style={{ fontWeight: 600 }}>orientation="vertical"</div>
+        <Stack orientation="vertical" gap="sm">
+          {renderBoxes()}
+        </Stack>
+      </Stack>
+    </Stack>
+  )
+};
+
+export const LogicalAxisLegend: Story = {
+  name: "Inline / Block 축 설명",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack gap="md">
+      <div style={{ fontWeight: 600 }}>
+        Flexbox naming은 논리 축(inline/block) 기준입니다. 글쓰기 방향이 바뀌면 축의 화살표도 함께 바뀝니다. 직관적인 `orientation`
+        prop으로도 같은 축을 설정할 수 있습니다.
+      </div>
+      <Stack direction="row" gap="md" wrap>
+        <Stack gap="xs" style={axisCardStyle}>
+          <div style={{ fontWeight: 600 }}>row = inline axis</div>
+          <div style={{ color: "var(--ara-color-text-muted, #475569)" }}>
+            LTR: 좌 → 우 · RTL: 우 → 좌. 인라인 축을 따라 콘텐츠가 이어집니다.
+          </div>
+        </Stack>
+        <Stack gap="xs" style={axisCardStyle}>
+          <div style={{ fontWeight: 600 }}>column = block axis</div>
+          <div style={{ color: "var(--ara-color-text-muted, #475569)" }}>
+            `horizontal-tb`에서는 위 → 아래. 세로쓰기(`vertical-rl` 등)에서는 글 흐름을 따라 오른쪽 → 왼쪽으로 내려갑니다.
+          </div>
+        </Stack>
+      </Stack>
+      <div style={{ color: "var(--ara-color-text-muted, #475569)" }}>
+        컬럼이 가로를 의미하는 표/그리드 용어와 달리, Flexbox에서는 inline/block 논리 축을 기준으로 이름이 붙었습니다.
+      </div>
+    </Stack>
+  )
+};
+
+export const ResponsiveStack: Story = {
+  name: "Responsive Stack",
+  parameters: {
+    controls: { exclude: ["orientation", "gap", "align", "justify", "wrap", "inline"] }
+  },
+  render: () => (
+    <Stack
+      orientation={{ base: "vertical", md: "horizontal" }}
+      gap={{ base: "md", md: "xl" }}
+      align={{ base: "stretch", md: "center" }}
+      justify={{ base: "start", md: "between" }}
+      wrap={{ base: true, md: false }}
+    >
+      {renderBoxes(3)}
+    </Stack>
+  )
+};
+
+export const FlexToolbar: Story = {
+  name: "Toolbar (Flex)",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Flex
+      align={{ base: "stretch", sm: "center" }}
+      justify="between"
+      gap="md"
+      wrap
+      style={{ border: "1px solid var(--ara-color-border-weak, #e5e7eb)", padding: "1rem", borderRadius: "0.75rem" }}
+    >
+      <Stack orientation={{ base: "vertical", sm: "horizontal" }} gap="sm" align={{ base: "start", sm: "center" }}>
+        <div style={{ fontWeight: 600 }}>프로젝트</div>
+        <Stack direction="row" gap="sm" align="center">
+          <div style={boxStyle}>상태 필터</div>
+          <div style={boxStyle}>정렬</div>
+        </Stack>
+      </Stack>
+      <Flex gap="sm" align="center" wrap={{ base: true, sm: false }} justify="end">
+        <Button variant="outline" tone="neutral">
+          필터 저장
+        </Button>
+        <Button leadingIcon={<Plus aria-hidden />}>
+          새 항목
+        </Button>
+      </Flex>
+    </Flex>
+  )
+};
+
+export const GridCards: Story = {
+  name: "Card Grid",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Grid columns={{ base: 1, sm: 2, md: 3 }} gap="lg" align="stretch">
+      {Array.from({ length: 6 }, (_, index) => (
+        <Stack
+          key={index}
+          gap="sm"
+          style={{
+            ...boxStyle,
+            height: "100%",
+            boxShadow: "0 10px 30px rgba(15, 23, 42, 0.08)",
+            background: "var(--ara-color-surface-strong, #fff)"
+          }}
+        >
+          <div style={{ fontSize: "1.05rem", fontWeight: 600 }}>카드 #{index + 1}</div>
+          <div style={{ color: "var(--ara-color-text-muted, #475569)" }}>
+            반응형 `columns`를 이용해 뷰포트 크기에 따라 열 수를 조절합니다. `gap`, `rowGap`, `columnGap`은
+            레이아웃 토큰을 그대로 사용합니다.
+          </div>
+          <Flex gap="sm" align="center" wrap>
+            <Button variant="ghost" size="sm" tone="neutral">
+              자세히
+            </Button>
+            <Button size="sm" trailingIcon={<ArrowRight aria-hidden />}>
+              이동
+            </Button>
+          </Flex>
+        </Stack>
+      ))}
+    </Grid>
+  )
+};
+
+export const SpacerPatterns: Story = {
+  name: "Spacer Patterns",
+  args: {
+    orientation: "horizontal",
+    gap: "sm",
+    align: "center",
+    justify: "start"
+  },
+  parameters: {
+    controls: { exclude: ["wrap", "inline", "divider", "as"] }
+  },
+  render: (args) => (
+    <Stack {...args} wrap>
+      <Button variant="outline" tone="neutral">
+        기본 액션
+      </Button>
+      <Spacer size="md" />
+      <Button tone="neutral" variant="ghost">
+        보조 액션
+      </Button>
+      <Spacer size={24} direction="inline" inline />
+      <span style={{ color: "var(--ara-color-text-muted, #475569)" }}>텍스트 사이에도 인라인 Spacer를 넣을 수 있습니다.</span>
+    </Stack>
+  )
+};

--- a/packages/react/src/components/layout/Flex.tsx
+++ b/packages/react/src/components/layout/Flex.tsx
@@ -13,6 +13,7 @@ import {
   type Breakpoint,
   type FlexAlign,
   type FlexDirection,
+  type FlexOrientation,
   type FlexJustify,
   type FlexWrap,
   type Responsive,
@@ -22,6 +23,7 @@ import {
   mapJustify,
   mapWrap,
   mergeClassNames,
+  normalizeDirection,
   normalizeResponsiveValue,
   resolveSpaceValue,
   useLayoutClassName
@@ -30,6 +32,7 @@ import {
 interface FlexOwnProps<T extends ElementType = "div"> {
   readonly as?: T;
   readonly direction?: Responsive<FlexDirection>;
+  readonly orientation?: Responsive<FlexOrientation>;
   readonly gap?: Responsive<SpaceScale | string | number>;
   readonly align?: Responsive<FlexAlign>;
   readonly justify?: Responsive<FlexJustify>;
@@ -53,6 +56,7 @@ export const Flex = forwardRef(function Flex<T extends ElementType = "div">(
   const {
     as,
     direction: directionProp,
+    orientation: orientationProp,
     gap: gapProp,
     align: alignProp,
     justify: justifyProp,
@@ -68,8 +72,8 @@ export const Flex = forwardRef(function Flex<T extends ElementType = "div">(
   const generatedClassName = useLayoutClassName("flex");
 
   const direction = useMemo(
-    () => normalizeResponsiveValue<FlexDirection>(directionProp, "row"),
-    [directionProp]
+    () => normalizeDirection(directionProp, orientationProp, "row", "horizontal"),
+    [directionProp, orientationProp]
   );
   const gap = useMemo(
     () => normalizeResponsiveValue<SpaceScale | string | number>(gapProp, 0),

--- a/packages/react/src/components/layout/Stack.tsx
+++ b/packages/react/src/components/layout/Stack.tsx
@@ -17,6 +17,7 @@ import {
   type Breakpoint,
   type FlexAlign,
   type FlexDirection,
+  type FlexOrientation,
   type FlexJustify,
   type FlexWrap,
   type Responsive,
@@ -26,6 +27,7 @@ import {
   mapJustify,
   mapWrap,
   mergeClassNames,
+  normalizeDirection,
   normalizeResponsiveValue,
   resolveSpaceValue,
   useLayoutClassName
@@ -39,6 +41,7 @@ type StackWrap = FlexWrap;
 interface StackOwnProps<T extends ElementType = "div"> {
   readonly as?: T;
   readonly direction?: Responsive<StackDirection>;
+  readonly orientation?: Responsive<FlexOrientation>;
   readonly gap?: Responsive<SpaceScale | string | number>;
   readonly align?: Responsive<StackAlign>;
   readonly justify?: Responsive<StackJustify>;
@@ -97,6 +100,7 @@ export const Stack = forwardRef(function Stack<T extends ElementType = "div">(
   const {
     as,
     direction: directionProp,
+    orientation: orientationProp,
     gap: gapProp,
     align: alignProp,
     justify: justifyProp,
@@ -113,8 +117,8 @@ export const Stack = forwardRef(function Stack<T extends ElementType = "div">(
   const generatedClassName = useLayoutClassName("stack");
 
   const direction = useMemo(
-    () => normalizeResponsiveValue<StackDirection>(directionProp, "column"),
-    [directionProp]
+    () => normalizeDirection(directionProp, orientationProp, "column", "vertical"),
+    [directionProp, orientationProp]
   );
   const gap = useMemo(
     () => normalizeResponsiveValue<SpaceScale | string | number>(gapProp, 0),

--- a/packages/react/src/components/layout/shared.ts
+++ b/packages/react/src/components/layout/shared.ts
@@ -22,6 +22,7 @@ export type Responsive<T> =
 export type ResponsiveMap<T> = { base: T; sm?: T; md?: T; lg?: T };
 
 export type FlexDirection = "row" | "row-reverse" | "column" | "column-reverse";
+export type FlexOrientation = "horizontal" | "horizontal-reverse" | "vertical" | "vertical-reverse";
 export type FlexAlign = "start" | "center" | "end" | "stretch" | "baseline";
 export type FlexJustify = "start" | "center" | "end" | "between" | "around" | "evenly";
 export type FlexWrap = false | "wrap" | "wrap-reverse";
@@ -56,6 +57,39 @@ export function normalizeResponsiveValue<T>(value: Responsive<T> | undefined, fa
   }
 
   return { base: (value ?? fallback) as T };
+}
+
+function mapOrientationToDirection(value: FlexOrientation): FlexDirection {
+  switch (value) {
+    case "horizontal":
+      return "row";
+    case "horizontal-reverse":
+      return "row-reverse";
+    case "vertical-reverse":
+      return "column-reverse";
+    case "vertical":
+    default:
+      return "column";
+  }
+}
+
+export function normalizeDirection(
+  direction: Responsive<FlexDirection> | undefined,
+  orientation: Responsive<FlexOrientation> | undefined,
+  defaultDirection: FlexDirection,
+  defaultOrientation: FlexOrientation
+): ResponsiveMap<FlexDirection> {
+  if (orientation !== undefined) {
+    const normalizedOrientation = normalizeResponsiveValue<FlexOrientation>(orientation, defaultOrientation);
+    return {
+      base: mapOrientationToDirection(normalizedOrientation.base),
+      sm: normalizedOrientation.sm ? mapOrientationToDirection(normalizedOrientation.sm) : undefined,
+      md: normalizedOrientation.md ? mapOrientationToDirection(normalizedOrientation.md) : undefined,
+      lg: normalizedOrientation.lg ? mapOrientationToDirection(normalizedOrientation.lg) : undefined
+    };
+  }
+
+  return normalizeResponsiveValue<FlexDirection>(direction, defaultDirection);
 }
 
 export function toCSSValue(value: string | number | undefined): string | undefined {


### PR DESCRIPTION
## Summary
- [x] `orientation` prop을 Stack/Flex에 추가해 horizontal/vertical 기반으로 방향을 지정하도록 했습니다.
- [x] 스토리/문서 기본 컨트롤을 orientation으로 전환해 row/column 혼동 없이 방향을 선택할 수 있게 했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [ ] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.

## Testing
- [ ] 관련 스크립트나 테스트를 실행했습니다. (`pnpm test`, `pnpm lint` 등)
- [ ] 테스트 결과를 아래에 기재했습니다.

## Screenshots
필요 시 UI 변경 전/후 스크린샷 또는 캡처를 첨부합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d4b9897c08322b12e78030dbec082)