### PR TITLE
Fix React build dependencies

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -202,6 +202,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@ara/icons": "workspace:*",
     "@ara/core": "workspace:*",
     "@ara/tokens": "workspace:*",
     "@radix-ui/react-slot": "^1.1.0",

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -14,30 +14,13 @@
     "moduleResolution": "Bundler",
     "types": ["react", "react-dom"],
     "paths": {
-      "@ara/core": [
-        "../core/dist/index.d.ts",
-        "../core/dist/index.js"
-      ],
-      "@ara/core/*": [
-        "../core/dist/*.d.ts",
-        "../core/dist/*.js"
-      ],
-      "@ara/icons": [
-        "../icons/dist/index.d.ts",
-        "../icons/dist/index.js"
-      ],
-      "@ara/icons/*": [
-        "../icons/dist/*.d.ts",
-        "../icons/dist/*.js"
-      ],
-      "@ara/tokens": [
-        "../tokens/dist/index.d.ts",
-        "../tokens/dist/index.js"
-      ],
-      "@ara/tokens/*": [
-        "../tokens/dist/*.d.ts",
-        "../tokens/dist/*.js"
-      ]
+      "@ara/core": ["./node_modules/@ara/core/dist/index.d.ts"],
+      "@ara/core/*": ["./node_modules/@ara/core/dist/*.d.ts"],
+      "@ara/icons": ["./node_modules/@ara/icons/dist/index.d.ts"],
+      "@ara/icons/types": ["./node_modules/@ara/icons/dist/types.d.ts"],
+      "@ara/icons/*": ["./node_modules/@ara/icons/dist/*.d.ts"],
+      "@ara/tokens": ["./node_modules/@ara/tokens/dist/index.d.ts"],
+      "@ara/tokens/*": ["./node_modules/@ara/tokens/dist/*.d.ts"]
     }
   },
   "include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       '@ara/core':
         specifier: workspace:*
         version: link:../core
+      '@ara/icons':
+        specifier: workspace:*
+        version: link:../icons
       '@ara/tokens':
         specifier: workspace:*
         version: link:../tokens


### PR DESCRIPTION
## Summary
- point React build TypeScript paths at installed workspace packages instead of sibling source folders
- add @ara/icons as an explicit dependency for the React package

## Testing
- pnpm --filter @ara/react build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eacd9d1248322bc8209f37c03eb84)