### PR TITLE
Add @ara/icons alias for showcase build

### DIFF
--- a/apps/showcase/vite.config.ts
+++ b/apps/showcase/vite.config.ts
@@ -62,6 +62,14 @@ export default defineConfig({
       {
         find: "@ara/tokens/",
         replacement: `${resolve(currentDir, "../../packages/tokens/src")}/`
+      },
+      {
+        find: "@ara/icons",
+        replacement: resolve(currentDir, "../../packages/icons/src")
+      },
+      {
+        find: "@ara/icons/",
+        replacement: `${resolve(currentDir, "../../packages/icons/src")}/`
       }
     ]
   },


### PR DESCRIPTION
## Summary
- add Vite alias mappings for @ara/icons in the showcase app
- allow Vite/Rollup to resolve icon imports during the production build

## Testing
- pnpm --filter @ara/showcase build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692400ac3dbc8322bb5bb77c77e9fcb3)