### PR TITLE
[T-000083] Form Controls 계약 문서 초안

### DIFF
--- a/packages/react/src/components/checkbox/README.md
+++ b/packages/react/src/components/checkbox/README.md
@@ -1,0 +1,114 @@
+# Checkbox / CheckboxGroup
+
+> 파일: `packages/react/src/components/checkbox/README.md`
+> 범위: 단일 체크박스와 체크박스 그룹(다중 선택). 토글 스위치, 라디오 그룹은 별도 계약 참고.
+
+## 1) 목적 / 범위
+
+- **목적:** 체크박스/체크박스 그룹의 Props·이벤트·상태(data-state)·Exports 계약을 확정한다.
+- **성공 기준:** 구현/스토리/테스트가 본 계약과 일치하며, 이후 변경은 SemVer Major 사유로 관리한다.
+
+---
+
+## 2) Public API (Props 계약)
+
+### Checkbox
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **checked** | `boolean | "indeterminate"` | — | 제어 모드 상태. 존재 시 `onCheckedChange` 필수. |
+| **defaultChecked** | `boolean | "indeterminate"` | false | 비제어 초기 상태. 이후 내부에서 관리. |
+| **onCheckedChange** | `(state: boolean | "indeterminate") => void` | — | 상태 변경 시 호출. indeterminate → click/space 시 `true` 로 전환. |
+| **value** | string | "on" | 폼 제출 값. 그룹 내에서는 각 항목의 고유 값. |
+| **name** | string | — | 네이티브 폼 제출용 이름. 그룹에서 전달받은 이름 우선. |
+| **label** | ReactNode | — | 표시 레이블. `<label for>` 연결. |
+| **description** | ReactNode | — | 보조 설명. `aria-describedby` 연결. |
+| **disabled** | boolean | false | 상호작용 차단 + `data-disabled` + `aria-disabled`. |
+| **readOnly** | boolean | false | 읽기 전용. 값 보여주되 토글 차단, `aria-readonly` 적용. |
+| **required** | boolean | false | 필수 여부. `aria-required` 적용, UI 표시 선택. |
+| **invalid** | boolean | false | 오류 상태. `aria-invalid` + `data-invalid`. |
+| **id** | string | — | 숨김 `<input>` id. 미지정 시 자동 생성. |
+| **inputRef** | `React.Ref<HTMLInputElement>` | — | 내부 `<input type="checkbox">` 포워딩. |
+| **className / style** | 문자열 / 스타일 | — | 루트 요소에 병합. 사용자 정의 우선. |
+
+> **CheckedState 규칙:** `"indeterminate"` 는 표시 전용 상태이며, 다음 상호작용에서 `true` 로 전환된다.
+
+### CheckboxGroup
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **value** | `string[]` | — | 제어 모드 선택 목록. |
+| **defaultValue** | `string[]` | `[]` | 비제어 초기 선택 목록. |
+| **onValueChange** | `(values: string[]) => void` | — | 그룹 선택 변경 시 호출. 중복 없는 배열 보장. |
+| **name** | string | — | 그룹 전체에서 공유할 `input` name. 지정 시 각 항목에 동일 적용. |
+| **label** | ReactNode | — | 그룹 레이블. `aria-labelledby`로 연결. |
+| **description** | ReactNode | — | 그룹 설명. `aria-describedby` 연결. |
+| **disabled** | boolean | false | 그룹 내 모든 항목 비활성화. 항목 개별 `disabled`가 있으면 그룹보다 우선? 아니 그룹 우선. |
+| **readOnly** | boolean | false | 그룹 전체 읽기 전용. 항목 개별 `readOnly`와 병합 시 그룹 우선. |
+| **required** | boolean | false | 최소 1개 선택 요구 시 `aria-required` 적용(네이티브 검증은 직접 처리 필요). |
+| **invalid** | boolean | false | 오류 상태. 그룹 컨테이너 및 항목에 `data-invalid`/`aria-invalid` 반영. |
+| **orientation** | horizontal · vertical | vertical | 배치 방향. 키보드 포커스 이동 힌트에 사용. |
+| **className / style** | 문자열 / 스타일 | — | 그룹 루트에 병합. |
+
+> **항목 등록 규칙:** 그룹 컨텍스트가 항목에 `name/disabled/readOnly/required/invalid/onChange`를 주입해 일관성을 유지한다.
+
+---
+
+## 3) 동작 계약 (Behavior)
+
+- **토글:**
+  - 클릭/Space 로 상태 전환. `indeterminate` → `true` → `false` 순환.
+  - `disabled` 는 모든 상호작용 차단, `readOnly` 는 포커스 허용하되 토글만 차단.
+- **그룹 값 관리:**
+  - 그룹은 항목 `value` 기준으로 집합을 유지한다. 중복 추가 없음.
+  - 항목 토글 결과는 그룹 `onValueChange(updatedValues)` 로 통지. 제어 모드에서는 상위에서 배열을 갱신해야 UI가 반영된다.
+- **폼 제출:**
+  - 단일 체크박스: `name`+`value` 가 설정된 경우에만 제출. 미선택 시 미포함.
+  - 그룹: 동일 `name` 으로 여러 값이 제출된다. `disabled` 항목은 제출 제외, `readOnly` 는 제출 포함.
+- **포커스 흐름:**
+  - 체크박스 단독: 기본 탭 순서 사용.
+  - 그룹: 포커스 이동은 브라우저 기본(tab) + 컨테이너 단위 포커스 보조 UI 가능(로빙 탭 인덱스는 라디오 그룹에만 적용).
+  - `orientation`이 horizontal 이면 좌우 방향키 안내를 문서화하되, 실제 키보드 포커스 이동은 기본값을 유지한다.
+
+---
+
+## 4) 접근성 계약 (A11y)
+
+- **역할/속성:** 숨김 `<input type="checkbox">` 에 `checked|indeterminate` 상태를 설정하고, 커스텀 UI는 `role="checkbox"` + `aria-checked` 로 동기화.
+- **레이블:** `label` 제공 시 `<label for>` 연결 및 `aria-labelledby` 구성. 외부 `aria-labelledby` 가 전달되면 병합.
+- **설명:** `description` 이 존재하면 `aria-describedby`에 포함. 그룹 `description` 은 개별 항목과 병합.
+- **상태 ARIA:**
+  - `required` → `aria-required="true"`
+  - `disabled` → `aria-disabled="true"` + 포커스/입력 차단
+  - `readOnly` → `aria-readonly="true"` (포커스 허용)
+  - `invalid` → `aria-invalid="true"`
+- **키보드:** Space/Enter 로 토글, `Tab` 으로 포커스 이동. 그룹에서는 로빙 탭 인덱스 미사용.
+
+---
+
+## 5) 스타일/데이터 속성
+
+- **데이터 속성:** `[data-state="checked|unchecked|indeterminate"]`, `[data-disabled]`, `[data-readonly]`, `[data-required]`, `[data-invalid]`, `[data-orientation]`(그룹) 노출.
+- **CSS 변수:** 테마 시스템과 연동해 상태별 색상/배경/보더/아이콘 크기 토큰을 정의. (구체 값은 디자인 토큰 확정 시 반영.)
+- **클래스 병합:** 기본 스타일 → 사용자 `className` 순으로 병합.
+
+---
+
+## 6) Exports 계약
+
+- **@ara/react**
+  - `@ara/react/checkbox` → `Checkbox`, `CheckboxProps`, `CheckboxGroup`, `CheckboxGroupProps`
+- **@ara/core**
+  - `@ara/core/use-checkbox` → `useCheckbox`, `UseCheckboxResult`
+  - `@ara/core/use-checkbox-group` → `useCheckboxGroup`, `UseCheckboxGroupResult`
+- **package.json (react 패키지)**
+  - `exports`: `./checkbox`(ESM) + `types`, `sideEffects:false`
+
+---
+
+## 7) 에지 케이스 / 동결 규칙
+
+- `disabled && readOnly` → disabled 우선, readOnly ARIA 생략.
+- `indeterminate` 상태에서 `required`일 경우 최소 1개 선택 규칙은 상위 비즈니스 로직에서 검증.
+- 그룹/항목 `name` 불일치 금지: 그룹이 우선하며, 개별로 다른 name을 주입하려 하면 오류/경고 처리.
+- 본 계약 변경은 Major 사유로 취급한다.

