### PR TITLE
Fix TextField type resolution path

### DIFF
--- a/packages/core/src/use-text-field.test.tsx
+++ b/packages/core/src/use-text-field.test.tsx
@@ -23,6 +23,7 @@ describe("useTextField", () => {
     const { inputProps, labelProps, descriptionProps, errorProps, value, isComposing } =
       useTextField({
         ...options,
+        hasLabel: withLabel,
         hasHelperText: withHelper,
         hasErrorText: withError
       });
@@ -72,9 +73,28 @@ describe("useTextField", () => {
     expect(error).toHaveAttribute("id", "custom-id-error");
 
     expect(input).toHaveAttribute("id", "custom-id");
+    expect(input).toHaveAttribute("aria-labelledby", "custom-id-label");
     expect(input).toHaveAttribute("aria-required", "true");
     expect(input).toHaveAttribute("aria-invalid", "true");
     expect(input.getAttribute("aria-describedby")).toBe("custom-id-error custom-id-description");
+  });
+
+  it("merges external labelled/description ids into aria attributes", () => {
+    const { getByTestId } = render(
+      <Field
+        withHelper
+        options={{
+          id: "merge-id",
+          labelledByIds: ["external-label"],
+          describedByIds: ["external-description"]
+        }}
+      />
+    );
+
+    const input = getByTestId("input");
+
+    expect(input).toHaveAttribute("aria-labelledby", "merge-id-label external-label");
+    expect(input.getAttribute("aria-describedby")).toBe("merge-id-description external-description");
   });
 
   it("handles uncontrolled value updates", () => {

--- a/packages/core/src/use-text-field.ts
+++ b/packages/core/src/use-text-field.ts
@@ -20,9 +20,11 @@ export interface UseTextFieldOptions {
   readonly required?: boolean;
   readonly disabled?: boolean;
   readonly readOnly?: boolean;
+  readonly hasLabel?: boolean;
   readonly hasHelperText?: boolean;
   readonly hasErrorText?: boolean;
   readonly describedByIds?: readonly string[];
+  readonly labelledByIds?: readonly string[];
   readonly onValueChange?: (value: string) => void;
   readonly onCommit?: (value: string) => void;
 }
@@ -56,6 +58,7 @@ export interface TextFieldInputProps {
   readonly "aria-readonly"?: true;
   readonly "aria-disabled"?: true;
   readonly "aria-describedby"?: string;
+  readonly "aria-labelledby"?: string;
   readonly onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   readonly onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
   readonly onCompositionStart: (event: CompositionEvent<HTMLInputElement>) => void;
@@ -85,9 +88,11 @@ export function useTextField(options: UseTextFieldOptions = {}): UseTextFieldRes
     required = false,
     disabled = false,
     readOnly = false,
+    hasLabel = true,
     hasHelperText = false,
     hasErrorText = false,
     describedByIds = [],
+    labelledByIds = [],
     onValueChange,
     onCommit
   } = options;
@@ -168,10 +173,27 @@ export function useTextField(options: UseTextFieldOptions = {}): UseTextFieldRes
 
     if (hasErrorText) idsToApply.push(ids.errorId);
     if (hasHelperText) idsToApply.push(ids.descriptionId);
-    if (describedByIds.length > 0) idsToApply.push(...describedByIds);
+    if (describedByIds.length > 0) {
+      for (const describedById of describedByIds) {
+        if (describedById) idsToApply.push(describedById);
+      }
+    }
 
     return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
   }, [describedByIds, hasErrorText, hasHelperText, ids.descriptionId, ids.errorId]);
+
+  const ariaLabelledBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasLabel) idsToApply.push(ids.labelId);
+    if (labelledByIds.length > 0) {
+      for (const labelledById of labelledByIds) {
+        if (labelledById) idsToApply.push(labelledById);
+      }
+    }
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [hasLabel, labelledByIds, ids.labelId]);
 
   const inputProps: TextFieldInputProps = {
     id: ids.inputId,
@@ -186,6 +208,7 @@ export function useTextField(options: UseTextFieldOptions = {}): UseTextFieldRes
     "aria-readonly": appliedReadOnly || undefined,
     "aria-disabled": disabled || undefined,
     "aria-describedby": ariaDescribedBy,
+    "aria-labelledby": ariaLabelledBy,
     onChange: handleChange,
     onKeyDown: handleKeyDown,
     onCompositionStart: handleCompositionStart,

--- a/packages/react/src/components/text-field/README.md
+++ b/packages/react/src/components/text-field/README.md
@@ -66,14 +66,20 @@
 
 ## 4) 접근성 계약 (A11y)
 
-- **레이블:** `label` 제공 시 `<label for>` → `<input id>` 연결. `label` 미제공 시 `aria-label` 또는 외부 `aria-labelledby` 요구.
-- **에러/도움말:** `errorText`/`helperText`가 DOM에 존재하면 `aria-describedby`에 모두 연결(에러 우선순위 시각 강조).
+- **레이블:** `label` 제공 시 `<label for>` → `<input id>` 연결하고 `aria-labelledby`에 label id를 포함한다. `aria-labelledby` prop이 있을 경우 외부 레이블 id와 병합한다. `label` 미제공 시 `aria-label` 또는 외부 `aria-labelledby` 요구.
+- **에러/도움말:** `errorText`/`helperText`가 DOM에 존재하면 `aria-describedby`에 모두 연결(에러 우선순위 시각 강조). 소비자가 전달한 `aria-describedby` 값이 있으면 동일 문자열을 끝에 병합해 외부 설명도 함께 노출한다.
 - **상태 ARIA:**
   - `required` → `aria-required="true"`
   - `disabled` → `aria-disabled="true"` + tab 이동 차단
   - `readOnly` → `aria-readonly="true"`
   - `errorText` 존재 → `aria-invalid="true"`
 - **입력 타입:** `type`에 따른 네이티브 키보드/스크린리더 힌트를 존중하되, password toggle/clear 버튼은 `aria-label`을 명시.
+- **자동 완성 가이드:**
+  - 일반 텍스트는 기본 `autoComplete="on"`을 유지.
+  - 이메일 입력: `autoComplete="email"` 권장.
+  - 사용자명/닉네임: `autoComplete="username"`.
+  - 비밀번호 변경 플로우: 현재 비밀번호는 `autoComplete="current-password"`, 새 비밀번호는 `autoComplete="new-password"`.
+  - 이름 필드가 분리된 경우 `given-name`/`family-name`을 사용해 브라우저 저장값을 재활용.
 - **포커스 링:** 키보드 유입 시 `:focus-visible` 스타일을 명확히 제공. 마우스 클릭 시 최소화.
 
 ---

--- a/packages/react/src/components/text-field/TextField.test.tsx
+++ b/packages/react/src/components/text-field/TextField.test.tsx
@@ -15,14 +15,46 @@ describe("TextField", () => {
     );
 
     const input = getByLabelText(/이메일/) as HTMLInputElement;
+    const label = getByText("이메일");
     const helper = getByText("helper");
     const error = getByText("error");
 
     expect(input).toHaveAttribute("aria-describedby", `${error.id} ${helper.id}`);
+    expect(input).toHaveAttribute("aria-labelledby", label.id);
     expect(input).toHaveAttribute("aria-invalid", "true");
     expect(input).toHaveAttribute("aria-required", "true");
     expect(helper.id).toContain(input.id);
     expect(error.id).toContain(input.id);
+  });
+
+  it("외부 aria-labelledby/aria-describedby와 병합한다", () => {
+    const { getByLabelText, getByText } = render(
+      <>
+        <span id="external-label">외부 레이블</span>
+        <span id="external-desc">외부 설명</span>
+        <TextField
+          label="이메일"
+          helperText="helper"
+          errorText="error"
+          aria-labelledby="external-label"
+          aria-describedby="external-desc"
+        />
+      </>
+    );
+
+    const input = getByLabelText(/이메일/) as HTMLInputElement;
+    const label = getByText("이메일");
+    const helper = getByText("helper");
+    const error = getByText("error");
+
+    expect(input).toHaveAttribute(
+      "aria-labelledby",
+      `${label.id} external-label`
+    );
+    expect(input).toHaveAttribute(
+      "aria-describedby",
+      `${error.id} ${helper.id} external-desc`
+    );
   });
 
   it("clearable과 Escape 키로 값을 초기화하고 onChange에 동일한 이벤트를 제공한다", () => {

--- a/packages/react/src/components/text-field/TextField.tsx
+++ b/packages/react/src/components/text-field/TextField.tsx
@@ -180,13 +180,18 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
     required,
     disabled,
     readOnly,
+    hasLabel: Boolean(label),
     hasHelperText: Boolean(helperText),
     hasErrorText: Boolean(errorText),
     onValueChange,
     onCommit,
     describedByIds:
       typeof restInputProps["aria-describedby"] === "string"
-        ? restInputProps["aria-describedby"].split(" ")
+        ? restInputProps["aria-describedby"].split(" ").filter(Boolean)
+        : undefined,
+    labelledByIds:
+      typeof restInputProps["aria-labelledby"] === "string"
+        ? restInputProps["aria-labelledby"].split(" ").filter(Boolean)
         : undefined
   });
 

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    "baseUrl": "../..",
     "rootDir": "src",
     "outDir": "dist",
     "jsx": "react-jsx",
