### PR TITLE
feat: 텍스트필드용 보조 아이콘 추가

### DIFF
--- a/packages/icons/src/Close.ts
+++ b/packages/icons/src/Close.ts
@@ -1,0 +1,1 @@
+export { Close } from "./icons/close.js";

--- a/packages/icons/src/Eye.ts
+++ b/packages/icons/src/Eye.ts
@@ -1,0 +1,1 @@
+export { Eye } from "./icons/eye.js";

--- a/packages/icons/src/Search.ts
+++ b/packages/icons/src/Search.ts
@@ -1,0 +1,1 @@
+export { Search } from "./icons/search.js";

--- a/packages/icons/src/icons/close.tsx
+++ b/packages/icons/src/icons/close.tsx
@@ -1,0 +1,21 @@
+import type { IconProps } from "../types.js";
+export const Close = ({ title, ...props }: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden={title ? undefined : true}
+    role={title ? "img" : undefined}
+    {...props}
+  >
+    {title ? <title>{title}</title> : null}
+
+    <path
+      d="M6 6l12 12M18 6 6 18"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/packages/icons/src/icons/eye.tsx
+++ b/packages/icons/src/icons/eye.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from "../types.js";
+export const Eye = ({ title, ...props }: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden={title ? undefined : true}
+    role={title ? "img" : undefined}
+    {...props}
+  >
+    {title ? <title>{title}</title> : null}
+
+    <path
+      d="M3 12s3.5-6 9-6 9 6 9 6-3.5 6-9 6-9-6-9-6z"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="2" />
+  </svg>
+);

--- a/packages/icons/src/icons/search.tsx
+++ b/packages/icons/src/icons/search.tsx
@@ -1,0 +1,22 @@
+import type { IconProps } from "../types.js";
+export const Search = ({ title, ...props }: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden={title ? undefined : true}
+    role={title ? "img" : undefined}
+    {...props}
+  >
+    {title ? <title>{title}</title> : null}
+
+    <circle cx="11" cy="11" r="6" stroke="currentColor" strokeWidth="2" />
+    <path
+      d="m15.5 15.5 4.5 4.5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,12 +1,18 @@
 export type { IconProps } from "./types.js";
 export { __ICON_TYPES__ } from "./types.js";
 import { ArrowRight } from "./icons/arrow-right.js";
+import { Close } from "./icons/close.js";
 import { CheckCircle } from "./icons/check-circle.js";
+import { Eye } from "./icons/eye.js";
 import { Plus } from "./icons/plus.js";
-export { ArrowRight, CheckCircle, Plus };
+import { Search } from "./icons/search.js";
+export { ArrowRight, CheckCircle, Close, Eye, Plus, Search };
 export const icons = {
   ArrowRight,
   CheckCircle,
-  Plus
+  Close,
+  Eye,
+  Plus,
+  Search
 } as const;
 export type IconName = keyof typeof icons;

--- a/packages/icons/svgs/close.svg
+++ b/packages/icons/svgs/close.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M6 6l12 12M18 6 6 18"/>
+</svg>

--- a/packages/icons/svgs/eye.svg
+++ b/packages/icons/svgs/eye.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12s3.5-6 9-6 9 6 9 6-3.5 6-9 6-9-6-9-6Z"/>
+  <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/packages/icons/svgs/search.svg
+++ b/packages/icons/svgs/search.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <circle cx="11" cy="11" r="6" stroke="currentColor" stroke-width="2"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="m15.5 15.5 4.5 4.5"/>
+</svg>


### PR DESCRIPTION
## Summary
- 닫기(X), 눈(Eye), 검색(Search) 아이콘을 currentColor 기반 24x24 스타일로 추가했습니다.
- 루트/개별 엔트리포인트와 icons 맵에 신규 아이콘을 노출했습니다.
- 원본 SVG 자산을 저장해 아이콘 생성 파이프라인에 반영했습니다.

## Testing
- pnpm --filter @ara/icons lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923fd67567c8322bd8c4609194b9de0)