### PR TITLE
Update planning records for T-000085 completion

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -270,7 +270,7 @@ T-000083,W-000009,Form Controls v0 Comp,계약/설계,API 계약 정의(Form Con
 T-000084,W-000009,Form Controls v0 Comp,코어(headless),useCheckbox 로직,완료,High," ● 내용: checked/indeterminate 관리, label/description id 연결, 스페이스/클릭 토글, disabled/readOnly 차단
  ● 산출물: packages/core/use-checkbox + 유닛 테스트 골격
  ● 점검: pnpm --filter @ara/core test 통과",확인
-T-000085,W-000009,Form Controls v0 Comp,코어(headless),useRadio/useRadioGroup 로직,계획,High," ● 내용: 단일 선택·name 공유·로빙 탭인덱스, 화살표(←→/↑↓)로 이동·스페이스로 확정, orientation 지원
+T-000085,W-000009,Form Controls v0 Comp,코어(headless),useRadio/useRadioGroup 로직,완료,High," ● 내용: 단일 선택·name 공유·로빙 탭인덱스, 화살표(←→/↑↓)로 이동·스페이스로 확정, orientation 지원
  ● 산출물: packages/core/use-radio, use-radio-group + 테스트 골격
  ● 점검: 그룹 내 키보드 내비게이션 시나리오 통과",확인
 T-000086,W-000009,Form Controls v0 Comp,코어(headless),useSwitch 로직,계획,High," ● 내용: checkbox语義 기반 토글을 role=""switch""+aria-checked로 노출(폼 제출은 input[type=checkbox] 재사용)

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -61,7 +61,7 @@ W-000008,T1,TextField v0 Comp,완료,100,"TextField v0
  ● a11y: label 연결·aria-describedby(error/helper)·aria-invalid/required; IME(조합) 안전·Enter onCommit
  ● Storybook/테스트/Exports 고정; canary 프리릴리스 포함
  ● AC: CI·Tests·Storybook·ESM+types·라벨/에러 연결·IME/Enter 시나리오 통과",--
-W-000009,T1,Form Controls v0 Comp,진행중,20,"Form Controls v0
+W-000009,T1,Form Controls v0 Comp,진행중,25,"Form Controls v0
  ● 설계문서 : root/packages/react/src/components/{checkbox,radio,switch}/README.md
  ● 범위: Checkbox(+indeterminate)/CheckboxGroup · Radio/RadioGroup · Switch(토글)
  ● a11y: label 연결·aria-checked/indeterminate·Radio 그룹 화살표 내비게이션(로빙 탭인덱스)


### PR DESCRIPTION
## Summary
- mark task T-000085 (useRadio/useRadioGroup) as complete with GPT check recorded
- update W-000009 progress to reflect the completed radio work

## Testing
- not run (not needed for planning file updates)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69250c91de548322a02f59318327f672)