@@ -12,16 +12,7 @@
     "sourceMap": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "types": ["react", "react-dom"],
-    "paths": {
-      "@ara/core": ["./node_modules/@ara/core/dist/index.d.ts"],
-      "@ara/core/*": ["./node_modules/@ara/core/dist/*.d.ts"],
-      "@ara/icons": ["./node_modules/@ara/icons/dist/index.d.ts"],
-      "@ara/icons/types": ["./node_modules/@ara/icons/dist/types.d.ts"],
-      "@ara/icons/*": ["./node_modules/@ara/icons/dist/*.d.ts"],
-      "@ara/tokens": ["./node_modules/@ara/tokens/dist/index.d.ts"],
-      "@ara/tokens/*": ["./node_modules/@ara/tokens/dist/*.d.ts"]
-    }
+    "types": ["react", "react-dom"]
   },
   "include": [
     "src/**/*"

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -3,7 +3,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "baseUrl": "../..",
-    "rootDir": "src",
     "outDir": "dist",
     "jsx": "react-jsx",
     "declaration": true,

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -237,7 +237,7 @@ T-000072,W-000008,TextField v0 Comp,코어(headless),useTextField 로직 구현,
 T-000073,W-000008,TextField v0 Comp,React 바인딩,TextField 구현,완료,High," ● 내용: forwardRef, 슬롯 구조(label/input/helper/error/prefix/suffix/clear/password-toggle), className 병합, data-* 상태 표식(invalid/focused/disabled), tokens 매핑(size/tone)
  ● 산출물: packages/react/src/components/text-field/index.tsx
  ● 점검: 스모크 렌더·ref 포워딩·Props 스냅",확인
-T-000074,W-000008,TextField v0 Comp,접근성,라벨/에러 연결 및 ARIA,계획,High," ● 내용: label→input ‘for/id’ 연결, error/helper를 aria-describedby로 연결, invalid/required 반영, autoComplete 가이드
+T-000074,W-000008,TextField v0 Comp,접근성,라벨/에러 연결 및 ARIA,완료,High," ● 내용: label→input ‘for/id’ 연결, error/helper를 aria-describedby로 연결, invalid/required 반영, autoComplete 가이드
  ● 산출물: A11y 가이드/테스트 케이스
  ● 점검: 스크린리더에서 라벨·에러 읽힘·탭 순서 정상",확인
 T-000075,W-000008,TextField v0 Comp,입력 UX,Clear/Password 토글/IME,계획,High," ● 내용: clearable(X 버튼)·password 토글(가시성 전환)·Enter onCommit·IME 조합 중 Enter 무시·maxlength 카운터(옵션)

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -54,7 +54,7 @@ W-000007,T1,Layout Primitives v0,완료,100,"Layout Primitives v0
  ● RTL·SSR 안전
  ● Exports 고정
  ● AC: CI/Tests/Storybook/pack/canary",--
-W-000008,T1,TextField v0 Comp,진행,25,"TextField v0
+W-000008,T1,TextField v0 Comp,진행,35,"TextField v0
  ● 설계문서 : root/packages/react/src/components/text-field/README.md
  ● 범위: 단일라인 입력(type: text|email|password|number) — textarea/마스킹은 제외
  ● tokens→core(useTextField)→react 바인딩; label/helper/error; prefix/suffix; clear; password 토글


### PR DESCRIPTION
## Summary
- react 빌드 tsconfig의 baseUrl을 워크스페이스 루트로 돌려 @ara/core 최신 타입을 정확히 해석하도록 수정

## Testing
- pnpm --filter @ara/react test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ba3c33088322a326c30140dbade2)