### PR TITLE
TextField 스토리북 추가 (T-000079)

### DIFF
--- a/apps/storybook/stories/components/TextField.docs.mdx
+++ b/apps/storybook/stories/components/TextField.docs.mdx
@@ -1,0 +1,103 @@
+import { Meta, Title, Subtitle, Description, Canvas, ArgsTable, Primary, Controls } from "@storybook/blocks";
+import * as TextFieldStories from "./TextField.stories";
+
+<Meta of={TextFieldStories} />
+
+<Title>TextField 입력</Title>
+
+<Subtitle>단일 텍스트 입력을 위한 기본 필드로, clear 버튼과 패스워드 토글 등 보조 액션을 포함합니다.</Subtitle>
+
+<Description>
+`TextField`는 `@ara/core/use-text-field`의 ARIA/이벤트 계약을 그대로 따르는 React UI 바인딩입니다. label/description/error 연결을 자동
+으로 처리하며, prefix/suffix 슬롯과 clear, password toggle, maxLength counter와 같은 보조 기능을 제공합니다. 제어/비제어 모드 모두를
+지원하고 `AraProvider`/`AraThemeBoundary`로 전달된 토큰에 따라 스타일이 결정됩니다.
+</Description>
+
+## Playground
+
+<Primary of={TextFieldStories.Playground} />
+<Controls of={TextFieldStories.Playground} />
+
+## Sizes
+
+사이즈는 높이/폰트/간격이 함께 조정됩니다.
+
+<Canvas of={TextFieldStories.Sizes} />
+
+## 상태(Disabled / ReadOnly / Invalid)
+
+네이티브 `disabled`/`readOnly`/`aria-invalid` 계약을 준수하며, 오류가 있을 때 `aria-describedby` 연결과 시각적 강조를 제공합니다.
+
+<Canvas of={TextFieldStories.States} />
+
+## Helper &amp; Error
+
+도움말과 오류 메시지는 모두 `aria-describedby`에 연결되어 스크린 리더에서도 함께 읽힙니다.
+
+<Canvas of={TextFieldStories.HelperAndError} />
+
+## Prefix / Suffix
+
+입력 앞/뒤에 아이콘이나 버튼을 배치해 금액 단위, 액션 버튼 등을 결합할 수 있습니다.
+
+<Canvas of={TextFieldStories.PrefixSuffix} />
+
+## Clearable
+
+값이 있을 때만 노출되는 clear 버튼으로 Esc 또는 클릭/키보드로 값을 초기화할 수 있습니다.
+
+<Canvas of={TextFieldStories.Clearable} />
+
+## Password Toggle
+
+`type="password"`와 함께 `passwordToggle`을 켜면 시각/비시각 사용자 모두에게 안전한 비밀번호 가시성 전환을 제공합니다.
+
+<Canvas of={TextFieldStories.PasswordToggle} />
+
+## 제어 vs 비제어
+
+`value` + `onValueChange`로 제어 모드를 구성하거나, `defaultValue` 기반 내부 상태를 사용할 수 있습니다.
+
+<Canvas of={TextFieldStories.ControlledVsUncontrolled} />
+
+## Types
+
+텍스트/이메일/비밀번호/숫자 타입을 제공하며, password toggle과 clear는 타입에 따라 조건부로 노출됩니다.
+
+<Canvas of={TextFieldStories.Types} />
+
+## Form Submit
+
+Enter 확정(onCommit)과 네이티브 form submit을 함께 검증할 수 있는 예제입니다. `name`이 있는 입력만 제출 페이로드에 포함됩니다.
+
+<Canvas of={TextFieldStories.FormSubmit} />
+
+## Props
+
+<ArgsTable of={TextFieldStories.Playground} />
+
+## 접근성 / 자동 완성 가이드
+
+- label이 제공되지 않을 경우 `aria-label` 또는 외부 `aria-labelledby`를 지정해야 합니다.
+- `errorText`/`helperText`가 DOM에 존재하면 `aria-describedby`에 자동으로 연결됩니다.
+- 자동 완성 권장값: 이메일 `autoComplete="email"`, 사용자명 `autoComplete="username"`, 비밀번호 변경 시 `current-password` / `new-password`.
+- clear 버튼과 password toggle에는 적절한 `aria-label`이 포함되어 키보드/스크린 리더 사용자가 동등한 정보를 얻습니다.
+
+## 커스터마이징
+
+```tsx
+<TextField
+  label="닉네임"
+  style={{
+    "--ara-tf-surface-default": "#0f172a",
+    "--ara-tf-text-default": "#e2e8f0",
+    "--ara-tf-border-default": "#1e293b",
+    "--ara-tf-radius": "0.75rem",
+    "--ara-tf-size-md-height": "48px"
+  }}
+  prefixIcon={<Icon icon={Plus} size="sm" aria-hidden />}
+/>
+```
+
+- CSS 변수(`--ara-tf-*`)를 오버라이드하면 테마 토큰을 유지하면서 제품별 스킨을 적용할 수 있습니다.
+- `className`에 `.ara-text-field__input`, `.ara-text-field__suffix` 등 슬롯명을 활용하면 특정 영역만 선택적으로 커스터마이즈할 수 있습니다.

