### PR TITLE
Update layout documentation task status

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -216,7 +216,7 @@ T-000065,W-000007,Layout Primitives v0,토큰 연동,Tokens 간격/반지름 매
 T-000066,W-000007,Layout Primitives v0,테스트,Vitest+RTL(Responsive/RTL) 테스트,완료,High," ● 내용: responsive props 해석, RTL 전환 시 레이아웃 동일성, class 병합·style 우선순위
  ● 산출물: 테스트 스위트
  ● 점검: pnpm --filter @ara/react test 통과",확인
-T-000067,W-000007,Layout Primitives v0,문서/스토리북,스토리/MDX(Playground/Patterns),계획,Medium," ● 내용: Stack/Flex/Grid/Spacer 데모, 레이아웃 패턴(툴바, 카드 그리드), Controls로 props 조절
+T-000067,W-000007,Layout Primitives v0,문서/스토리북,스토리/MDX(Playground/Patterns),완료,Medium," ● 내용: Stack/Flex/Grid/Spacer 데모, 레이아웃 패턴(툴바, 카드 그리드), Controls로 props 조절
  ● 산출물: stories 및 MDX
  ● 점검: build-storybook 스모크",확인
 T-000068,W-000007,Layout Primitives v0,통합,Button/Form와 통합 스모크,계획,Medium," ● 내용: Button 그룹(Stack), Form 레이아웃(Grid), 아이콘/텍스트 정렬(Flex)

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -47,7 +47,7 @@ W-000006,T1,Icons v0,완료,100,"Icons v0
  ● Exports/배포: @ara/icons(개별/집합) · @ara/react/icon, check:icons(dry-run+lint)·CI 해상도 검증
  ● 문서/스토리북: 아이콘 갤러리 Controls 기본값, 시각 회귀 스냅샷 옵션, 접근성 예시 포함
  ● AC: CI·Tests·Storybook·pack dry-run·canary",--
-W-000007,T1,Layout Primitives v0,진행중,80,"Layout Primitives v0
+W-000007,T1,Layout Primitives v0,진행중,90,"Layout Primitives v0
  ● Stack·Flex·Grid·Spacer
  ● 간격/정렬/래핑/분배 API
  ● responsive props(sm/md/lg…)


### PR DESCRIPTION
## Summary
- mark layout documentation and Storybook task T-000067 as complete in Tasks.csv
- update WBS entry for Layout Primitives v0 to reflect progress

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e69bd1b2c83229c9993cdb09ba86d)