### PR TITLE
chore: TextField 보조 아이콘 @ara 자산으로 교체 (T-000080)

### DIFF
--- a/apps/storybook/stories/components/TextField.stories.tsx
+++ b/apps/storybook/stories/components/TextField.stories.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type ComponentProps } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import { ArrowRight, CheckCircle, Plus } from "@ara/icons";
+import { ArrowRight, CheckCircle, Plus, Search } from "@ara/icons";
 import { AraProvider, AraThemeBoundary, Button, Icon, Stack, TextField } from "@ara/react";
 
 const meta = {
@@ -106,7 +106,7 @@ export const PrefixSuffix: Story = {
       <TextField
         label="검색"
         placeholder="키워드를 입력하세요"
-        prefixIcon={<Icon icon={ArrowRight} size="sm" aria-hidden />}
+        prefixIcon={<Icon icon={Search} size="sm" aria-hidden />}
         suffixAction={
           <Button tone="primary" variant="solid" size="sm">
             검색
@@ -125,7 +125,9 @@ export const Clearable: Story = {
     clearable: true,
     defaultValue: "ara-design"
   },
-  render: (args) => <TextField {...args} label="사용자명" helperText="Esc 또는 X 버튼으로 초기화할 수 있습니다." />
+  render: (args) => (
+    <TextField {...args} label="사용자명" helperText="Esc 또는 지우기 버튼으로 초기화할 수 있습니다." />
+  )
 };
 
 export const PasswordToggle: Story = {

--- a/packages/icons/src/Close.ts
+++ b/packages/icons/src/Close.ts
@@ -1,0 +1,1 @@
+export { Close } from "./icons/close.js";

--- a/packages/icons/src/Eye.ts
+++ b/packages/icons/src/Eye.ts
@@ -1,0 +1,1 @@
+export { Eye } from "./icons/eye.js";

--- a/packages/icons/src/Search.ts
+++ b/packages/icons/src/Search.ts
@@ -1,0 +1,1 @@
+export { Search } from "./icons/search.js";

--- a/packages/icons/src/icons/close.tsx
+++ b/packages/icons/src/icons/close.tsx
@@ -1,0 +1,21 @@
+import type { IconProps } from "../types.js";
+export const Close = ({ title, ...props }: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden={title ? undefined : true}
+    role={title ? "img" : undefined}
+    {...props}
+  >
+    {title ? <title>{title}</title> : null}
+
+    <path
+      d="M6 6l12 12M18 6 6 18"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/packages/icons/src/icons/eye.tsx
+++ b/packages/icons/src/icons/eye.tsx
@@ -1,0 +1,23 @@
+import type { IconProps } from "../types.js";
+export const Eye = ({ title, ...props }: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden={title ? undefined : true}
+    role={title ? "img" : undefined}
+    {...props}
+  >
+    {title ? <title>{title}</title> : null}
+
+    <path
+      d="M3 12s3.5-6 9-6 9 6 9 6-3.5 6-9 6-9-6-9-6z"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <circle cx="12" cy="12" r="3" stroke="currentColor" strokeWidth="2" />
+  </svg>
+);

--- a/packages/icons/src/icons/search.tsx
+++ b/packages/icons/src/icons/search.tsx
@@ -1,0 +1,22 @@
+import type { IconProps } from "../types.js";
+export const Search = ({ title, ...props }: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden={title ? undefined : true}
+    role={title ? "img" : undefined}
+    {...props}
+  >
+    {title ? <title>{title}</title> : null}
+
+    <circle cx="11" cy="11" r="6" stroke="currentColor" strokeWidth="2" />
+    <path
+      d="m15.5 15.5 4.5 4.5"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+);

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,12 +1,18 @@
 export type { IconProps } from "./types.js";
 export { __ICON_TYPES__ } from "./types.js";
 import { ArrowRight } from "./icons/arrow-right.js";
+import { Close } from "./icons/close.js";
 import { CheckCircle } from "./icons/check-circle.js";
+import { Eye } from "./icons/eye.js";
 import { Plus } from "./icons/plus.js";
-export { ArrowRight, CheckCircle, Plus };
+import { Search } from "./icons/search.js";
+export { ArrowRight, CheckCircle, Close, Eye, Plus, Search };
 export const icons = {
   ArrowRight,
   CheckCircle,
-  Plus
+  Close,
+  Eye,
+  Plus,
+  Search
 } as const;
 export type IconName = keyof typeof icons;

--- a/packages/icons/svgs/close.svg
+++ b/packages/icons/svgs/close.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="M6 6l12 12M18 6 6 18"/>
+</svg>

--- a/packages/icons/svgs/eye.svg
+++ b/packages/icons/svgs/eye.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12s3.5-6 9-6 9 6 9 6-3.5 6-9 6-9-6-9-6Z"/>
+  <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/packages/icons/svgs/search.svg
+++ b/packages/icons/svgs/search.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none" viewBox="0 0 24 24">
+  <circle cx="11" cy="11" r="6" stroke="currentColor" stroke-width="2"/>
+  <path stroke="currentColor" stroke-linecap="round" stroke-width="2" d="m15.5 15.5 4.5 4.5"/>
+</svg>

--- a/packages/react/src/components/text-field/TextField.tsx
+++ b/packages/react/src/components/text-field/TextField.tsx
@@ -15,8 +15,10 @@ import {
   type ReactNode,
   type Ref
 } from "react";
+import { Close, Eye } from "@ara/icons";
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { useTextField, type TextFieldType } from "@ara/core";
+import { Icon } from "../icon/index.js";
 
 type TextFieldSize = "sm" | "md" | "lg";
 
@@ -348,6 +350,9 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
   const filled = Boolean(currentValue);
 
   const sizeTokens = SIZE_TOKENS[size];
+  const iconSizeValue = `var(--ara-tf-size-${size}-icon, ${sizeTokens.icon})`;
+  const clearSizeValue = `var(--ara-tf-size-${size}-clear, ${sizeTokens.clear})`;
+  const toggleSizeValue = `var(--ara-tf-size-${size}-toggle, ${sizeTokens.toggle})`;
   const maxLengthValue =
     typeof restInputProps.maxLength === "number"
       ? restInputProps.maxLength
@@ -465,8 +470,8 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
     display: "inline-flex",
     alignItems: "center",
     justifyContent: "center",
-    width: `var(--ara-tf-size-${size}-icon, ${sizeTokens.icon})`,
-    height: `var(--ara-tf-size-${size}-icon, ${sizeTokens.icon})`,
+    width: iconSizeValue,
+    height: iconSizeValue,
     flexShrink: 0
   };
 
@@ -479,8 +484,8 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
     display: "inline-flex",
     alignItems: "center",
     justifyContent: "center",
-    width: `var(--ara-tf-size-${size}-clear, ${sizeTokens.clear})`,
-    height: `var(--ara-tf-size-${size}-clear, ${sizeTokens.clear})`,
+    width: clearSizeValue,
+    height: clearSizeValue,
     padding: 0,
     margin: 0
   };
@@ -624,7 +629,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
             disabled={disabled}
             aria-label="입력 지우기"
           >
-            ×
+            <Icon icon={Close} size={iconSizeValue} aria-hidden />
           </button>
         ) : null}
 
@@ -634,12 +639,12 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
             onClick={handleTogglePassword}
             onMouseDown={(event) => event.preventDefault()}
             className="ara-text-field__toggle"
-            style={{ ...actionButtonStyle, width: sizeTokens.toggle, height: sizeTokens.toggle }}
+            style={{ ...actionButtonStyle, width: toggleSizeValue, height: toggleSizeValue }}
             disabled={disabled}
             aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 보이기"}
             aria-pressed={showPassword}
           >
-            {showPassword ? "🙈" : "👁"}
+            <Icon icon={Eye} size={iconSizeValue} aria-hidden />
           </button>
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- [x] TextField의 clear/password 토글 버튼을 @ara/icons의 Close/Eye 아이콘과 Icon 컴포넌트로 교체했습니다. (WBS: W-000008 / Task: T-000080)
- [x] 검색 필드 등 스토리북 예제의 prefix 아이콘을 Search 자산으로 맞추고 안내 문구를 최신화했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [ ] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/react lint`

## Screenshots
UI 변경은 별도 스크린샷이 필요하지 않습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923fd67567c8322bd8c4609194b9de0)