### PR TITLE
T-000084: useCheckbox 훅 추가

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/use-button.js",
       "default": "./dist/use-button.js"
     },
+    "./use-checkbox": {
+      "types": "./dist/use-checkbox.d.ts",
+      "import": "./dist/use-checkbox.js",
+      "default": "./dist/use-checkbox.js"
+    },
     "./use-text-field": {
       "types": "./dist/use-text-field.d.ts",
       "import": "./dist/use-text-field.js",
@@ -36,6 +41,9 @@
       ],
       "use-button": [
         "dist/use-button.d.ts"
+      ],
+      "use-checkbox": [
+        "dist/use-checkbox.d.ts"
       ],
       "use-text-field": [
         "dist/use-text-field.d.ts"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,3 +18,15 @@ export type {
   UseTextFieldResult
 } from "./use-text-field.js";
 export { useTextField } from "./use-text-field.js";
+export type {
+  CheckboxAriaState,
+  CheckboxDataState,
+  CheckboxDescriptionProps,
+  CheckboxInputProps,
+  CheckboxLabelProps,
+  CheckboxRootProps,
+  CheckboxState,
+  UseCheckboxOptions,
+  UseCheckboxResult
+} from "./use-checkbox.js";
+export { useCheckbox } from "./use-checkbox.js";

--- a/packages/core/src/use-checkbox.test.tsx
+++ b/packages/core/src/use-checkbox.test.tsx
@@ -1,0 +1,192 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { type PropsWithChildren, useState } from "react";
+import { useCheckbox, type UseCheckboxOptions } from "./use-checkbox.js";
+
+describe("useCheckbox", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function CheckboxField({
+    options,
+    withLabel = true,
+    withDescription = false
+  }: PropsWithChildren<{
+    options?: UseCheckboxOptions;
+    withLabel?: boolean;
+    withDescription?: boolean;
+  }>) {
+    const { rootProps, inputProps, labelProps, descriptionProps, checkedState, isChecked, isIndeterminate } =
+      useCheckbox({
+        ...options,
+        hasLabel: withLabel,
+        hasDescription: withDescription
+      });
+
+    return (
+      <div data-testid="root" {...rootProps} data-checked={isChecked} data-indeterminate={isIndeterminate}>
+        <input data-testid="input" {...inputProps} />
+        {withLabel ? (
+          <label data-testid="label" {...labelProps}>
+            label
+          </label>
+        ) : null}
+        {withDescription ? (
+          <p data-testid="description" {...descriptionProps}>
+            description
+          </p>
+        ) : null}
+        <span data-testid="state">{String(checkedState)}</span>
+      </div>
+    );
+  }
+
+  it("generates ids and aria attributes for label/description", () => {
+    const { getByTestId } = render(
+      <CheckboxField
+        withDescription
+        options={{
+          id: "checkbox-id",
+          required: true,
+          invalid: true
+        }}
+      />
+    );
+
+    const root = getByTestId("root");
+    const input = getByTestId("input");
+    const label = getByTestId("label");
+    const description = getByTestId("description");
+
+    expect(label).toHaveAttribute("id", "checkbox-id-label");
+    expect(label).toHaveAttribute("for", "checkbox-id");
+    expect(description).toHaveAttribute("id", "checkbox-id-description");
+
+    expect(root).toHaveAttribute("aria-labelledby", "checkbox-id-label");
+    expect(root.getAttribute("aria-describedby")).toBe("checkbox-id-description");
+    expect(root).toHaveAttribute("aria-required", "true");
+    expect(root).toHaveAttribute("aria-invalid", "true");
+
+    expect(input).toHaveAttribute("id", "checkbox-id");
+    expect(input).toHaveAttribute("aria-labelledby", "checkbox-id-label");
+    expect(input.getAttribute("aria-describedby")).toBe("checkbox-id-description");
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("merges external labelling and description ids", () => {
+    const { getByTestId } = render(
+      <CheckboxField
+        withDescription
+        options={{
+          id: "merge-id",
+          describedByIds: ["external-description"],
+          labelledByIds: ["external-label"]
+        }}
+      />
+    );
+
+    const root = getByTestId("root");
+    const input = getByTestId("input");
+
+    expect(root.getAttribute("aria-labelledby")).toBe("merge-id-label external-label");
+    expect(input.getAttribute("aria-labelledby")).toBe("merge-id-label external-label");
+    expect(root.getAttribute("aria-describedby")).toBe("merge-id-description external-description");
+    expect(input.getAttribute("aria-describedby")).toBe("merge-id-description external-description");
+  });
+
+  it("cycles indeterminate → checked → unchecked on interactions", () => {
+    const onCheckedChange = vi.fn();
+    const { getByTestId } = render(
+      <CheckboxField
+        withDescription
+        options={{
+          defaultChecked: "indeterminate",
+          onCheckedChange
+        }}
+      />
+    );
+
+    const root = getByTestId("root");
+    const input = getByTestId("input") as HTMLInputElement;
+    const state = getByTestId("state");
+
+    expect(root).toHaveAttribute("data-state", "indeterminate");
+    expect(input.indeterminate).toBe(true);
+
+    fireEvent.click(root);
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+    expect(state.textContent).toBe("true");
+    expect(root).toHaveAttribute("data-state", "checked");
+    expect(input.checked).toBe(true);
+
+    fireEvent.keyDown(root, { key: " " });
+    expect(onCheckedChange).toHaveBeenCalledWith(false);
+    expect(state.textContent).toBe("false");
+    expect(root).toHaveAttribute("data-state", "unchecked");
+    expect(input.checked).toBe(false);
+  });
+
+  it("respects controlled checked state", () => {
+    function ControlledCheckbox() {
+      const [value, setValue] = useState<UseCheckboxOptions["checked"]>("indeterminate");
+      const handleChange = (next: UseCheckboxOptions["checked"]) => setValue(next);
+      const { rootProps, inputProps, checkedState } = useCheckbox({ checked: value, onCheckedChange: handleChange });
+
+      return (
+        <div data-testid="root" {...rootProps}>
+          <input data-testid="input" {...inputProps} />
+          <span data-testid="state">{String(checkedState)}</span>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<ControlledCheckbox />);
+    const root = getByTestId("root");
+    const input = getByTestId("input") as HTMLInputElement;
+    const state = getByTestId("state");
+
+    expect(input.indeterminate).toBe(true);
+
+    fireEvent.click(root);
+    expect(state.textContent).toBe("true");
+    fireEvent.keyDown(root, { key: "Enter" });
+    expect(state.textContent).toBe("false");
+  });
+
+  it("blocks toggling when disabled or readOnly", () => {
+    const { getByTestId: getDisabled, unmount } = render(
+      <CheckboxField
+        options={{
+          defaultChecked: true,
+          disabled: true
+        }}
+      />
+    );
+
+    const disabledRoot = getDisabled("root");
+    const disabledInput = getDisabled("input") as HTMLInputElement;
+
+    fireEvent.click(disabledRoot);
+    expect(disabledInput.checked).toBe(true);
+
+    unmount();
+
+    const { getByTestId: getReadOnly } = render(
+      <CheckboxField
+        options={{
+          defaultChecked: false,
+          readOnly: true
+        }}
+      />
+    );
+
+    const readOnlyRoot = getReadOnly("root");
+    const readOnlyInput = getReadOnly("input") as HTMLInputElement;
+
+    fireEvent.keyDown(readOnlyRoot, { key: " " });
+    expect(readOnlyInput.checked).toBe(false);
+  });
+});

--- a/packages/core/src/use-checkbox.ts
+++ b/packages/core/src/use-checkbox.ts
@@ -1,0 +1,279 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+  type MouseEvent
+} from "react";
+
+export type CheckboxState = boolean | "indeterminate";
+export type CheckboxAriaState = boolean | "mixed";
+export type CheckboxDataState = "checked" | "unchecked" | "indeterminate";
+
+export interface UseCheckboxOptions {
+  readonly id?: string;
+  readonly name?: string;
+  readonly value?: string;
+  readonly checked?: CheckboxState;
+  readonly defaultChecked?: CheckboxState;
+  readonly required?: boolean;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly invalid?: boolean;
+  readonly hasLabel?: boolean;
+  readonly hasDescription?: boolean;
+  readonly describedByIds?: readonly string[];
+  readonly labelledByIds?: readonly string[];
+  readonly onCheckedChange?: (checked: CheckboxState) => void;
+}
+
+interface UseCheckboxIds {
+  readonly inputId: string;
+  readonly labelId: string;
+  readonly descriptionId: string;
+}
+
+export interface UseCheckboxResult {
+  readonly rootProps: CheckboxRootProps;
+  readonly inputProps: CheckboxInputProps;
+  readonly labelProps: CheckboxLabelProps;
+  readonly descriptionProps: CheckboxDescriptionProps;
+  readonly checkedState: CheckboxState;
+  readonly isChecked: boolean;
+  readonly isIndeterminate: boolean;
+}
+
+export interface CheckboxRootProps {
+  readonly role: "checkbox";
+  readonly tabIndex: number;
+  readonly "aria-checked": CheckboxAriaState;
+  readonly "aria-labelledby"?: string;
+  readonly "aria-describedby"?: string;
+  readonly "aria-required"?: true;
+  readonly "aria-invalid"?: true;
+  readonly "aria-readonly"?: true;
+  readonly "aria-disabled"?: true;
+  readonly "data-state": CheckboxDataState;
+  readonly "data-disabled"?: true;
+  readonly "data-readonly"?: true;
+  readonly "data-required"?: true;
+  readonly "data-invalid"?: true;
+  readonly onClick: (event: MouseEvent<HTMLElement>) => void;
+  readonly onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+}
+
+export interface CheckboxInputProps {
+  readonly id: string;
+  readonly name?: string;
+  readonly value: string;
+  readonly required?: boolean;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly checked: boolean;
+  readonly ref: (node: HTMLInputElement | null) => void;
+  readonly "aria-invalid"?: true;
+  readonly "aria-required"?: true;
+  readonly "aria-readonly"?: true;
+  readonly "aria-disabled"?: true;
+  readonly "aria-describedby"?: string;
+  readonly "aria-labelledby"?: string;
+  readonly onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export interface CheckboxLabelProps {
+  readonly id: string;
+  readonly htmlFor: string;
+}
+
+export interface CheckboxDescriptionProps {
+  readonly id: string;
+}
+
+export function useCheckbox(options: UseCheckboxOptions = {}): UseCheckboxResult {
+  const {
+    id,
+    name,
+    value = "on",
+    checked,
+    defaultChecked = false,
+    required = false,
+    disabled = false,
+    readOnly = false,
+    invalid = false,
+    hasLabel = true,
+    hasDescription = false,
+    describedByIds = [],
+    labelledByIds = [],
+    onCheckedChange
+  } = options;
+
+  const generatedId = useId();
+  const ids = useMemo<UseCheckboxIds>(() => {
+    const inputId = id ?? `ara-checkbox-${generatedId}`;
+    return {
+      inputId,
+      labelId: `${inputId}-label`,
+      descriptionId: `${inputId}-description`
+    };
+  }, [generatedId, id]);
+
+  const appliedReadOnly = !disabled && readOnly;
+  const isControlled = checked !== undefined;
+  const [uncontrolledState, setUncontrolledState] = useState<CheckboxState>(defaultChecked);
+  const currentState = isControlled ? checked ?? false : uncontrolledState;
+  const stateRef = useRef<CheckboxState>(currentState);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const dataState: CheckboxDataState = useMemo(() => {
+    if (currentState === "indeterminate") return "indeterminate";
+    return currentState ? "checked" : "unchecked";
+  }, [currentState]);
+
+  const ariaChecked: CheckboxAriaState = useMemo(() => {
+    if (currentState === "indeterminate") return "mixed";
+    return currentState;
+  }, [currentState]);
+
+  const setCheckedState = useCallback(
+    (next: CheckboxState) => {
+      stateRef.current = next;
+      if (!isControlled) {
+        setUncontrolledState(next);
+      }
+      onCheckedChange?.(next);
+    },
+    [isControlled, onCheckedChange]
+  );
+
+  const toggleState = useCallback(() => {
+    if (disabled || appliedReadOnly) return;
+    const nextState = stateRef.current === "indeterminate" ? true : !stateRef.current;
+    setCheckedState(nextState);
+  }, [appliedReadOnly, disabled, setCheckedState]);
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      if (event.defaultPrevented) return;
+      event.preventDefault();
+      toggleState();
+    },
+    [toggleState]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.defaultPrevented) return;
+      if (event.key === " " || event.key === "Spacebar" || event.key === "Enter") {
+        event.preventDefault();
+        toggleState();
+      }
+    },
+    [toggleState]
+  );
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      toggleState();
+    },
+    [toggleState]
+  );
+
+  useEffect(() => {
+    stateRef.current = currentState;
+  }, [currentState]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = currentState === "indeterminate";
+    }
+  }, [currentState]);
+
+  const ariaDescribedBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasDescription) idsToApply.push(ids.descriptionId);
+    if (describedByIds.length > 0) {
+      for (const describedById of describedByIds) {
+        if (describedById) idsToApply.push(describedById);
+      }
+    }
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [describedByIds, hasDescription, ids.descriptionId]);
+
+  const ariaLabelledBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasLabel) idsToApply.push(ids.labelId);
+    if (labelledByIds.length > 0) {
+      for (const labelledById of labelledByIds) {
+        if (labelledById) idsToApply.push(labelledById);
+      }
+    }
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [hasLabel, labelledByIds, ids.labelId]);
+
+  const rootProps: CheckboxRootProps = {
+    role: "checkbox",
+    tabIndex: disabled ? -1 : 0,
+    "aria-checked": ariaChecked,
+    "aria-labelledby": ariaLabelledBy,
+    "aria-describedby": ariaDescribedBy,
+    "aria-required": required ? true : undefined,
+    "aria-invalid": invalid ? true : undefined,
+    "aria-readonly": appliedReadOnly ? true : undefined,
+    "aria-disabled": disabled ? true : undefined,
+    "data-state": dataState,
+    "data-disabled": disabled ? true : undefined,
+    "data-readonly": appliedReadOnly ? true : undefined,
+    "data-required": required ? true : undefined,
+    "data-invalid": invalid ? true : undefined,
+    onClick: handleClick,
+    onKeyDown: handleKeyDown
+  };
+
+  const inputProps: CheckboxInputProps = {
+    id: ids.inputId,
+    name,
+    value,
+    required: required || undefined,
+    disabled: disabled || undefined,
+    readOnly: appliedReadOnly || undefined,
+    checked: currentState === true,
+    ref: (node) => {
+      inputRef.current = node;
+    },
+    "aria-invalid": invalid ? true : undefined,
+    "aria-required": required ? true : undefined,
+    "aria-readonly": appliedReadOnly ? true : undefined,
+    "aria-disabled": disabled ? true : undefined,
+    "aria-describedby": ariaDescribedBy,
+    "aria-labelledby": ariaLabelledBy,
+    onChange: handleInputChange
+  };
+
+  const labelProps: CheckboxLabelProps = {
+    id: ids.labelId,
+    htmlFor: ids.inputId
+  };
+
+  const descriptionProps: CheckboxDescriptionProps = {
+    id: ids.descriptionId
+  };
+
+  return {
+    rootProps,
+    inputProps,
+    labelProps,
+    descriptionProps,
+    checkedState: currentState,
+    isChecked: currentState === true,
+    isIndeterminate: currentState === "indeterminate"
+  };
+}


### PR DESCRIPTION
## Summary
- [x] useCheckbox 훅으로 체크 상태/ARIA/data 속성 관리를 제공합니다.
- [x] indeterminate 순환 토글과 disabled/readOnly 차단을 검증하는 테스트를 추가합니다.
- [x] 코어 export와 manifest에 use-checkbox 엔트리를 노출합니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] pnpm --filter @ara/core test

## Screenshots
N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692502d572f48322987be915bb7b417c)