### PR TITLE
T-000077: TextField 상태/사이즈 토큰 매핑

### DIFF
--- a/packages/react/src/components/text-field/TextField.test.tsx
+++ b/packages/react/src/components/text-field/TextField.test.tsx
@@ -161,4 +161,29 @@ describe("TextField", () => {
 
     expect(onCommit).toHaveBeenCalledTimes(1);
   });
+
+  it("사이즈/상태 토큰을 CSS 변수로 노출하고 상태에 맞춰 적용한다", () => {
+    const { container, getByLabelText } = render(<TextField label="이메일" size="sm" />);
+
+    const root = container.firstChild as HTMLElement;
+    const control = container.querySelector(
+      ".ara-text-field__control"
+    ) as HTMLElement;
+    const input = getByLabelText("이메일");
+
+    expect(root.style.getPropertyValue("--ara-tf-size-sm-height")).toBe("2.25rem");
+    expect(root.style.getPropertyValue("--ara-tf-size-md-gap")).toBe("0.5rem");
+    expect(root.style.getPropertyValue("--ara-tf-border-default")).toBe("#cdd4e0");
+
+    expect(control.style.borderColor).toBe("var(--ara-tf-border-default, #cdd4e0)");
+
+    fireEvent.pointerEnter(control);
+    expect(control.style.borderColor).toBe("var(--ara-tf-border-hover, #cdd4e0)");
+
+    fireEvent.pointerLeave(control);
+    fireEvent.focus(input);
+    expect(control.style.outline).toBe(
+      "var(--ara-tf-outline, 2px solid var(--ara-color-role-light-interactive-primary-focus-border, #5b8def))"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- TextField에 상태/사이즈 CSS 변수 기본값을 정의하고 호버 상태를 추가했습니다.
- 포커스/호버/비활성 등 상태에 맞게 테두리·배경·텍스트 토큰을 적용하도록 개선했습니다.
- 토큰 노출과 상태 변화를 검증하는 테스트를 추가했습니다.

## Testing
- pnpm --filter @ara/react test -- --filter TextField

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ddf6faf08322962c4405413131fd)