### PR TITLE
Add distinct password visibility toggle icon

### DIFF
--- a/packages/icons/src/EyeOff.ts
+++ b/packages/icons/src/EyeOff.ts
@@ -1,0 +1,1 @@
+export { EyeOff } from "./icons/eye-off.js";

--- a/packages/icons/src/icons/eye-off.tsx
+++ b/packages/icons/src/icons/eye-off.tsx
@@ -1,0 +1,44 @@
+import type { IconProps } from "../types.js";
+
+export const EyeOff = ({ title, ...props }: IconProps) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden={title ? undefined : true}
+    role={title ? "img" : undefined}
+    {...props}
+  >
+    {title ? <title>{title}</title> : null}
+
+    <path
+      d="M10.73 5.08A10.1 10.1 0 0 1 12 5c5 0 9 5 9 7 0 .99-.6 2.54-1.67 3.96"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M6.12 6.12A10.45 10.45 0 0 0 3 12c0 2 4 7 9 7 1.3 0 2.53-.26 3.67-.74"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="m3 3 18 18"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14.12 14.12A3 3 0 0 1 9.88 9.88"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -4,14 +4,16 @@ import { ArrowRight } from "./icons/arrow-right.js";
 import { Close } from "./icons/close.js";
 import { CheckCircle } from "./icons/check-circle.js";
 import { Eye } from "./icons/eye.js";
+import { EyeOff } from "./icons/eye-off.js";
 import { Plus } from "./icons/plus.js";
 import { Search } from "./icons/search.js";
-export { ArrowRight, CheckCircle, Close, Eye, Plus, Search };
+export { ArrowRight, CheckCircle, Close, Eye, EyeOff, Plus, Search };
 export const icons = {
   ArrowRight,
   CheckCircle,
   Close,
   Eye,
+  EyeOff,
   Plus,
   Search
 } as const;

--- a/packages/react/src/components/text-field/TextField.tsx
+++ b/packages/react/src/components/text-field/TextField.tsx
@@ -15,7 +15,7 @@ import {
   type ReactNode,
   type Ref
 } from "react";
-import { Close, Eye } from "@ara/icons";
+import { Close, Eye, EyeOff } from "@ara/icons";
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { useTextField, type TextFieldType } from "@ara/core";
 import { Icon } from "../icon/index.js";
@@ -644,7 +644,7 @@ export const TextField = forwardRef<HTMLDivElement, TextFieldProps>(function Tex
             aria-label={showPassword ? "비밀번호 숨기기" : "비밀번호 보이기"}
             aria-pressed={showPassword}
           >
-            <Icon icon={Eye} size={iconSizeValue} aria-hidden />
+            <Icon icon={showPassword ? EyeOff : Eye} size={iconSizeValue} aria-hidden />
           </button>
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- add an eye-off icon to the icons package and export it
- swap the password toggle to display the closed-eye icon when the password is visible

## Testing
- pnpm --filter @ara/react test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69240439e59c83229a7d15d58fd9635a)