--- a/apps/storybook/stories/components/TextField.stories.tsx
+++ b/apps/storybook/stories/components/TextField.stories.tsx
@@ -1,0 +1,212 @@
+import { useMemo, useState, type ComponentProps } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ArrowRight, CheckCircle, Plus } from "@ara/icons";
+import { AraProvider, AraThemeBoundary, Button, Icon, Stack, TextField } from "@ara/react";
+
+const meta = {
+  title: "Components/TextField",
+  component: TextField,
+  decorators: [
+    (Story) => (
+      <AraProvider>
+        <AraThemeBoundary>
+          <Story />
+        </AraThemeBoundary>
+      </AraProvider>
+    )
+  ],
+  parameters: {
+    layout: "padded"
+  },
+  args: {
+    label: "이메일",
+    placeholder: "example@ara.design",
+    size: "md",
+    helperText: "입력 시 이메일 형식을 확인하세요.",
+    required: false,
+    disabled: false
+  },
+  argTypes: {
+    prefixIcon: { control: false },
+    suffixIcon: { control: false },
+    helperText: { control: "text" },
+    errorText: { control: "text" }
+  },
+  tags: ["autodocs"]
+} satisfies Meta<typeof TextField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+type TextFieldProps = ComponentProps<typeof TextField>;
+
+const spacingProps = { gap: "md", style: { maxWidth: "720px" } } as const;
+
+export const Playground: Story = {};
+
+export const Sizes: Story = {
+  parameters: {
+    controls: { exclude: ["size"] }
+  },
+  render: (args) => (
+    <Stack orientation="horizontal" gap="md">
+      <TextField {...args} size="sm" label="이메일 (sm)" />
+      <TextField {...args} size="md" label="이메일 (md)" />
+      <TextField {...args} size="lg" label="이메일 (lg)" />
+    </Stack>
+  )
+};
+
+export const HelperAndError: Story = {
+  name: "Helper & Error",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack {...spacingProps}>
+      <TextField label="닉네임" helperText="최소 2자 이상 입력하세요." placeholder="ara" />
+      <TextField
+        label="이메일"
+        defaultValue="ara@"
+        errorText="이메일 형식이 올바르지 않습니다."
+        helperText="도메인까지 입력해야 합니다."
+      />
+    </Stack>
+  )
+};
+
+export const States: Story = {
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack {...spacingProps}>
+      <TextField label="기본" placeholder="입력 가능" />
+      <TextField label="읽기 전용" defaultValue="고정 값" readOnly />
+      <TextField label="비활성화" defaultValue="입력 불가" disabled />
+      <TextField label="유효성 오류" defaultValue="ara" errorText="필수 값이 비어 있습니다." />
+    </Stack>
+  )
+};
+
+export const PrefixSuffix: Story = {
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack {...spacingProps}>
+      <TextField
+        label="금액"
+        type="number"
+        placeholder="10000"
+        prefixIcon={<Icon icon={Plus} size="sm" aria-hidden />}
+        suffixIcon={<Icon icon={CheckCircle} tone="primary" size="sm" aria-hidden />}
+      />
+      <TextField
+        label="검색"
+        placeholder="키워드를 입력하세요"
+        prefixIcon={<Icon icon={ArrowRight} size="sm" aria-hidden />}
+        suffixIcon={<Button tone="neutral" variant="outline" size="sm">검색</Button>}
+      />
+    </Stack>
+  )
+};
+
+export const Clearable: Story = {
+  parameters: {
+    controls: { exclude: ["clearable", "defaultValue"] }
+  },
+  args: {
+    clearable: true,
+    defaultValue: "ara-design"
+  },
+  render: (args) => <TextField {...args} label="사용자명" helperText="Esc 또는 X 버튼으로 초기화할 수 있습니다." />
+};
+
+export const PasswordToggle: Story = {
+  args: {
+    label: "비밀번호",
+    type: "password",
+    passwordToggle: true,
+    autoComplete: "new-password"
+  }
+};
+
+export const ControlledVsUncontrolled: Story = {
+  name: "Controlled vs Uncontrolled",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => {
+    const [email, setEmail] = useState("ara@design.com");
+
+    return (
+      <Stack {...spacingProps}>
+        <TextField
+          label="제어 모드"
+          value={email}
+          onValueChange={setEmail}
+          helperText="상위 상태를 직접 갱신합니다."
+        />
+        <TextField
+          label="비제어 모드"
+          defaultValue="초기값"
+          helperText="내부 상태를 사용하며 onValueChange로만 알림"
+          onValueChange={(value) => console.log("비제어 변경", value)}
+        />
+        <div style={{ color: "var(--ara-color-text-muted, #475569)" }}>현재 이메일 값: {email}</div>
+      </Stack>
+    );
+  }
+};
+
+export const Types: Story = {
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack {...spacingProps}>
+      <TextField label="텍스트" type="text" placeholder="자유 입력" />
+      <TextField label="이메일" type="email" placeholder="example@ara.design" />
+      <TextField label="비밀번호" type="password" passwordToggle placeholder="********" />
+      <TextField label="숫자" type="number" placeholder="12345" />
+    </Stack>
+  )
+};
+
+export const FormSubmit: Story = {
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => {
+    const [submitted, setSubmitted] = useState<TextFieldProps["defaultValue"]>("");
+    const [value, setValue] = useState("hello");
+
+    const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+      event.preventDefault();
+      const formData = new FormData(event.currentTarget);
+      const nextValue = formData.get("feedback")?.toString() ?? "";
+      setSubmitted(nextValue);
+    };
+
+    const helper = useMemo(() => "Enter 키로 onCommit, Submit 버튼으로 네이티브 제출 흐름을 확인하세요.", []);
+
+    return (
+      <form onSubmit={handleSubmit} style={{ width: "320px", display: "grid", gap: "0.75rem" }}>
+        <TextField
+          label="의견"
+          name="feedback"
+          value={value}
+          onValueChange={setValue}
+          onCommit={setSubmitted}
+          helperText={helper}
+          required
+        />
+        <Button type="submit">제출</Button>
+        <div style={{ color: "var(--ara-color-text-muted, #475569)" }}>
+          마지막 제출 값: <strong>{submitted || "(비어 있음)"}</strong>
+        </div>
+      </form>
+    );
+  }
+};


### PR DESCRIPTION
## 요약
- TextField 스토리북 스토리를 추가하여 사이즈, 상태, 타입, 패스워드 토글, 폼 제출 흐름을 데모
- MDX 문서를 작성해 playground와 접근성/자동완성 가이드를 제공

## 테스트
- (실행하지 않음)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e3402fc08322a7d26069c6b4ae32)