### PR TITLE
T-000073: TextField readOnly/disabled 처리 개선

### DIFF
--- a/packages/core/src/use-text-field.ts
+++ b/packages/core/src/use-text-field.ts
@@ -103,6 +103,7 @@ export function useTextField(options: UseTextFieldOptions = {}): UseTextFieldRes
     };
   }, [generatedId, id]);
 
+  const appliedReadOnly = !disabled && readOnly;
   const isControlled = value !== undefined;
   const [uncontrolledValue, setUncontrolledValue] = useState<string>(defaultValue);
   const currentValue = isControlled ? value ?? "" : uncontrolledValue;
@@ -179,10 +180,10 @@ export function useTextField(options: UseTextFieldOptions = {}): UseTextFieldRes
     value: currentValue,
     required: required || undefined,
     disabled: disabled || undefined,
-    readOnly: readOnly || undefined,
+    readOnly: appliedReadOnly || undefined,
     "aria-invalid": hasErrorText || undefined,
     "aria-required": required || undefined,
-    "aria-readonly": readOnly || undefined,
+    "aria-readonly": appliedReadOnly || undefined,
     "aria-disabled": disabled || undefined,
     "aria-describedby": ariaDescribedBy,
     onChange: handleChange,

--- a/packages/react/src/components/text-field/TextField.tsx
+++ b/packages/react/src/components/text-field/TextField.tsx
@@ -162,6 +162,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
 
   const resolvedType: TextFieldType =
     passwordToggle && typeProp === "password" && showPassword ? "text" : typeProp;
+  const isReadOnly = readOnly && !disabled;
 
   const {
     inputProps,
@@ -371,11 +372,12 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
         flexDirection: "column",
         gap: "0.25rem",
         fontFamily: "var(--ara-tf-font, var(--ara-typography-body, inherit))",
+        fontWeight: "var(--ara-tf-font-weight, inherit)",
         ...style
       }}
       data-size={size}
       data-disabled={disabled || undefined}
-      data-readonly={readOnly || undefined}
+      data-readonly={isReadOnly || undefined}
       data-invalid={invalid || undefined}
       data-has-prefix={prefixIcon ? true : undefined}
       data-has-suffix={suffixIcon ? true : undefined}
@@ -402,9 +404,6 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
           ref={mergedInputRef}
           type={resolvedType}
           autoComplete={autoComplete}
-          disabled={disabled}
-          readOnly={readOnly}
-          required={required}
           onFocus={handleFocus}
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}


### PR DESCRIPTION
## Summary
- [x] TextField의 disabled+readOnly 조합에서 readOnly ARIA를 생략하도록 수정했습니다.
- [x] 루트에 폰트 굵기 토큰을 노출하고 data-readonly 플래그를 보정했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (W-000008 / T-000073)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.** (없음)

## Testing
- [x] 관련 스크립트나 테스트를 실행했습니다. (`pnpm test`, `pnpm lint` 등)
- [x] 테스트 결과를 아래에 기재했습니다.
  - pnpm --filter @ara/react test -- --runInBand

## Screenshots
변경된 UI가 없어 스크린샷이 필요하지 않습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eaf0385048322b5e48b02f0c4f95f)