### PR TITLE
[T-000072] useTextField 헤드리스 로직 추가

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/use-button.js",
       "default": "./dist/use-button.js"
     },
+    "./use-text-field": {
+      "types": "./dist/use-text-field.d.ts",
+      "import": "./dist/use-text-field.js",
+      "default": "./dist/use-text-field.js"
+    },
     "./theme": {
       "types": "./dist/theme.d.ts",
       "import": "./dist/theme.js",
@@ -31,6 +36,9 @@
       ],
       "use-button": [
         "dist/use-button.d.ts"
+      ],
+      "use-text-field": [
+        "dist/use-text-field.d.ts"
       ],
       "*": [
         "dist/*.d.ts"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,3 +8,13 @@ export type {
   UseButtonResult
 } from "./use-button.js";
 export { useButton } from "./use-button.js";
+export type {
+  TextFieldDescriptionProps,
+  TextFieldErrorProps,
+  TextFieldInputProps,
+  TextFieldLabelProps,
+  TextFieldType,
+  UseTextFieldOptions,
+  UseTextFieldResult
+} from "./use-text-field.js";
+export { useTextField } from "./use-text-field.js";

--- a/packages/core/src/use-text-field.test.tsx
+++ b/packages/core/src/use-text-field.test.tsx
@@ -1,0 +1,168 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { type PropsWithChildren, useState } from "react";
+import { useTextField, type UseTextFieldOptions } from "./use-text-field.js";
+
+describe("useTextField", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function Field({
+    options,
+    withLabel = true,
+    withHelper = false,
+    withError = false
+  }: PropsWithChildren<{
+    options?: UseTextFieldOptions;
+    withLabel?: boolean;
+    withHelper?: boolean;
+    withError?: boolean;
+  }>) {
+    const { inputProps, labelProps, descriptionProps, errorProps, value, isComposing } =
+      useTextField({
+        ...options,
+        hasHelperText: withHelper,
+        hasErrorText: withError
+      });
+
+    return (
+      <div data-value={value} data-composing={isComposing}>
+        {withLabel ? (
+          <label data-testid="label" {...labelProps}>
+            label
+          </label>
+        ) : null}
+        <input data-testid="input" {...inputProps} />
+        {withHelper ? (
+          <p data-testid="helper" {...descriptionProps}>
+            helper
+          </p>
+        ) : null}
+        {withError ? (
+          <p data-testid="error" {...errorProps}>
+            error
+          </p>
+        ) : null}
+      </div>
+    );
+  }
+
+  it("generates ids and aria connections", () => {
+    const { getByTestId } = render(
+      <Field
+        withHelper
+        withError
+        options={{
+          required: true,
+          id: "custom-id"
+        }}
+      />
+    );
+
+    const input = getByTestId("input");
+    const label = getByTestId("label");
+    const helper = getByTestId("helper");
+    const error = getByTestId("error");
+
+    expect(label).toHaveAttribute("id", "custom-id-label");
+    expect(label).toHaveAttribute("for", "custom-id");
+    expect(helper).toHaveAttribute("id", "custom-id-description");
+    expect(error).toHaveAttribute("id", "custom-id-error");
+
+    expect(input).toHaveAttribute("id", "custom-id");
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input.getAttribute("aria-describedby")).toBe("custom-id-error custom-id-description");
+  });
+
+  it("handles uncontrolled value updates", () => {
+    const onValueChange = vi.fn();
+    const { getByTestId, container } = render(
+      <Field
+        options={{
+          defaultValue: "hello",
+          onValueChange
+        }}
+      />
+    );
+
+    const input = getByTestId("input") as HTMLInputElement;
+
+    expect(input.value).toBe("hello");
+    expect(container.firstChild).toHaveAttribute("data-value", "hello");
+
+    fireEvent.change(input, { target: { value: "world" } });
+
+    expect(onValueChange).toHaveBeenCalledWith("world");
+    expect(input.value).toBe("world");
+    expect(container.firstChild).toHaveAttribute("data-value", "world");
+  });
+
+  it("respects controlled values", () => {
+    function ControlledField() {
+      const [val, setVal] = useState("init");
+      const handleValueChange = (next: string) => setVal(next);
+
+      const { inputProps } = useTextField({
+        value: val,
+        onValueChange: handleValueChange
+      });
+
+      return <input data-testid="input" {...inputProps} />;
+    }
+
+    const { getByTestId } = render(<ControlledField />);
+    const input = getByTestId("input") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "next" } });
+
+    expect(input.value).toBe("next");
+  });
+
+  it("fires onCommit on Enter when not composing", () => {
+    const onCommit = vi.fn();
+    const { getByTestId } = render(
+      <Field
+        options={{
+          onCommit,
+          defaultValue: "value"
+        }}
+      />
+    );
+
+    const input = getByTestId("input");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith("value");
+  });
+
+  it("ignores Enter commits during composition", () => {
+    const onCommit = vi.fn();
+    const { getByTestId, container } = render(
+      <Field
+        options={{
+          onCommit,
+          defaultValue: "start"
+        }}
+      />
+    );
+
+    const input = getByTestId("input");
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "가" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(container.firstChild).toHaveAttribute("data-composing", "true");
+
+    fireEvent.compositionEnd(input, { data: "가" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith("가");
+  });
+});

