### PR TITLE
Add configurable suffix action slot to TextField

### DIFF
--- a/apps/storybook/stories/components/TextField.docs.mdx
+++ b/apps/storybook/stories/components/TextField.docs.mdx
@@ -38,7 +38,7 @@ import * as TextFieldStories from "./TextField.stories";
 
 ## Prefix / Suffix
 
-입력 앞/뒤에 아이콘이나 버튼을 배치해 금액 단위, 액션 버튼 등을 결합할 수 있습니다.
+입력 앞/뒤에 아이콘이나 버튼을 배치해 금액 단위, 액션 버튼 등을 결합할 수 있습니다. `suffixAction` 슬롯을 사용하면 텍스트 필드 안에 상호작용 가능한 버튼을 배치하고 사용자가 원하는 액션으로 연결할 수 있습니다.
 
 <Canvas of={TextFieldStories.PrefixSuffix} />
 

--- a/apps/storybook/stories/components/TextField.stories.tsx
+++ b/apps/storybook/stories/components/TextField.stories.tsx
@@ -29,6 +29,7 @@ const meta = {
   argTypes: {
     prefixIcon: { control: false },
     suffixIcon: { control: false },
+    suffixAction: { control: false },
     helperText: { control: "text" },
     errorText: { control: "text" }
   },
@@ -106,7 +107,11 @@ export const PrefixSuffix: Story = {
         label="검색"
         placeholder="키워드를 입력하세요"
         prefixIcon={<Icon icon={ArrowRight} size="sm" aria-hidden />}
-        suffixIcon={<Button tone="neutral" variant="outline" size="sm">검색</Button>}
+        suffixAction={
+          <Button tone="primary" variant="solid" size="sm">
+            검색
+          </Button>
+        }
       />
     </Stack>
   )

--- a/packages/react/src/components/text-field/TextField.tsx
+++ b/packages/react/src/components/text-field/TextField.tsx
@@ -27,6 +27,7 @@ interface TextFieldOwnProps {
   readonly helperTextMatchFieldWidth?: boolean;
   readonly prefixIcon?: ReactNode;
   readonly suffixIcon?: ReactNode;
+  readonly suffixAction?: ReactNode;
   readonly clearable?: boolean;
   readonly passwordToggle?: boolean;
   readonly maxLengthCounter?: boolean;
@@ -159,6 +160,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
     errorText,
     prefixIcon,
     suffixIcon,
+    suffixAction,
     clearable = false,
     passwordToggle = false,
     maxLengthCounter = false,
@@ -483,6 +485,14 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
     margin: 0
   };
 
+  const suffixActionStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "100%",
+    flexShrink: 0
+  };
+
   const helperStyle: CSSProperties = {
     margin: 0,
     alignSelf: helperTextMatchFieldWidth ? "stretch" : "flex-start",
@@ -546,7 +556,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
       data-readonly={isReadOnly || undefined}
       data-invalid={invalid || undefined}
       data-has-prefix={prefixIcon ? true : undefined}
-      data-has-suffix={suffixIcon ? true : undefined}
+      data-has-suffix={suffixIcon || suffixAction ? true : undefined}
       data-filled={filled || undefined}
       data-focus-visible={isFocusVisible || undefined}
     >
@@ -595,6 +605,12 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
         {suffixIcon ? (
           <span className="ara-text-field__suffix" style={iconStyle} aria-hidden>
             {suffixIcon}
+          </span>
+        ) : null}
+
+        {suffixAction ? (
+          <span className="ara-text-field__suffix-action" style={suffixActionStyle}>
+            {suffixAction}
           </span>
         ) : null}
 


### PR DESCRIPTION
## Summary
- add a new suffixAction slot to TextField for embedding interactive controls inside the input
- document and showcase the suffix action option in the TextField stories

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923fa1447f0832299a1a8fb18ab700b)