### PR TITLE
T-000069: @ara/react 서브패스 빌드 보완

### DIFF
--- a/packages/react/rollup.config.mjs
+++ b/packages/react/rollup.config.mjs
@@ -1,10 +1,16 @@
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { createLibraryConfig } from "../../scripts/build/rollup/createLibraryConfig.mjs";
 
 const packageDir = dirname(fileURLToPath(import.meta.url));
+const input = [
+  join(packageDir, "src/index.ts"),
+  join(packageDir, "src/components/index.ts"),
+  join(packageDir, "src/components/theme-provider/index.tsx")
+];
 
 export default createLibraryConfig({
-  packageDir
+  packageDir,
+  input
 });


### PR DESCRIPTION
## 개요
- rollup 입력에 컴포넌트 엔트리를 추가해 `@ara/react/components`와 `@ara/react/components/theme-provider` 서브패스가 실제 번들 파일로 생성되도록 보강했습니다.

## 테스트
- `pnpm --filter @ara/react build`
- `pnpm pack` (packages/react)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e80ba4e1c8322bd5b88912f6752d8)