### PR TITLE
T-000085: useRadio/useRadioGroup 훅 추가

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,3 +30,23 @@ export type {
   UseCheckboxResult
 } from "./use-checkbox.js";
 export { useCheckbox } from "./use-checkbox.js";
+export type {
+  RadioDataState,
+  RadioDescriptionProps,
+  RadioInputProps,
+  RadioLabelProps,
+  RadioRootProps,
+  UseRadioOptions,
+  UseRadioResult
+} from "./use-radio.js";
+export { useRadio } from "./use-radio.js";
+export type {
+  RadioGroupDescriptionProps,
+  RadioGroupLabelProps,
+  RadioGroupOrientation,
+  RadioGroupRootProps,
+  RadioItemController,
+  UseRadioGroupOptions,
+  UseRadioGroupResult
+} from "./use-radio-group.js";
+export { useRadioGroup } from "./use-radio-group.js";

--- a/packages/core/src/use-radio-group.ts
+++ b/packages/core/src/use-radio-group.ts
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+
+export type RadioGroupOrientation = "horizontal" | "vertical";
+
+export interface UseRadioGroupOptions {
+  readonly id?: string;
+  readonly name?: string;
+  readonly value?: string;
+  readonly defaultValue?: string;
+  readonly required?: boolean;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly invalid?: boolean;
+  readonly orientation?: RadioGroupOrientation;
+  readonly loop?: boolean;
+  readonly hasLabel?: boolean;
+  readonly hasDescription?: boolean;
+  readonly describedByIds?: readonly string[];
+  readonly labelledByIds?: readonly string[];
+  readonly onValueChange?: (value: string) => void;
+}
+
+interface UseRadioGroupIds {
+  readonly rootId: string;
+  readonly labelId: string;
+  readonly descriptionId: string;
+}
+
+export interface RadioGroupRootProps {
+  readonly id: string;
+  readonly role: "radiogroup";
+  readonly "aria-labelledby"?: string;
+  readonly "aria-describedby"?: string;
+  readonly "aria-required"?: true;
+  readonly "aria-invalid"?: true;
+  readonly "aria-readonly"?: true;
+  readonly "aria-disabled"?: true;
+  readonly "aria-orientation"?: RadioGroupOrientation;
+  readonly "data-disabled"?: true;
+  readonly "data-readonly"?: true;
+  readonly "data-orientation": RadioGroupOrientation;
+}
+
+export interface RadioGroupLabelProps {
+  readonly id: string;
+  readonly htmlFor: string;
+}
+
+export interface RadioGroupDescriptionProps {
+  readonly id: string;
+}
+
+export interface RadioItemController {
+  readonly value: string;
+  readonly isDisabled: () => boolean;
+  readonly setTabIndex: (tabIndex: number) => void;
+  readonly focus: () => void;
+}
+
+export interface UseRadioGroupResult {
+  readonly rootProps: RadioGroupRootProps;
+  readonly labelProps: RadioGroupLabelProps;
+  readonly descriptionProps: RadioGroupDescriptionProps;
+  readonly value?: string;
+  readonly name?: string;
+  readonly isDisabled: boolean;
+  readonly isReadOnly: boolean;
+  readonly required: boolean;
+  readonly invalid: boolean;
+  readonly orientation: RadioGroupOrientation;
+  readonly loop: boolean;
+  readonly registerItem: (controller: RadioItemController) => () => void;
+  readonly updateTabStops: () => void;
+  readonly setValue: (value: string) => void;
+  readonly handleArrowNavigation: (current: string, key: string) => void;
+}
+
+export function useRadioGroup(options: UseRadioGroupOptions = {}): UseRadioGroupResult {
+  const {
+    id,
+    name,
+    value,
+    defaultValue,
+    required = false,
+    disabled = false,
+    readOnly = false,
+    invalid = false,
+    orientation = "horizontal",
+    loop = true,
+    hasLabel = true,
+    hasDescription = false,
+    describedByIds = [],
+    labelledByIds = [],
+    onValueChange
+  } = options;
+
+  const generatedId = useId();
+  const ids = useMemo<UseRadioGroupIds>(() => {
+    const rootId = id ?? `ara-radio-group-${generatedId}`;
+    return {
+      rootId,
+      labelId: `${rootId}-label`,
+      descriptionId: `${rootId}-description`
+    };
+  }, [generatedId, id]);
+
+  const groupName = useMemo(() => name ?? ids.rootId, [ids.rootId, name]);
+  const appliedReadOnly = !disabled && readOnly;
+  const isControlled = value !== undefined;
+  const [uncontrolledValue, setUncontrolledValue] = useState<string | undefined>(defaultValue);
+  const currentValue = isControlled ? value : uncontrolledValue;
+  const activeValueRef = useRef<string | undefined>(currentValue);
+  const itemsRef = useRef<RadioItemController[]>([]);
+
+  const setValue = useCallback(
+    (nextValue: string) => {
+      activeValueRef.current = nextValue;
+      if (!isControlled) {
+        setUncontrolledValue(nextValue);
+      }
+      onValueChange?.(nextValue);
+    },
+    [isControlled, onValueChange]
+  );
+
+  const updateTabStops = useCallback(() => {
+    const items = itemsRef.current;
+    const activeValue = activeValueRef.current ?? currentValue;
+
+    let activeIndex = activeValue
+      ? items.findIndex((item) => item.value === activeValue && !item.isDisabled())
+      : -1;
+
+    if (activeIndex === -1) {
+      activeIndex = items.findIndex((item) => !item.isDisabled());
+    }
+
+    items.forEach((item, index) => {
+      item.setTabIndex(index === activeIndex ? 0 : -1);
+    });
+  }, [currentValue]);
+
+  const registerItem = useCallback(
+    (controller: RadioItemController) => {
+      itemsRef.current.push(controller);
+      updateTabStops();
+
+      return () => {
+        itemsRef.current = itemsRef.current.filter((item) => item !== controller);
+        updateTabStops();
+      };
+    },
+    [updateTabStops]
+  );
+
+  const moveFocus = useCallback(
+    (current: string, direction: "next" | "previous") => {
+      const items = itemsRef.current;
+      const currentIndex = items.findIndex((item) => item.value === current);
+      if (currentIndex === -1 || items.length === 0) return;
+
+      const total = items.length;
+      for (let step = 1; step <= total; step += 1) {
+        const offset = direction === "next" ? step : -step;
+        const candidateIndex = currentIndex + offset;
+        if (!loop && (candidateIndex < 0 || candidateIndex >= total)) return;
+
+        const normalizedIndex = (candidateIndex + total) % total;
+        const candidate = items[normalizedIndex];
+        if (!candidate || candidate.isDisabled()) continue;
+
+        activeValueRef.current = candidate.value;
+        candidate.focus();
+        updateTabStops();
+        return;
+      }
+    },
+    [loop, updateTabStops]
+  );
+
+  const handleArrowNavigation = useCallback(
+    (current: string, key: string) => {
+      if (key === "ArrowRight" || key === "ArrowDown") {
+        moveFocus(current, "next");
+      } else if (key === "ArrowLeft" || key === "ArrowUp") {
+        moveFocus(current, "previous");
+      }
+    },
+    [moveFocus]
+  );
+
+  useEffect(() => {
+    activeValueRef.current = currentValue;
+    updateTabStops();
+  }, [currentValue, updateTabStops]);
+
+  const ariaDescribedBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasDescription) idsToApply.push(ids.descriptionId);
+    if (describedByIds.length > 0) {
+      for (const describedById of describedByIds) {
+        if (describedById) idsToApply.push(describedById);
+      }
+    }
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [describedByIds, hasDescription, ids.descriptionId]);
+
+  const ariaLabelledBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasLabel) idsToApply.push(ids.labelId);
+    if (labelledByIds.length > 0) {
+      for (const labelledById of labelledByIds) {
+        if (labelledById) idsToApply.push(labelledById);
+      }
+    }
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [hasLabel, labelledByIds, ids.labelId]);
+
+  const rootProps: RadioGroupRootProps = {
+    id: ids.rootId,
+    role: "radiogroup",
+    "aria-labelledby": ariaLabelledBy,
+    "aria-describedby": ariaDescribedBy,
+    "aria-required": required ? true : undefined,
+    "aria-invalid": invalid ? true : undefined,
+    "aria-readonly": appliedReadOnly ? true : undefined,
+    "aria-disabled": disabled ? true : undefined,
+    "aria-orientation": orientation,
+    "data-disabled": disabled ? true : undefined,
+    "data-readonly": appliedReadOnly ? true : undefined,
+    "data-orientation": orientation
+  };
+
+  const labelProps: RadioGroupLabelProps = {
+    id: ids.labelId,
+    htmlFor: ids.rootId
+  };
+
+  const descriptionProps: RadioGroupDescriptionProps = {
+    id: ids.descriptionId
+  };
+
+  return {
+    rootProps,
+    labelProps,
+    descriptionProps,
+    value: currentValue,
+    name: groupName,
+    isDisabled: disabled,
+    isReadOnly: appliedReadOnly,
+    required,
+    invalid,
+    orientation,
+    loop,
+    registerItem,
+    updateTabStops,
+    setValue,
+    handleArrowNavigation
+  };
+}