--- a/packages/core/src/use-text-field.ts
+++ b/packages/core/src/use-text-field.ts
@@ -1,0 +1,215 @@
+import {
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type CompositionEvent,
+  type KeyboardEvent
+} from "react";
+
+export type TextFieldType = "text" | "email" | "password" | "number";
+
+export interface UseTextFieldOptions {
+  readonly id?: string;
+  readonly name?: string;
+  readonly type?: TextFieldType;
+  readonly value?: string;
+  readonly defaultValue?: string;
+  readonly required?: boolean;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly hasHelperText?: boolean;
+  readonly hasErrorText?: boolean;
+  readonly describedByIds?: readonly string[];
+  readonly onValueChange?: (value: string) => void;
+  readonly onCommit?: (value: string) => void;
+}
+
+interface UseTextFieldIds {
+  readonly inputId: string;
+  readonly labelId: string;
+  readonly descriptionId: string;
+  readonly errorId: string;
+}
+
+export interface UseTextFieldResult {
+  readonly inputProps: TextFieldInputProps;
+  readonly labelProps: TextFieldLabelProps;
+  readonly descriptionProps: TextFieldDescriptionProps;
+  readonly errorProps: TextFieldErrorProps;
+  readonly value: string;
+  readonly isComposing: boolean;
+}
+
+export interface TextFieldInputProps {
+  readonly id: string;
+  readonly name?: string;
+  readonly type: TextFieldType;
+  readonly value: string;
+  readonly required?: boolean;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly "aria-invalid"?: true;
+  readonly "aria-required"?: true;
+  readonly "aria-readonly"?: true;
+  readonly "aria-disabled"?: true;
+  readonly "aria-describedby"?: string;
+  readonly onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  readonly onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  readonly onCompositionStart: (event: CompositionEvent<HTMLInputElement>) => void;
+  readonly onCompositionEnd: (event: CompositionEvent<HTMLInputElement>) => void;
+}
+
+export interface TextFieldLabelProps {
+  readonly id: string;
+  readonly htmlFor: string;
+}
+
+export interface TextFieldDescriptionProps {
+  readonly id: string;
+}
+
+export interface TextFieldErrorProps {
+  readonly id: string;
+}
+
+export function useTextField(options: UseTextFieldOptions = {}): UseTextFieldResult {
+  const {
+    id,
+    name,
+    type = "text",
+    value,
+    defaultValue = "",
+    required = false,
+    disabled = false,
+    readOnly = false,
+    hasHelperText = false,
+    hasErrorText = false,
+    describedByIds = [],
+    onValueChange,
+    onCommit
+  } = options;
+
+  const generatedId = useId();
+  const ids = useMemo<UseTextFieldIds>(() => {
+    const inputId = id ?? `ara-text-field-${generatedId}`;
+    return {
+      inputId,
+      labelId: `${inputId}-label`,
+      descriptionId: `${inputId}-description`,
+      errorId: `${inputId}-error`
+    };
+  }, [generatedId, id]);
+
+  const isControlled = value !== undefined;
+  const [uncontrolledValue, setUncontrolledValue] = useState<string>(defaultValue);
+  const currentValue = isControlled ? value ?? "" : uncontrolledValue;
+  const valueRef = useRef<string>(currentValue);
+  const [isComposing, setIsComposing] = useState(false);
+  const isComposingRef = useRef(false);
+
+  const setComposing = useCallback((next: boolean) => {
+    if (isComposingRef.current !== next) {
+      isComposingRef.current = next;
+      setIsComposing(next);
+    }
+  }, []);
+
+  const updateValue = useCallback(
+    (nextValue: string) => {
+      valueRef.current = nextValue;
+      if (!isControlled) {
+        setUncontrolledValue(nextValue);
+      }
+      onValueChange?.(nextValue);
+    },
+    [isControlled, onValueChange]
+  );
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      if (disabled || readOnly) return;
+      updateValue(event.target.value);
+    },
+    [disabled, readOnly, updateValue]
+  );
+
+  const handleCompositionStart = useCallback(() => {
+    setComposing(true);
+  }, [setComposing]);
+
+  const handleCompositionEnd = useCallback(
+    (event: CompositionEvent<HTMLInputElement>) => {
+      setComposing(false);
+      if (disabled || readOnly) return;
+      updateValue(event.currentTarget.value);
+    },
+    [disabled, readOnly, updateValue, setComposing]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key !== "Enter") return;
+      if (disabled || isComposingRef.current) return;
+
+      event.preventDefault();
+      onCommit?.(valueRef.current);
+    },
+    [disabled, onCommit]
+  );
+
+  valueRef.current = currentValue;
+
+  const ariaDescribedBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasErrorText) idsToApply.push(ids.errorId);
+    if (hasHelperText) idsToApply.push(ids.descriptionId);
+    if (describedByIds.length > 0) idsToApply.push(...describedByIds);
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [describedByIds, hasErrorText, hasHelperText, ids.descriptionId, ids.errorId]);
+
+  const inputProps: TextFieldInputProps = {
+    id: ids.inputId,
+    name,
+    type,
+    value: currentValue,
+    required: required || undefined,
+    disabled: disabled || undefined,
+    readOnly: readOnly || undefined,
+    "aria-invalid": hasErrorText || undefined,
+    "aria-required": required || undefined,
+    "aria-readonly": readOnly || undefined,
+    "aria-disabled": disabled || undefined,
+    "aria-describedby": ariaDescribedBy,
+    onChange: handleChange,
+    onKeyDown: handleKeyDown,
+    onCompositionStart: handleCompositionStart,
+    onCompositionEnd: handleCompositionEnd
+  };
+
+  const labelProps: TextFieldLabelProps = {
+    id: ids.labelId,
+    htmlFor: ids.inputId
+  };
+
+  const descriptionProps: TextFieldDescriptionProps = {
+    id: ids.descriptionId
+  };
+
+  const errorProps: TextFieldErrorProps = {
+    id: ids.errorId
+  };
+
+  return {
+    inputProps,
+    labelProps,
+    descriptionProps,
+    errorProps,
+    value: valueRef.current,
+    isComposing: isComposingRef.current || isComposing
+  };
+}


### PR DESCRIPTION
## Summary
- [x] T-000072 / W-000008: TextField용 useTextField 훅을 추가해 id/ARIA 연결과 값 상태를 관리합니다.
- [x] IME 합성/Enter onCommit 흐름과 제어/비제어 입력을 검증하는 유닛 테스트를 추가했습니다.
- [x] @ara/core exports/typesVersions에 use-text-field 항목을 노출했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/core test`

## Screenshots
해당 없음


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e9dc607e883228fa8b1c4826a90ef)