### PR TITLE
[T-000073] TextField 컴포넌트 추가

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,6 +57,11 @@
       "import": "./dist/components/icon/index.js",
       "default": "./dist/components/icon/index.js"
     },
+    "./components/text-field": {
+      "types": "./dist/components/text-field/index.d.ts",
+      "import": "./dist/components/text-field/index.js",
+      "default": "./dist/components/text-field/index.js"
+    },
     "./components/button": {
       "types": "./dist/components/button/index.d.ts",
       "import": "./dist/components/button/index.js",
@@ -66,6 +71,11 @@
       "types": "./dist/components/button/index.d.ts",
       "import": "./dist/components/button/index.js",
       "default": "./dist/components/button/index.js"
+    },
+    "./text-field": {
+      "types": "./dist/components/text-field/index.d.ts",
+      "import": "./dist/components/text-field/index.js",
+      "default": "./dist/components/text-field/index.js"
     },
     "./icon": {
       "types": "./dist/components/icon/index.d.ts",
@@ -128,8 +138,14 @@
       "components/theme-provider": [
         "dist/components/theme-provider/index.d.ts"
       ],
+      "components/text-field": [
+        "dist/components/text-field/index.d.ts"
+      ],
       "button": [
         "dist/components/button/index.d.ts"
+      ],
+      "text-field": [
+        "dist/components/text-field/index.d.ts"
       ],
       "icon": [
         "dist/components/icon/index.d.ts"

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -3,3 +3,4 @@ export * from "./icon/index.js";
 export * from "./layout/index.js";
 export * from "./spacer/index.js";
 export * from "./theme-provider/index.js";
+export * from "./text-field/index.js";

--- a/packages/react/src/components/text-field/TextField.test.tsx
+++ b/packages/react/src/components/text-field/TextField.test.tsx
@@ -1,0 +1,83 @@
+import "@testing-library/jest-dom/vitest";
+import { describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { TextField } from "./TextField.js";
+
+describe("TextField", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("연결된 label/helper/error를 렌더링하고 aria를 설정한다", () => {
+    const { getByLabelText, getByText } = render(
+      <TextField label="이메일" helperText="helper" errorText="error" required />
+    );
+
+    const input = getByLabelText(/이메일/) as HTMLInputElement;
+    const helper = getByText("helper");
+    const error = getByText("error");
+
+    expect(input).toHaveAttribute("aria-describedby", `${error.id} ${helper.id}`);
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(helper.id).toContain(input.id);
+    expect(error.id).toContain(input.id);
+  });
+
+  it("clearable과 Escape 키로 값을 초기화한다", () => {
+    const onValueChange = vi.fn();
+    const { getByRole, getByLabelText } = render(
+      <TextField label="이름" clearable defaultValue="hello" onValueChange={onValueChange} />
+    );
+
+    const input = getByLabelText("이름") as HTMLInputElement;
+    const clearButton = getByRole("button", { name: "입력 지우기" });
+
+    expect(clearButton).toBeInTheDocument();
+
+    fireEvent.click(clearButton);
+    expect(onValueChange).toHaveBeenCalledWith("");
+    expect(input.value).toBe("");
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.change(input, { target: { value: "next" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(input.value).toBe("");
+  });
+
+  it("passwordToggle로 입력 타입을 전환한다", () => {
+    const { getByRole, getByLabelText } = render(
+      <TextField label="비밀번호" type="password" passwordToggle />
+    );
+
+    const input = getByLabelText(/^비밀번호$/) as HTMLInputElement;
+    const toggle = getByRole("button", { name: "비밀번호 보이기" });
+
+    expect(input.type).toBe("password");
+
+    fireEvent.click(toggle);
+    expect(input.type).toBe("text");
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.click(toggle);
+    expect(input.type).toBe("password");
+  });
+
+  it("Enter 키로 onCommit을 발화하고 IME 조합 중에는 무시한다", () => {
+    const onCommit = vi.fn();
+    const { getByLabelText } = render(
+      <TextField label="닉네임" defaultValue="ara" onCommit={onCommit} />
+    );
+
+    const input = getByLabelText("닉네임");
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onCommit).toHaveBeenCalledWith("ara");
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "가" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onCommit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/components/text-field/TextField.tsx
+++ b/packages/react/src/components/text-field/TextField.tsx
@@ -1,0 +1,465 @@
+import {
+  forwardRef,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type CSSProperties,
+  type FocusEventHandler,
+  type HTMLAttributes,
+  type InputHTMLAttributes,
+  type KeyboardEvent,
+  type KeyboardEventHandler,
+  type ReactNode,
+  type Ref
+} from "react";
+import { composeRefs } from "@radix-ui/react-compose-refs";
+import { useTextField, type TextFieldType } from "@ara/core";
+
+type TextFieldSize = "sm" | "md" | "lg";
+
+interface TextFieldOwnProps {
+  readonly label?: ReactNode;
+  readonly helperText?: ReactNode;
+  readonly errorText?: ReactNode;
+  readonly prefixIcon?: ReactNode;
+  readonly suffixIcon?: ReactNode;
+  readonly clearable?: boolean;
+  readonly passwordToggle?: boolean;
+  readonly size?: TextFieldSize;
+  readonly onValueChange?: (value: string) => void;
+  readonly onCommit?: (value: string) => void;
+  readonly inputRef?: Ref<HTMLInputElement>;
+}
+
+type NativeInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "size" | "type" | "value" | "defaultValue" | "onChange" | "children"
+>;
+
+export type TextFieldProps = TextFieldOwnProps &
+  NativeInputProps &
+  Pick<HTMLAttributes<HTMLDivElement>, "className" | "style"> & {
+    readonly type?: TextFieldType;
+    readonly value?: string;
+    readonly defaultValue?: string;
+  };
+
+const supportsFocusVisible = (() => {
+  if (typeof window === "undefined" || typeof window.CSS === "undefined") return false;
+  if (typeof window.CSS.supports !== "function") return false;
+  try {
+    return window.CSS.supports("selector(:focus-visible)");
+  } catch {
+    return false;
+  }
+})();
+
+function mergeClassNames(...values: Array<string | undefined | null | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+function normalizeSize(size: TextFieldSize | undefined): TextFieldSize {
+  if (size === "sm" || size === "lg") return size;
+  return "md";
+}
+
+function composeEventHandlers<Event>(
+  ours: ((event: Event) => void) | undefined,
+  theirs: ((event: Event) => void) | undefined
+): (event: Event) => void {
+  if (!ours && !theirs) return () => {};
+  return (event: Event) => {
+    ours?.(event);
+    theirs?.(event);
+  };
+}
+
+const SIZE_TOKENS: Record<TextFieldSize, {
+  height: string;
+  paddingX: string;
+  paddingY: string;
+  gap: string;
+  fontSize: string;
+  lineHeight: string;
+  icon: string;
+  clear: string;
+  toggle: string;
+}> = {
+  sm: {
+    height: "2.25rem",
+    paddingX: "0.5rem",
+    paddingY: "0.375rem",
+    gap: "0.375rem",
+    fontSize: "0.875rem",
+    lineHeight: "1.4",
+    icon: "1rem",
+    clear: "1.25rem",
+    toggle: "1.25rem"
+  },
+  md: {
+    height: "2.75rem",
+    paddingX: "0.75rem",
+    paddingY: "0.5rem",
+    gap: "0.5rem",
+    fontSize: "1rem",
+    lineHeight: "1.5",
+    icon: "1.25rem",
+    clear: "1.25rem",
+    toggle: "1.25rem"
+  },
+  lg: {
+    height: "3.25rem",
+    paddingX: "1rem",
+    paddingY: "0.75rem",
+    gap: "0.625rem",
+    fontSize: "1.125rem",
+    lineHeight: "1.5",
+    icon: "1.35rem",
+    clear: "1.35rem",
+    toggle: "1.35rem"
+  }
+};
+
+export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function TextField(
+  props,
+  ref
+) {
+  const {
+    label,
+    helperText,
+    errorText,
+    prefixIcon,
+    suffixIcon,
+    clearable = false,
+    passwordToggle = false,
+    size: sizeProp,
+    className,
+    style,
+    type: typeProp = "text",
+    value,
+    defaultValue,
+    disabled = false,
+    readOnly = false,
+    required = false,
+    onValueChange,
+    onCommit,
+    inputRef,
+    autoComplete = "on",
+    onChange: onChangeProp,
+    onKeyDown: onKeyDownProp,
+    onFocus: onFocusProp,
+    onBlur: onBlurProp,
+    ...restInputProps
+  } = props;
+
+  const size = normalizeSize(sizeProp);
+  const valueRef = useRef(value ?? defaultValue ?? "");
+  const [showPassword, setShowPassword] = useState(false);
+  const [isFocusVisible, setFocusVisible] = useState(false);
+
+  const resolvedType: TextFieldType =
+    passwordToggle && typeProp === "password" && showPassword ? "text" : typeProp;
+
+  const {
+    inputProps,
+    labelProps,
+    descriptionProps,
+    errorProps,
+    value: currentValue,
+    isComposing
+  } = useTextField({
+    id: restInputProps.id,
+    name: restInputProps.name,
+    type: resolvedType,
+    value,
+    defaultValue,
+    required,
+    disabled,
+    readOnly,
+    hasHelperText: Boolean(helperText),
+    hasErrorText: Boolean(errorText),
+    onValueChange,
+    onCommit,
+    describedByIds:
+      typeof restInputProps["aria-describedby"] === "string"
+        ? restInputProps["aria-describedby"].split(" ")
+        : undefined
+  });
+
+  valueRef.current = currentValue;
+
+  const internalInputRef = useRef<HTMLInputElement>(null);
+  const mergedInputRef = composeRefs(internalInputRef, inputRef);
+
+  const applyValue = useCallback(
+    (next: string) => {
+      const syntheticEvent = {
+        target: { value: next }
+      } as unknown as ChangeEvent<HTMLInputElement>;
+      inputProps.onChange(syntheticEvent);
+      onChangeProp?.(syntheticEvent);
+    },
+    [inputProps, onChangeProp]
+  );
+
+  const handleClear = useCallback(() => {
+    if (!clearable) return;
+    if (disabled || readOnly || isComposing) return;
+    if (!valueRef.current) return;
+
+    applyValue("");
+    internalInputRef.current?.focus({ preventScroll: true });
+  }, [applyValue, clearable, disabled, isComposing, readOnly]);
+
+  const handleTogglePassword = useCallback(() => {
+    if (!passwordToggle || typeProp !== "password") return;
+    if (disabled) return;
+    setShowPassword((prev) => !prev);
+    internalInputRef.current?.focus({ preventScroll: true });
+  }, [disabled, passwordToggle, typeProp]);
+
+  const handleFocus: FocusEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      if (!supportsFocusVisible) {
+        setFocusVisible(true);
+      } else {
+        try {
+          setFocusVisible(event.currentTarget.matches(":focus-visible"));
+        } catch {
+          setFocusVisible(true);
+        }
+      }
+      onFocusProp?.(event);
+    },
+    [onFocusProp]
+  );
+
+  const handleBlur: FocusEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      setFocusVisible(false);
+      onBlurProp?.(event);
+    },
+    [onBlurProp]
+  );
+
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    (event) => {
+      inputProps.onKeyDown(event as KeyboardEvent<HTMLInputElement>);
+      if (event.defaultPrevented) return;
+
+      if (event.key === "Escape") {
+        handleClear();
+      }
+
+      onKeyDownProp?.(event);
+    },
+    [handleClear, inputProps, onKeyDownProp]
+  );
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      inputProps.onChange(event);
+      onChangeProp?.(event);
+    },
+    [inputProps, onChangeProp]
+  );
+
+  const handleCompositionStart = useCallback(
+    composeEventHandlers(inputProps.onCompositionStart, restInputProps.onCompositionStart),
+    [inputProps, restInputProps.onCompositionStart]
+  );
+
+  const handleCompositionEnd = useCallback(
+    composeEventHandlers(inputProps.onCompositionEnd, restInputProps.onCompositionEnd),
+    [inputProps, restInputProps.onCompositionEnd]
+  );
+
+  const invalid = Boolean(errorText);
+  const filled = Boolean(currentValue);
+
+  const sizeTokens = SIZE_TOKENS[size];
+
+  const controlStyle = useMemo<CSSProperties>(() => {
+    const borderState = invalid ? "invalid" : isFocusVisible ? "focus" : disabled ? "disabled" : "default";
+    const surfaceState = invalid ? "invalid" : isFocusVisible ? "focus" : disabled ? "disabled" : "default";
+    const textState = disabled ? "disabled" : invalid ? "invalid" : "default";
+
+    const borderColor = `var(--ara-tf-border-${borderState}, #cdd4e0)`;
+    const surfaceColor = `var(--ara-tf-surface-${surfaceState}, #fff)`;
+    const textColor = `var(--ara-tf-text-${textState}, var(--ara-color-role-light-text-strong, inherit))`;
+
+    return {
+      display: "inline-flex",
+      alignItems: "center",
+      width: "100%",
+      boxSizing: "border-box",
+      gap: `var(--ara-tf-gap, var(--ara-tf-size-${size}-gap, ${sizeTokens.gap}))`,
+      paddingInline: `var(--ara-tf-px, var(--ara-tf-size-${size}-px, ${sizeTokens.paddingX}))`,
+      paddingBlock: `var(--ara-tf-py, var(--ara-tf-size-${size}-py, ${sizeTokens.paddingY}))`,
+      minHeight: `var(--ara-tf-size-${size}-height, ${sizeTokens.height})`,
+      borderWidth: "var(--ara-tf-border-width, 1px)",
+      borderStyle: "solid",
+      borderColor,
+      borderRadius: "var(--ara-tf-radius, 0.5rem)",
+      backgroundColor: surfaceColor,
+      color: textColor,
+      opacity: disabled ? "var(--ara-tf-disabled-opacity, 0.6)" : 1,
+      outline: isFocusVisible
+        ? `var(--ara-tf-outline, 2px solid var(--ara-color-role-light-interactive-primary-focus-border, #5b8def))`
+        : "none",
+      boxShadow: isFocusVisible ? "var(--ara-tf-shadow-focus, 0 0 0 4px rgba(91, 141, 239, 0.2))" : undefined
+    };
+  }, [disabled, invalid, isFocusVisible, size, sizeTokens]);
+
+  const inputStyle = useMemo<CSSProperties>(
+    () => ({
+      flex: 1,
+      minWidth: 0,
+      border: "none",
+      outline: "none",
+      background: "transparent",
+      font: "inherit",
+      fontSize: `var(--ara-tf-size-${size}-font-size, ${sizeTokens.fontSize})`,
+      lineHeight: `var(--ara-tf-size-${size}-line-height, ${sizeTokens.lineHeight})`,
+      color: "inherit",
+      padding: 0
+    }),
+    [size, sizeTokens.fontSize, sizeTokens.lineHeight]
+  );
+
+  const iconStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: `var(--ara-tf-size-${size}-icon, ${sizeTokens.icon})`,
+    height: `var(--ara-tf-size-${size}-icon, ${sizeTokens.icon})`,
+    flexShrink: 0
+  };
+
+  const actionButtonStyle: CSSProperties = {
+    appearance: "none",
+    border: "none",
+    background: "transparent",
+    color: "inherit",
+    cursor: disabled ? "not-allowed" : "pointer",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: `var(--ara-tf-size-${size}-clear, ${sizeTokens.clear})`,
+    height: `var(--ara-tf-size-${size}-clear, ${sizeTokens.clear})`,
+    padding: 0,
+    margin: 0
+  };
+
+  const showClearButton = clearable && filled && !disabled && !readOnly;
+  const showPasswordToggle = passwordToggle && typeProp === "password";
+
+  const mergedClassName = mergeClassNames("ara-text-field", className);
+
+  return (
+    <div
+      ref={ref}
+      className={mergedClassName}
+      style={{
+        display: "inline-flex",
+        flexDirection: "column",
+        gap: "0.25rem",
+        fontFamily: "var(--ara-tf-font, var(--ara-typography-body, inherit))",
+        ...style
+      }}
+      data-size={size}
+      data-disabled={disabled || undefined}
+      data-readonly={readOnly || undefined}
+      data-invalid={invalid || undefined}
+      data-has-prefix={prefixIcon ? true : undefined}
+      data-has-suffix={suffixIcon ? true : undefined}
+      data-filled={filled || undefined}
+      data-focus-visible={isFocusVisible || undefined}
+    >
+      {label ? (
+        <label {...labelProps} className="ara-text-field__label">
+          {label}
+          {required ? <span aria-hidden="true">*</span> : null}
+        </label>
+      ) : null}
+
+      <div className="ara-text-field__control" style={controlStyle}>
+        {prefixIcon ? (
+          <span className="ara-text-field__prefix" style={iconStyle} aria-hidden>
+            {prefixIcon}
+          </span>
+        ) : null}
+
+        <input
+          {...restInputProps}
+          {...inputProps}
+          ref={mergedInputRef}
+          type={resolvedType}
+          autoComplete={autoComplete}
+          disabled={disabled}
+          readOnly={readOnly}
+          required={required}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          onChange={handleChange}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
+          className="ara-text-field__input"
+          style={inputStyle}
+        />
+
+        {suffixIcon ? (
+          <span className="ara-text-field__suffix" style={iconStyle} aria-hidden>
+            {suffixIcon}
+          </span>
+        ) : null}
+
+        {showClearButton ? (
+          <button
+            type="button"
+            onClick={handleClear}
+            onMouseDown={(event) => event.preventDefault()}
+            className="ara-text-field__clear"
+            style={actionButtonStyle}
+            disabled={disabled}
+            aria-label="입력 지우기"
+          >
+            ×
+          </button>
+        ) : null}
+
+        {showPasswordToggle ? (
+          <button
+            type="button"
+            onClick={handleTogglePassword}
+            onMouseDown={(event) => event.preventDefault()}
+            className="ara-text-field__toggle"
+            style={{ ...actionButtonStyle, width: sizeTokens.toggle, height: sizeTokens.toggle }}
+            disabled={disabled}
+            aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 보이기"}
+            aria-pressed={showPassword}
+          >
+            {showPassword ? "🙈" : "👁"}
+          </button>
+        ) : null}
+      </div>
+
+      {helperText ? (
+        <p {...descriptionProps} className="ara-text-field__helper">
+          {helperText}
+        </p>
+      ) : null}
+
+      {errorText ? (
+        <p {...errorProps} className="ara-text-field__error">
+          {errorText}
+        </p>
+      ) : null}
+    </div>
+  );
+});
+
+TextField.displayName = "TextField";

--- a/packages/react/src/components/text-field/TextField.tsx
+++ b/packages/react/src/components/text-field/TextField.tsx
@@ -44,6 +44,7 @@ export type TextFieldProps = TextFieldOwnProps &
     readonly type?: TextFieldType;
     readonly value?: string;
     readonly defaultValue?: string;
+    readonly onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
   };
 
 const supportsFocusVisible = (() => {

--- a/packages/react/src/components/text-field/index.ts
+++ b/packages/react/src/components/text-field/index.ts
@@ -1,0 +1,1 @@
+export { TextField, type TextFieldProps } from "./TextField.js";


### PR DESCRIPTION
## Summary
- TextField 컴포넌트를 구현해 슬롯 구성, 상태 data 속성, 클리어 버튼/패스워드 토글을 제공하도록 했습니다.
- ARIA 연결과 IME 조합 처리 등을 확인하는 텍스트 필드 상호작용 테스트를 추가했습니다.
- @ara/react 패키지에서 text-field 서브패스 export와 인덱스 노출을 등록했습니다.

## Testing
- pnpm --filter @ara/react test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ea0a2e9148322b00ad78c7fdc37e1)