--- a/packages/react/src/components/radio/README.md
+++ b/packages/react/src/components/radio/README.md
@@ -1,0 +1,104 @@
+# Radio / RadioGroup
+
+> 파일: `packages/react/src/components/radio/README.md`
+> 범위: 단일 라디오와 라디오 그룹(단일 선택). 체크박스/스위치는 별도 계약 참고.
+
+## 1) 목적 / 범위
+
+- **목적:** 라디오/라디오 그룹의 Props·이벤트·상태(data-state)·키보드 내비게이션 계약을 명확히 한다.
+- **성공 기준:** 선택 로직, ARIA, Exports 가 본 문서와 일치하며, 변경 시 Major 로 관리한다.
+
+---
+
+## 2) Public API (Props 계약)
+
+### Radio
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **value** | string | — | 그룹에서 구분할 값(필수). 단일 사용 시 폼 제출 값. |
+| **checked** | boolean | — | 제어 모드 선택 여부. 존재 시 `onChange` 필수. |
+| **defaultChecked** | boolean | false | 비제어 초기 선택 여부. |
+| **onChange** | `(checked: boolean) => void` | — | 선택 상태 변경 시 호출. 그룹 제공 핸들러 우선. |
+| **label** | ReactNode | — | 라디오 레이블. `<label for>` 연결. |
+| **description** | ReactNode | — | 보조 설명. `aria-describedby` 연결. |
+| **disabled** | boolean | false | 상호작용 차단, 그룹 `disabled` 우선. |
+| **required** | boolean | false | 단일 라디오 사용 시 적용. 그룹에서는 그룹 `required` 가 우선. |
+| **invalid** | boolean | false | 오류 표시 및 `aria-invalid` 설정. 그룹 상태와 병합 시 그룹 우선. |
+| **id** | string | — | 숨김 `<input>` id. 미지정 시 자동 생성. |
+| **inputRef** | `React.Ref<HTMLInputElement>` | — | 내부 `<input type="radio">` 포워딩. |
+| **className / style** | 문자열 / 스타일 | — | 루트 요소에 병합. |
+
+### RadioGroup
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **value** | string | — | 제어 모드 선택 값. |
+| **defaultValue** | string | — | 비제어 초기 선택 값. 미설정 시 아무것도 선택되지 않음. |
+| **onValueChange** | `(value: string) => void` | — | 선택 변경 시 호출. 제어 모드에서 UI 갱신은 상위 책임. |
+| **name** | string | — | 그룹 내 모든 라디오에 동일 적용되는 `name`. 폼 제출 시 단일 값으로 전달. |
+| **label** | ReactNode | — | 그룹 레이블. `aria-labelledby` 연결. |
+| **description** | ReactNode | — | 그룹 설명. `aria-describedby` 연결. |
+| **disabled** | boolean | false | 그룹 전체 비활성화. 항목 개별 `disabled` 존재 시 그룹 우선. |
+| **required** | boolean | false | 최소 1개 선택 요구. 네이티브 검증 시 group `required` 를 첫 항목에 적용. |
+| **invalid** | boolean | false | 오류 상태. `aria-invalid`/`data-invalid`를 그룹/항목에 반영. |
+| **orientation** | horizontal · vertical | vertical | 표시 방향 + 키보드 이동 힌트. |
+| **loop** | boolean | true | 화살표 탐색 시 끝에서 시작으로 순환 여부. |
+| **className / style** | 문자열 / 스타일 | — | 그룹 루트 병합. |
+
+> **항목 컨텍스트:** 그룹은 각 라디오에 `name`, `onChange`, `checked` 상태, `disabled/required/invalid` 플래그를 주입한다.
+
+---
+
+## 3) 동작 계약 (Behavior)
+
+- **단일 선택:**
+  - 클릭/Space/Enter 시 해당 라디오로 선택 이동. 다른 항목은 자동 해제.
+  - 제어 모드에서는 `onValueChange` 호출만 수행하며, 렌더 상태는 상위 `value`에 의존.
+- **키보드 내비게이션:**
+  - `Tab` 으로 그룹 컨테이너에 진입하면 현재 선택된 항목이 포커스를 받는다. 선택이 없으면 첫 항목 포커스.
+  - 좌우(orientation=horizontal) 또는 상하(orientation=vertical) 화살표로 포커스를 이동하며, 이동과 동시에 선택을 갱신한다.
+  - `loop=true` 시 마지막→첫/첫→마지막으로 순환. `loop=false`면 끝에서 멈춤.
+- **폼 제출:** `name`이 설정된 경우 선택된 라디오의 `value` 하나만 제출. 미선택이면 제출되지 않음.
+- **포커스 표시:** 키보드 진입 시 포커스 링을 명확히 표시하고, 마우스 클릭 시 최소화한다.
+
+---
+
+## 4) 접근성 계약 (A11y)
+
+- **역할/속성:** 커스텀 UI에는 `role="radio"` + `aria-checked`를 적용하고, 그룹 컨테이너에는 `role="radiogroup"` + `aria-labelledby`/`aria-describedby`를 연결한다.
+- **레이블/설명:** `label`/`description` 은 각각 `aria-labelledby`/`aria-describedby` 로 연결. 외부 aria 속성 전달 시 병합.
+- **상태 ARIA:**
+  - `disabled` → `aria-disabled="true"`
+  - `required` → `aria-required="true"`
+  - `invalid` → `aria-invalid="true"`
+- **로빙 탭 인덱스:** 그룹은 하나의 포커스 루트를 유지하기 위해 선택 항목에 `tabIndex=0`, 나머지에 `-1`을 부여한다.
+
+---
+
+## 5) 스타일/데이터 속성
+
+- **데이터 속성:** `[data-state="checked|unchecked"]`, `[data-disabled]`, `[data-required]`, `[data-invalid]`, `[data-orientation]`, `[data-loop]`.
+- **CSS 변수:** 상태별 배경/보더/포커스 링/아이콘 토큰을 정의. orientation 에 따라 간격/정렬 토큰 분기.
+- **클래스 병합:** 기본 스타일 후 사용자 `className`을 마지막에 적용.
+
+---
+
+## 6) Exports 계약
+
+- **@ara/react**
+  - `@ara/react/radio` → `Radio`, `RadioProps`, `RadioGroup`, `RadioGroupProps`
+- **@ara/core**
+  - `@ara/core/use-radio` → `useRadio`, `UseRadioResult`
+  - `@ara/core/use-radio-group` → `useRadioGroup`, `UseRadioGroupResult`
+- **package.json (react 패키지)**
+  - `exports`: `./radio`(ESM) + `types`, `sideEffects:false`
+
+---
+
+## 7) 에지 케이스 / 동결 규칙
+
+- 그룹 없이 단일 라디오 사용 시에도 ARIA/폼 제출이 일관되도록 `name`/`required`/`invalid` 를 그대로 반영한다.
+- `disabled && required` 조합은 disabled 우선. required ARIA는 생략한다.
+- 화살표 이동 시 스크롤 발생을 방지하기 위해 기본 동작을 `preventDefault` 처리한다.
+- 계약 변경은 Major 사유로 취급한다.

