### PR TITLE
Add source fallbacks for react build paths

### DIFF
--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -15,27 +15,33 @@
     "paths": {
       "@ara/core": [
         "../core/dist/index.d.ts",
-        "../core/dist/index.js"
+        "../core/dist/index.js",
+        "../core/src/index.ts"
       ],
       "@ara/core/*": [
         "../core/dist/*.d.ts",
-        "../core/dist/*.js"
+        "../core/dist/*.js",
+        "../core/src/*.ts"
       ],
       "@ara/icons": [
         "../icons/dist/index.d.ts",
-        "../icons/dist/index.js"
+        "../icons/dist/index.js",
+        "../icons/src/index.ts"
       ],
       "@ara/icons/*": [
         "../icons/dist/*.d.ts",
-        "../icons/dist/*.js"
+        "../icons/dist/*.js",
+        "../icons/src/*.ts"
       ],
       "@ara/tokens": [
         "../tokens/dist/index.d.ts",
-        "../tokens/dist/index.js"
+        "../tokens/dist/index.js",
+        "../tokens/src/index.ts"
       ],
       "@ara/tokens/*": [
         "../tokens/dist/*.d.ts",
-        "../tokens/dist/*.js"
+        "../tokens/dist/*.js",
+        "../tokens/src/*.ts"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- allow React build to resolve workspace packages even when their dist outputs are missing by including source fallbacks in path mappings

## Testing
- pnpm --filter @ara/react build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c6ba171c8322b2016ba4d8ba1f6f)