### PR TITLE
T-000069: React 레이아웃 프리미티브 exports/types 정리

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,20 +27,25 @@
       "import": "./dist/components/layout/index.js",
       "default": "./dist/components/layout/index.js"
     },
+    "./components/grid": {
+      "types": "./dist/components/layout/Grid.d.ts",
+      "import": "./dist/components/layout/Grid.js",
+      "default": "./dist/components/layout/Grid.js"
+    },
     "./components/spacer": {
       "types": "./dist/components/spacer/index.d.ts",
       "import": "./dist/components/spacer/index.js",
       "default": "./dist/components/spacer/index.js"
     },
     "./components/flex": {
-      "types": "./dist/components/layout/index.d.ts",
-      "import": "./dist/components/layout/index.js",
-      "default": "./dist/components/layout/index.js"
+      "types": "./dist/components/layout/Flex.d.ts",
+      "import": "./dist/components/layout/Flex.js",
+      "default": "./dist/components/layout/Flex.js"
     },
     "./components/stack": {
-      "types": "./dist/components/layout/index.d.ts",
-      "import": "./dist/components/layout/index.js",
-      "default": "./dist/components/layout/index.js"
+      "types": "./dist/components/layout/Stack.d.ts",
+      "import": "./dist/components/layout/Stack.js",
+      "default": "./dist/components/layout/Stack.js"
     },
     "./components/theme-provider": {
       "types": "./dist/components/theme-provider/index.d.ts",
@@ -67,10 +72,15 @@
       "import": "./dist/components/icon/index.js",
       "default": "./dist/components/icon/index.js"
     },
+    "./grid": {
+      "types": "./dist/components/layout/Grid.d.ts",
+      "import": "./dist/components/layout/Grid.js",
+      "default": "./dist/components/layout/Grid.js"
+    },
     "./stack": {
-      "types": "./dist/components/layout/index.d.ts",
-      "import": "./dist/components/layout/index.js",
-      "default": "./dist/components/layout/index.js"
+      "types": "./dist/components/layout/Stack.d.ts",
+      "import": "./dist/components/layout/Stack.js",
+      "default": "./dist/components/layout/Stack.js"
     },
     "./spacer": {
       "types": "./dist/components/spacer/index.d.ts",
@@ -78,9 +88,9 @@
       "default": "./dist/components/spacer/index.js"
     },
     "./flex": {
-      "types": "./dist/components/layout/index.d.ts",
-      "import": "./dist/components/layout/index.js",
-      "default": "./dist/components/layout/index.js"
+      "types": "./dist/components/layout/Flex.d.ts",
+      "import": "./dist/components/layout/Flex.js",
+      "default": "./dist/components/layout/Flex.js"
     },
     "./theme-provider": {
       "types": "./dist/components/theme-provider/index.d.ts",
@@ -103,11 +113,17 @@
       "components/layout": [
         "dist/components/layout/index.d.ts"
       ],
+      "components/grid": [
+        "dist/components/layout/Grid.d.ts"
+      ],
       "components/spacer": [
         "dist/components/spacer/index.d.ts"
       ],
       "components/flex": [
-        "dist/components/layout/index.d.ts"
+        "dist/components/layout/Flex.d.ts"
+      ],
+      "components/stack": [
+        "dist/components/layout/Stack.d.ts"
       ],
       "components/theme-provider": [
         "dist/components/theme-provider/index.d.ts"
@@ -118,14 +134,17 @@
       "icon": [
         "dist/components/icon/index.d.ts"
       ],
+      "grid": [
+        "dist/components/layout/Grid.d.ts"
+      ],
       "spacer": [
         "dist/components/spacer/index.d.ts"
       ],
       "flex": [
-        "dist/components/layout/index.d.ts"
+        "dist/components/layout/Flex.d.ts"
       ],
       "stack": [
-        "dist/components/layout/index.d.ts"
+        "dist/components/layout/Stack.d.ts"
       ],
       "theme-provider": [
         "dist/components/theme-provider/index.d.ts"


### PR DESCRIPTION
## Summary
- [x] @ara/react 레이아웃 프리미티브 서브패스 exports를 각 컴포넌트 번들로 매핑했습니다.
- [x] typesVersions를 flex/grid/stack 선언 경로와 일치하도록 보정했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm pack --pack-destination /tmp` (packages/react에서 실행, Node 20 엔진 경고)

## Screenshots
필요 시 UI 변경 전/후 스크린샷 또는 캡처를 첨부합니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e7c8e89808322b34f7c4692a0b487)