--- a/packages/core/src/use-radio.test.tsx
+++ b/packages/core/src/use-radio.test.tsx
@@ -1,0 +1,228 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { type PropsWithChildren, useState } from "react";
+import { useRadio } from "./use-radio.js";
+import { useRadioGroup, type UseRadioGroupOptions } from "./use-radio-group.js";
+
+interface RadioItemOptions {
+  readonly value: string;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly hasDescription?: boolean;
+}
+
+function RadioGroupField({
+  groupOptions,
+  items
+}: PropsWithChildren<{
+  groupOptions?: UseRadioGroupOptions;
+  items: readonly RadioItemOptions[];
+}>) {
+  const group = useRadioGroup(groupOptions);
+
+  return (
+    <div data-testid="group" {...group.rootProps}>
+      <label data-testid="group-label" {...group.labelProps}>
+        group label
+      </label>
+      {groupOptions?.hasDescription ? (
+        <p data-testid="group-description" {...group.descriptionProps}>
+          group description
+        </p>
+      ) : null}
+      {items.map((item) => {
+        const { rootProps, inputProps, labelProps, descriptionProps, isChecked } = useRadio({
+          value: item.value,
+          disabled: item.disabled,
+          readOnly: item.readOnly,
+          hasDescription: item.hasDescription,
+          group
+        });
+
+        return (
+          <div data-testid={`radio-${item.value}-root`} key={item.value} {...rootProps} data-checked={isChecked}>
+            <input data-testid={`radio-${item.value}-input`} {...inputProps} />
+            <label data-testid={`radio-${item.value}-label`} {...labelProps}>
+              {item.value}
+            </label>
+            {item.hasDescription ? (
+              <p data-testid={`radio-${item.value}-description`} {...descriptionProps}>
+                desc {item.value}
+              </p>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+describe("useRadio & useRadioGroup", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("generates ids, names, and aria attributes for group and radios", async () => {
+    const { getByTestId } = render(
+      <RadioGroupField
+        groupOptions={{ id: "radio-group", hasDescription: true, required: true, invalid: true }}
+        items={[
+          { value: "a", hasDescription: true },
+          { value: "b" }
+        ]}
+      />
+    );
+
+    const group = getByTestId("group");
+    const groupLabel = getByTestId("group-label");
+    const groupDescription = getByTestId("group-description");
+
+    expect(group).toHaveAttribute("id", "radio-group");
+    expect(group).toHaveAttribute("role", "radiogroup");
+    expect(group.getAttribute("aria-labelledby")).toBe("radio-group-label");
+    expect(group.getAttribute("aria-describedby")).toBe("radio-group-description");
+    expect(group).toHaveAttribute("aria-required", "true");
+    expect(group).toHaveAttribute("aria-invalid", "true");
+    expect(groupLabel).toHaveAttribute("for", "radio-group");
+    expect(groupDescription).toHaveAttribute("id", "radio-group-description");
+
+    const radioAInput = getByTestId("radio-a-input");
+    const radioALabel = getByTestId("radio-a-label");
+    const radioADescription = getByTestId("radio-a-description");
+
+    const radioAId = radioAInput.getAttribute("id");
+    const radioALabelId = radioALabel.getAttribute("id");
+    const radioADescriptionId = radioADescription.getAttribute("id");
+
+    expect(radioAInput).toHaveAttribute("name", "radio-group");
+    expect(radioALabel).toHaveAttribute("for", radioAId);
+    expect(radioALabelId).toBe(`${radioAId}-label`);
+    expect(radioADescriptionId).toBe(`${radioAId}-description`);
+    expect(radioAInput.getAttribute("aria-labelledby")).toBe(radioALabelId);
+    expect(radioAInput.getAttribute("aria-describedby")).toBe(radioADescriptionId);
+  });
+
+  it("manages roving tab index and arrow navigation while skipping disabled items", async () => {
+    const { getByTestId } = render(
+      <RadioGroupField
+        items={[
+          { value: "a" },
+          { value: "b", disabled: true },
+          { value: "c" }
+        ]}
+      />
+    );
+
+    const radioARoot = getByTestId("radio-a-root");
+    const radioBRoot = getByTestId("radio-b-root");
+    const radioCRoot = getByTestId("radio-c-root");
+
+    await waitFor(() => {
+      expect(radioARoot).toHaveAttribute("tabindex", "0");
+    });
+    expect(radioBRoot).toHaveAttribute("tabindex", "-1");
+    expect(radioCRoot).toHaveAttribute("tabindex", "-1");
+
+    radioARoot.focus();
+    fireEvent.keyDown(radioARoot, { key: "ArrowRight" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(radioCRoot);
+    });
+    expect(radioARoot).toHaveAttribute("tabindex", "-1");
+    expect(radioCRoot).toHaveAttribute("tabindex", "0");
+  });
+
+  it("selects the focused radio with space and reports value changes", async () => {
+    const onValueChange = vi.fn();
+    const { getByTestId } = render(
+      <RadioGroupField
+        groupOptions={{ onValueChange }}
+        items={[
+          { value: "a" },
+          { value: "b" }
+        ]}
+      />
+    );
+
+    const radioARoot = getByTestId("radio-a-root");
+    const radioBRoot = getByTestId("radio-b-root");
+    const radioBInput = getByTestId("radio-b-input");
+
+    radioARoot.focus();
+    fireEvent.keyDown(radioARoot, { key: "ArrowRight" });
+    await waitFor(() => expect(document.activeElement).toBe(radioBRoot));
+
+    fireEvent.keyDown(radioBRoot, { key: " " });
+    expect(onValueChange).toHaveBeenCalledWith("b");
+    expect(radioBRoot).toHaveAttribute("data-state", "checked");
+    expect((radioBInput as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("respects controlled value", async () => {
+    function ControlledRadioGroup() {
+      const [value, setValue] = useState("a");
+      const handleChange = (next: string) => setValue(next);
+      const group = useRadioGroup({ value, onValueChange: handleChange });
+      const radioA = useRadio({ value: "a", group });
+      const radioB = useRadio({ value: "b", group });
+
+      return (
+        <div>
+          <div data-testid="radio-a-root" {...radioA.rootProps}>
+            <input data-testid="radio-a-input" {...radioA.inputProps} />
+          </div>
+          <div data-testid="radio-b-root" {...radioB.rootProps}>
+            <input data-testid="radio-b-input" {...radioB.inputProps} />
+          </div>
+          <span data-testid="value">{value}</span>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<ControlledRadioGroup />);
+    const radioARoot = getByTestId("radio-a-root");
+    const radioBRoot = getByTestId("radio-b-root");
+    const valueDisplay = getByTestId("value");
+
+    expect(valueDisplay.textContent).toBe("a");
+    fireEvent.click(radioARoot);
+    expect(valueDisplay.textContent).toBe("a");
+
+    fireEvent.keyDown(radioARoot, { key: "ArrowRight" });
+    await waitFor(() => expect(document.activeElement).toBe(radioBRoot));
+    fireEvent.keyDown(radioBRoot, { key: " " });
+    expect(valueDisplay.textContent).toBe("b");
+  });
+
+  it("blocks selection when disabled or readOnly", () => {
+    const { getByTestId: getDisabled } = render(
+      <RadioGroupField
+        groupOptions={{ disabled: true }}
+        items={[
+          { value: "a" }
+        ]}
+      />
+    );
+
+    const disabledRoot = getDisabled("radio-a-root");
+    fireEvent.click(disabledRoot);
+    expect(disabledRoot).toHaveAttribute("data-state", "unchecked");
+
+    cleanup();
+
+    const { getByTestId: getReadOnly } = render(
+      <RadioGroupField
+        groupOptions={{ readOnly: true }}
+        items={[
+          { value: "a" }
+        ]}
+      />
+    );
+
+    const readOnlyRoot = getReadOnly("radio-a-root");
+    fireEvent.keyDown(readOnlyRoot, { key: " " });
+    expect(readOnlyRoot).toHaveAttribute("data-state", "unchecked");
+  });
+});

--- a/packages/core/src/use-radio.ts
+++ b/packages/core/src/use-radio.ts
@@ -1,0 +1,274 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+  type MouseEvent
+} from "react";
+import { type UseRadioGroupResult } from "./use-radio-group.js";
+
+export type RadioDataState = "checked" | "unchecked";
+
+export interface UseRadioOptions {
+  readonly id?: string;
+  readonly value: string;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly hasLabel?: boolean;
+  readonly hasDescription?: boolean;
+  readonly describedByIds?: readonly string[];
+  readonly labelledByIds?: readonly string[];
+  readonly group: UseRadioGroupResult;
+}
+
+interface UseRadioIds {
+  readonly inputId: string;
+  readonly labelId: string;
+  readonly descriptionId: string;
+}
+
+export interface UseRadioResult {
+  readonly rootProps: RadioRootProps;
+  readonly inputProps: RadioInputProps;
+  readonly labelProps: RadioLabelProps;
+  readonly descriptionProps: RadioDescriptionProps;
+  readonly isChecked: boolean;
+}
+
+export interface RadioRootProps {
+  readonly id: string;
+  readonly role: "radio";
+  readonly tabIndex: number;
+  readonly "aria-checked": boolean;
+  readonly "aria-labelledby"?: string;
+  readonly "aria-describedby"?: string;
+  readonly "aria-disabled"?: true;
+  readonly "aria-readonly"?: true;
+  readonly "data-state": RadioDataState;
+  readonly "data-disabled"?: true;
+  readonly "data-readonly"?: true;
+  readonly onClick: (event: MouseEvent<HTMLElement>) => void;
+  readonly onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+  readonly ref: (node: HTMLElement | null) => void;
+}
+
+export interface RadioInputProps {
+  readonly id: string;
+  readonly name?: string;
+  readonly value: string;
+  readonly type: "radio";
+  readonly required?: boolean;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly checked: boolean;
+  readonly "aria-invalid"?: true;
+  readonly "aria-required"?: true;
+  readonly "aria-readonly"?: true;
+  readonly "aria-disabled"?: true;
+  readonly "aria-describedby"?: string;
+  readonly "aria-labelledby"?: string;
+  readonly onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export interface RadioLabelProps {
+  readonly id: string;
+  readonly htmlFor: string;
+}
+
+export interface RadioDescriptionProps {
+  readonly id: string;
+}
+
+export function useRadio(options: UseRadioOptions): UseRadioResult {
+  const {
+    id,
+    value,
+    disabled = false,
+    readOnly = false,
+    hasLabel = true,
+    hasDescription = false,
+    describedByIds = [],
+    labelledByIds = [],
+    group
+  } = options;
+
+  const generatedId = useId();
+  const ids = useMemo<UseRadioIds>(() => {
+    const inputId = id ?? `ara-radio-${generatedId}`;
+    return {
+      inputId,
+      labelId: `${inputId}-label`,
+      descriptionId: `${inputId}-description`
+    };
+  }, [generatedId, id]);
+
+  const {
+    handleArrowNavigation,
+    invalid: groupInvalid,
+    isDisabled: groupDisabled,
+    isReadOnly: groupReadOnly,
+    name: groupName,
+    registerItem,
+    required: groupRequired,
+    setValue: setGroupValue,
+    updateTabStops,
+    value: groupValue
+  } = group;
+
+  const appliedReadOnly = (groupReadOnly || readOnly) && !groupDisabled;
+  const isDisabled = groupDisabled || disabled;
+  const isChecked = groupValue === value;
+  const [tabIndex, setTabIndex] = useState(-1);
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  const controller = useMemo(
+    () => ({
+      value,
+      isDisabled: () => isDisabled,
+      setTabIndex: (nextTabIndex: number) => {
+        setTabIndex(nextTabIndex);
+      },
+      focus: () => {
+        const node = rootRef.current;
+        if (node) node.focus();
+      }
+    }),
+    [isDisabled, value]
+  );
+
+  useEffect(() => {
+    const unregister = registerItem(controller);
+    return () => unregister();
+  }, [controller, registerItem]);
+
+  useEffect(() => {
+    updateTabStops();
+  }, [isDisabled, isChecked, updateTabStops]);
+
+  const ariaDescribedBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasDescription) idsToApply.push(ids.descriptionId);
+    if (describedByIds.length > 0) {
+      for (const describedById of describedByIds) {
+        if (describedById) idsToApply.push(describedById);
+      }
+    }
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [describedByIds, hasDescription, ids.descriptionId]);
+
+  const ariaLabelledBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasLabel) idsToApply.push(ids.labelId);
+    if (labelledByIds.length > 0) {
+      for (const labelledById of labelledByIds) {
+        if (labelledById) idsToApply.push(labelledById);
+      }
+    }
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [hasLabel, labelledByIds, ids.labelId]);
+
+  const setChecked = useCallback(() => {
+    if (isDisabled || appliedReadOnly) return;
+    setGroupValue(value);
+  }, [appliedReadOnly, isDisabled, setGroupValue, value]);
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      if (event.defaultPrevented) return;
+      event.preventDefault();
+      setChecked();
+    },
+    [setChecked]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.defaultPrevented) return;
+      if (isDisabled || appliedReadOnly) return;
+
+      if (event.key === " " || event.key === "Spacebar") {
+        event.preventDefault();
+        setChecked();
+      } else if (
+        event.key === "ArrowRight" ||
+        event.key === "ArrowLeft" ||
+        event.key === "ArrowUp" ||
+        event.key === "ArrowDown"
+      ) {
+        event.preventDefault();
+        handleArrowNavigation(value, event.key);
+      }
+    },
+    [appliedReadOnly, handleArrowNavigation, isDisabled, setChecked, value]
+  );
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      setChecked();
+    },
+    [setChecked]
+  );
+
+  const rootProps: RadioRootProps = {
+    id: ids.inputId,
+    role: "radio",
+    tabIndex: isDisabled ? -1 : tabIndex,
+    "aria-checked": isChecked,
+    "aria-labelledby": ariaLabelledBy,
+    "aria-describedby": ariaDescribedBy,
+    "aria-disabled": isDisabled ? true : undefined,
+    "aria-readonly": appliedReadOnly ? true : undefined,
+    "data-state": isChecked ? "checked" : "unchecked",
+    "data-disabled": isDisabled ? true : undefined,
+    "data-readonly": appliedReadOnly ? true : undefined,
+    onClick: handleClick,
+    onKeyDown: handleKeyDown,
+    ref: (node) => {
+      rootRef.current = node;
+    }
+  };
+
+  const inputProps: RadioInputProps = {
+    id: ids.inputId,
+    name: groupName,
+    value,
+    type: "radio",
+    required: groupRequired || undefined,
+    disabled: isDisabled || undefined,
+    readOnly: appliedReadOnly || undefined,
+    checked: isChecked,
+    "aria-invalid": groupInvalid ? true : undefined,
+    "aria-required": groupRequired ? true : undefined,
+    "aria-readonly": appliedReadOnly ? true : undefined,
+    "aria-disabled": isDisabled ? true : undefined,
+    "aria-describedby": ariaDescribedBy,
+    "aria-labelledby": ariaLabelledBy,
+    onChange: handleInputChange
+  };
+
+  const labelProps: RadioLabelProps = {
+    id: ids.labelId,
+    htmlFor: ids.inputId
+  };
+
+  const descriptionProps: RadioDescriptionProps = {
+    id: ids.descriptionId
+  };
+
+  return {
+    rootProps,
+    inputProps,
+    labelProps,
+    descriptionProps,
+    isChecked
+  };
+}


### PR DESCRIPTION
## Summary
- [x] useRadioGroup 훅으로 라디오 그룹의 상태, 포커스 이동, aria 속성을 제공합니다.
- [x] useRadio 훅과 테스트로 로빙 탭 인덱스·화살표 이동·스페이스 선택 시나리오를 검증합니다.
- [x] core 패키지 인덱스에 새 라디오 훅들을 노출합니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/core test`

## Screenshots
- 해당 없음

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69250a656ff88322aeba0b8d641c937e)