### PR TITLE
Escape quotes in Layout story text

### DIFF
--- a/apps/storybook/stories/components/Layout.stories.tsx
+++ b/apps/storybook/stories/components/Layout.stories.tsx
@@ -97,13 +97,13 @@ export const DirectionShowcase: Story = {
   render: () => (
     <Stack gap="lg">
       <Stack gap="xs">
-        <div style={{ fontWeight: 600 }}>orientation="horizontal"</div>
+        <div style={{ fontWeight: 600 }}>orientation=&quot;horizontal&quot;</div>
         <Stack orientation="horizontal" gap="sm" align="center">
           {renderBoxes()}
         </Stack>
       </Stack>
       <Stack gap="xs">
-        <div style={{ fontWeight: 600 }}>orientation="vertical"</div>
+        <div style={{ fontWeight: 600 }}>orientation=&quot;vertical&quot;</div>
         <Stack orientation="vertical" gap="sm">
           {renderBoxes()}
         </Stack>


### PR DESCRIPTION
## Summary
- escape double quotes in the DirectionShowcase story labels to satisfy eslint no-unescaped-entities

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d5c54ec6c8322957debcdd45162a1)