--- a/packages/react/src/components/switch/README.md
+++ b/packages/react/src/components/switch/README.md
@@ -1,0 +1,78 @@
+# Switch
+
+> 파일: `packages/react/src/components/switch/README.md`
+> 범위: 토글 스위치(checkbox semantics 기반). 체크박스/라디오 그룹은 별도 문서 참고.
+
+## 1) 목적 / 범위
+
+- **목적:** 스위치의 Props·이벤트·상태(data-state)·ARIA 계약을 확정한다.
+- **성공 기준:** 폼 제출/키보드/스크린리더 동작이 계약과 일치하며, 변경 시 Major 로 관리한다.
+
+---
+
+## 2) Public API (Props 계약)
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **checked** | boolean | — | 제어 모드 상태. 존재 시 `onCheckedChange` 필수. |
+| **defaultChecked** | boolean | false | 비제어 초기 상태. |
+| **onCheckedChange** | `(checked: boolean) => void` | — | 상태 변경 시 호출. 스페이스/클릭/폼 reset 등 모든 변경 경로 포함. |
+| **name** | string | — | 폼 제출용 이름. 숨김 체크박스에 적용. |
+| **value** | string | "on" | 제출 값. 미선택 시 제출되지 않음. |
+| **label** | ReactNode | — | 시각적 레이블. `<label for>` 연결. |
+| **description** | ReactNode | — | 보조 설명. `aria-describedby` 연결. |
+| **disabled** | boolean | false | 상호작용 차단 + `data-disabled` + `aria-disabled`. |
+| **readOnly** | boolean | false | 읽기 전용. 포커스는 허용하되 토글 차단, `aria-readonly` 적용. |
+| **required** | boolean | false | 필수 여부. 네이티브 검증 힌트(`aria-required`). |
+| **invalid** | boolean | false | 오류 상태. `aria-invalid` + `data-invalid`. |
+| **id** | string | — | 숨김 `<input>` id. 미지정 시 자동 생성. |
+| **inputRef** | `React.Ref<HTMLInputElement>` | — | 내부 `<input type="checkbox">` 포워딩. |
+| **className / style** | 문자열 / 스타일 | — | 루트 요소에 병합. |
+
+> **역할:** 스위치는 시맨틱상 체크박스를 사용하되, 커스텀 UI에 `role="switch"` + `aria-checked`를 부여한다.
+
+---
+
+## 3) 동작 계약 (Behavior)
+
+- **토글:** 클릭/Space/Enter 로 `true ↔ false` 전환. `readOnly` 는 토글 무효화, `disabled` 는 포커스도 차단.
+- **폼 제출:** `name` 설정 시 체크박스 값으로 제출. 미체크 시 제출 생략. `value` 는 문자열만 허용.
+- **reset 대응:** 비제어 모드에서 `form.reset()` 시 초기값으로 돌아가며, 제어 모드에서는 상위에서 `checked` 갱신 필요.
+- **포커스:** 키보드 진입 시 포커스 링 표시. 클릭 시에도 포커스 유지해 토글 후 단절 방지.
+
+---
+
+## 4) 접근성 계약 (A11y)
+
+- **역할/속성:** 커스텀 UI에 `role="switch"` + `aria-checked` 적용. 숨김 체크박스는 시각적으로 숨기되 포커스/스크린리더 가능하도록 유지.
+- **레이블/설명:** `label`/`description` 은 각각 `aria-labelledby`/`aria-describedby` 로 연결. 외부 aria 전달 시 병합.
+- **상태 ARIA:**
+  - `disabled` → `aria-disabled="true"`
+  - `readOnly` → `aria-readonly="true"`
+  - `required` → `aria-required="true"`
+  - `invalid` → `aria-invalid="true"`
+- **키보드:** Space/Enter 토글, `Tab` 포커스 이동. 방향키 특별 처리 없음.
+
+---
+
+## 5) 스타일/데이터 속성
+
+- **데이터 속성:** `[data-state="checked|unchecked"]`, `[data-disabled]`, `[data-readonly]`, `[data-required]`, `[data-invalid]`.
+- **CSS 변수:** thumb/track 색상·크기·애니메이션 토큰을 상태별로 제공. 포커스 링/disabled opacity 포함.
+- **클래스 병합:** 기본 스타일 뒤 사용자 `className` 적용.
+
+---
+
+## 6) Exports 계약
+
+- **@ara/react**: `@ara/react/switch` → `Switch`, `SwitchProps`
+- **@ara/core**: `@ara/core/use-switch` → `useSwitch`, `UseSwitchResult`
+- **package.json (react 패키지)**: `exports`에 `./switch`(ESM) + `types`, `sideEffects:false`
+
+---
+
+## 7) 에지 케이스 / 동결 규칙
+
+- `disabled && readOnly` → disabled 우선, readOnly ARIA 생략.
+- `required` 는 UI 표시 선택적이며, 실제 검증/오류 메시지는 상위 폼 로직에서 처리.
+- 계약 변경은 Major 사유로 취급한다.


### PR DESCRIPTION
## Summary
- [x] Checkbox/CheckboxGroup의 props·동작·ARIA·exports 계약 초안을 추가했습니다.
- [x] Radio/RadioGroup의 선택 흐름, 키보드 내비게이션, 데이터 속성을 명세했습니다.
- [x] Switch 토글/폼 제출/접근성 계약과 내보내기 범위를 정의했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [ ] 관련 스크립트나 테스트를 실행했습니다. (문서 변경으로 실행하지 않았습니다.)
- [ ] 테스트 결과를 아래에 기재했습니다.

## Screenshots
- 해당 사항 없음


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924fcba75dc83228c544be0b6eb43f1)