### PR TITLE
feat: TextField 입력 UX 개선 (T-000075)

### DIFF
--- a/packages/react/src/components/text-field/README.md
+++ b/packages/react/src/components/text-field/README.md
@@ -29,6 +29,7 @@
 | **prefixIcon / suffixIcon** | ReactNode | — | 입력 앞/뒤 아이콘 슬롯. 제공되지 않으면 DOM 미삽입. |
 | **clearable** | boolean | false | 값 존재 시 clear 버튼(`X`) 노출. 클릭 또는 `Esc`로 값 초기화+`onValueChange("")`. |
 | **passwordToggle** | boolean | false | `type="password"`일 때 가시성 토글 버튼 제공(eye). `type`/`aria-label` 자동 전환. |
+| **maxLengthCounter** | boolean | false | `maxLength` 제공 시 현재 글자 수/최대 글자 수를 보조 텍스트로 노출. |
 | **name** | string | — | 폼 제출용 이름. |
 | **id** | string | — | 입력 요소 id. 미지정 시 내부 생성(레이블/설명 연결에 사용). |
 | **autoComplete** | string | "on" | HTML `autocomplete` 속성 위임. 가이드에 따라 권장 값 표기. |
@@ -55,6 +56,9 @@
 - **Password toggle:**
   - `passwordToggle` 활성+`type="password"`에서만 렌더. 클릭으로 `type`을 `password ↔ text` 전환.
   - 전환 시 값 보존, 포커스는 입력에 남김.
+- **Max length counter:**
+  - `maxLengthCounter` + `maxLength` 지정 시 `현재/최대` 형식으로 보조 카운터 표기.
+  - 값 변경/clear/password 토글 등 모든 입력 이벤트에 즉시 반영.
 - **Enter 확정:**
   - `keydown Enter` 시 IME 조합 상태가 아니면 `preventDefault` 후 `onCommit(currentValue)` 호출.
   - `type="number"`에서도 동일 계약을 유지(폼 submit과 중복 방지).

--- a/packages/react/src/components/text-field/TextField.test.tsx
+++ b/packages/react/src/components/text-field/TextField.test.tsx
@@ -104,6 +104,28 @@ describe("TextField", () => {
     expect(input.value).toBe("");
   });
 
+  it("maxLengthCounter로 길이 카운터를 표기한다", () => {
+    const { getByLabelText, getByText, getByRole } = render(
+      <TextField
+        label="소개"
+        clearable
+        defaultValue="ara"
+        maxLength={10}
+        maxLengthCounter
+      />
+    );
+
+    const input = getByLabelText("소개") as HTMLInputElement;
+
+    expect(getByText("3/10")).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "hello" } });
+    expect(getByText("5/10")).toBeInTheDocument();
+
+    fireEvent.click(getByRole("button", { name: "입력 지우기" }));
+    expect(getByText("0/10")).toBeInTheDocument();
+  });
+
   it("passwordToggle로 입력 타입을 전환한다", () => {
     const { getByRole, getByLabelText } = render(
       <TextField label="비밀번호" type="password" passwordToggle />

--- a/packages/react/src/components/text-field/TextField.tsx
+++ b/packages/react/src/components/text-field/TextField.tsx
@@ -27,6 +27,7 @@ interface TextFieldOwnProps {
   readonly suffixIcon?: ReactNode;
   readonly clearable?: boolean;
   readonly passwordToggle?: boolean;
+  readonly maxLengthCounter?: boolean;
   readonly size?: TextFieldSize;
   readonly onValueChange?: (value: string) => void;
   readonly onCommit?: (value: string) => void;
@@ -135,6 +136,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
     suffixIcon,
     clearable = false,
     passwordToggle = false,
+    maxLengthCounter = false,
     size: sizeProp,
     className,
     style,
@@ -290,6 +292,14 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
   const filled = Boolean(currentValue);
 
   const sizeTokens = SIZE_TOKENS[size];
+  const maxLengthValue =
+    typeof restInputProps.maxLength === "number"
+      ? restInputProps.maxLength
+      : Number.isFinite(Number(restInputProps.maxLength))
+        ? Number(restInputProps.maxLength)
+        : undefined;
+
+  const shouldShowCounter = Boolean(maxLengthCounter && maxLengthValue && maxLengthValue > 0);
 
   const controlStyle = useMemo<CSSProperties>(() => {
     const borderState = invalid ? "invalid" : isFocusVisible ? "focus" : disabled ? "disabled" : "default";
@@ -465,6 +475,20 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
         <p {...errorProps} className="ara-text-field__error">
           {errorText}
         </p>
+      ) : null}
+
+      {shouldShowCounter ? (
+        <span
+          className="ara-text-field__counter"
+          style={{
+            alignSelf: "flex-end",
+            color: "var(--ara-tf-text-default, var(--ara-color-role-light-text-strong, inherit))",
+            fontSize: "0.875rem",
+            lineHeight: "1.4"
+          }}
+        >
+          {currentValue.length}/{maxLengthValue}
+        </span>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## 요약
- TextField에 `maxLengthCounter` 옵션을 추가해 `maxLength` 제공 시 글자 수 카운터를 렌더링합니다.
- clear/password 토글 등 입력 이벤트에 따라 카운터가 최신 길이를 반영하도록 UI를 보완했습니다.
- 계약 문서와 상호작용 테스트에 카운터 동작을 기록하고 검증했습니다.

## 테스트
- pnpm --filter @ara/react test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ca9906a8832295f2d3e829609bee)