### PR TITLE
feat(core): useSwitch 로직 추가 (T-000086)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/use-checkbox.js",
       "default": "./dist/use-checkbox.js"
     },
+    "./use-switch": {
+      "types": "./dist/use-switch.d.ts",
+      "import": "./dist/use-switch.js",
+      "default": "./dist/use-switch.js"
+    },
     "./use-text-field": {
       "types": "./dist/use-text-field.d.ts",
       "import": "./dist/use-text-field.js",
@@ -44,6 +49,9 @@
       ],
       "use-checkbox": [
         "dist/use-checkbox.d.ts"
+      ],
+      "use-switch": [
+        "dist/use-switch.d.ts"
       ],
       "use-text-field": [
         "dist/use-text-field.d.ts"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,16 @@ export type {
 } from "./use-checkbox.js";
 export { useCheckbox } from "./use-checkbox.js";
 export type {
+  SwitchDataState,
+  SwitchDescriptionProps,
+  SwitchInputProps,
+  SwitchLabelProps,
+  SwitchRootProps,
+  UseSwitchOptions,
+  UseSwitchResult
+} from "./use-switch.js";
+export { useSwitch } from "./use-switch.js";
+export type {
   RadioDataState,
   RadioDescriptionProps,
   RadioInputProps,

--- a/packages/core/src/use-switch.test.tsx
+++ b/packages/core/src/use-switch.test.tsx
@@ -1,0 +1,191 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { type PropsWithChildren, useState } from "react";
+import { useSwitch, type UseSwitchOptions } from "./use-switch.js";
+
+describe("useSwitch", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function SwitchField({
+    options,
+    withLabel = true,
+    withDescription = false
+  }: PropsWithChildren<{
+    options?: UseSwitchOptions;
+    withLabel?: boolean;
+    withDescription?: boolean;
+  }>) {
+    const { rootProps, inputProps, labelProps, descriptionProps, isChecked } = useSwitch({
+      ...options,
+      hasLabel: withLabel,
+      hasDescription: withDescription
+    });
+
+    return (
+      <div data-testid="root" {...rootProps} data-checked={isChecked}>
+        <input data-testid="input" {...inputProps} />
+        {withLabel ? (
+          <label data-testid="label" {...labelProps}>
+            label
+          </label>
+        ) : null}
+        {withDescription ? (
+          <p data-testid="description" {...descriptionProps}>
+            description
+          </p>
+        ) : null}
+        <span data-testid="state">{String(isChecked)}</span>
+      </div>
+    );
+  }
+
+  it("generates ids and aria attributes for label/description", () => {
+    const { getByTestId } = render(
+      <SwitchField
+        withDescription
+        options={{
+          id: "switch-id",
+          required: true,
+          invalid: true
+        }}
+      />
+    );
+
+    const root = getByTestId("root");
+    const input = getByTestId("input");
+    const label = getByTestId("label");
+    const description = getByTestId("description");
+
+    expect(label).toHaveAttribute("id", "switch-id-label");
+    expect(label).toHaveAttribute("for", "switch-id");
+    expect(description).toHaveAttribute("id", "switch-id-description");
+
+    expect(root).toHaveAttribute("aria-labelledby", "switch-id-label");
+    expect(root.getAttribute("aria-describedby")).toBe("switch-id-description");
+    expect(root).toHaveAttribute("aria-required", "true");
+    expect(root).toHaveAttribute("aria-invalid", "true");
+
+    expect(input).toHaveAttribute("id", "switch-id");
+    expect(input).toHaveAttribute("type", "checkbox");
+    expect(input).toHaveAttribute("aria-labelledby", "switch-id-label");
+    expect(input.getAttribute("aria-describedby")).toBe("switch-id-description");
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("merges external labelling and description ids", () => {
+    const { getByTestId } = render(
+      <SwitchField
+        withDescription
+        options={{
+          id: "merge-id",
+          describedByIds: ["external-description"],
+          labelledByIds: ["external-label"]
+        }}
+      />
+    );
+
+    const root = getByTestId("root");
+    const input = getByTestId("input");
+
+    expect(root.getAttribute("aria-labelledby")).toBe("merge-id-label external-label");
+    expect(input.getAttribute("aria-labelledby")).toBe("merge-id-label external-label");
+    expect(root.getAttribute("aria-describedby")).toBe("merge-id-description external-description");
+    expect(input.getAttribute("aria-describedby")).toBe("merge-id-description external-description");
+  });
+
+  it("toggles checked state on interactions", () => {
+    const onCheckedChange = vi.fn();
+    const { getByTestId } = render(
+      <SwitchField
+        options={{
+          defaultChecked: false,
+          onCheckedChange
+        }}
+      />
+    );
+
+    const root = getByTestId("root");
+    const input = getByTestId("input") as HTMLInputElement;
+    const state = getByTestId("state");
+
+    expect(root).toHaveAttribute("data-state", "unchecked");
+    expect(input.checked).toBe(false);
+
+    fireEvent.click(root);
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+    expect(state.textContent).toBe("true");
+    expect(root).toHaveAttribute("data-state", "checked");
+    expect(input.checked).toBe(true);
+
+    fireEvent.keyDown(root, { key: " " });
+    expect(onCheckedChange).toHaveBeenCalledWith(false);
+    expect(state.textContent).toBe("false");
+    expect(root).toHaveAttribute("data-state", "unchecked");
+    expect(input.checked).toBe(false);
+  });
+
+  it("respects controlled checked state", () => {
+    function ControlledSwitch() {
+      const [value, setValue] = useState<UseSwitchOptions["checked"]>(true);
+      const handleChange = (next: UseSwitchOptions["checked"]) => setValue(next);
+      const { rootProps, inputProps, isChecked } = useSwitch({ checked: value, onCheckedChange: handleChange });
+
+      return (
+        <div data-testid="root" {...rootProps}>
+          <input data-testid="input" {...inputProps} />
+          <span data-testid="state">{String(isChecked)}</span>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<ControlledSwitch />);
+    const root = getByTestId("root");
+    const input = getByTestId("input") as HTMLInputElement;
+    const state = getByTestId("state");
+
+    expect(input.checked).toBe(true);
+
+    fireEvent.click(root);
+    expect(state.textContent).toBe("false");
+    fireEvent.keyDown(root, { key: "Enter" });
+    expect(state.textContent).toBe("true");
+  });
+
+  it("blocks toggling when disabled or readOnly", () => {
+    const { getByTestId: getDisabled, unmount } = render(
+      <SwitchField
+        options={{
+          defaultChecked: true,
+          disabled: true
+        }}
+      />
+    );
+
+    const disabledRoot = getDisabled("root");
+    const disabledInput = getDisabled("input") as HTMLInputElement;
+
+    fireEvent.click(disabledRoot);
+    expect(disabledInput.checked).toBe(true);
+
+    unmount();
+
+    const { getByTestId: getReadOnly } = render(
+      <SwitchField
+        options={{
+          defaultChecked: false,
+          readOnly: true
+        }}
+      />
+    );
+
+    const readOnlyRoot = getReadOnly("root");
+    const readOnlyInput = getReadOnly("input") as HTMLInputElement;
+
+    fireEvent.keyDown(readOnlyRoot, { key: " " });
+    expect(readOnlyInput.checked).toBe(false);
+  });
+});

--- a/packages/core/src/use-switch.ts
+++ b/packages/core/src/use-switch.ts
@@ -1,0 +1,266 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+  type MouseEvent
+} from "react";
+
+export type SwitchDataState = "checked" | "unchecked";
+
+export interface UseSwitchOptions {
+  readonly id?: string;
+  readonly name?: string;
+  readonly value?: string;
+  readonly checked?: boolean;
+  readonly defaultChecked?: boolean;
+  readonly required?: boolean;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly invalid?: boolean;
+  readonly hasLabel?: boolean;
+  readonly hasDescription?: boolean;
+  readonly describedByIds?: readonly string[];
+  readonly labelledByIds?: readonly string[];
+  readonly onCheckedChange?: (checked: boolean) => void;
+}
+
+interface UseSwitchIds {
+  readonly inputId: string;
+  readonly labelId: string;
+  readonly descriptionId: string;
+}
+
+export interface UseSwitchResult {
+  readonly rootProps: SwitchRootProps;
+  readonly inputProps: SwitchInputProps;
+  readonly labelProps: SwitchLabelProps;
+  readonly descriptionProps: SwitchDescriptionProps;
+  readonly isChecked: boolean;
+}
+
+export interface SwitchRootProps {
+  readonly role: "switch";
+  readonly tabIndex: number;
+  readonly "aria-checked": boolean;
+  readonly "aria-labelledby"?: string;
+  readonly "aria-describedby"?: string;
+  readonly "aria-required"?: true;
+  readonly "aria-invalid"?: true;
+  readonly "aria-readonly"?: true;
+  readonly "aria-disabled"?: true;
+  readonly "data-state": SwitchDataState;
+  readonly "data-disabled"?: true;
+  readonly "data-readonly"?: true;
+  readonly "data-required"?: true;
+  readonly "data-invalid"?: true;
+  readonly onClick: (event: MouseEvent<HTMLElement>) => void;
+  readonly onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+}
+
+export interface SwitchInputProps {
+  readonly id: string;
+  readonly name?: string;
+  readonly value: string;
+  readonly type: "checkbox";
+  readonly required?: boolean;
+  readonly disabled?: boolean;
+  readonly readOnly?: boolean;
+  readonly checked: boolean;
+  readonly ref: (node: HTMLInputElement | null) => void;
+  readonly "aria-invalid"?: true;
+  readonly "aria-required"?: true;
+  readonly "aria-readonly"?: true;
+  readonly "aria-disabled"?: true;
+  readonly "aria-describedby"?: string;
+  readonly "aria-labelledby"?: string;
+  readonly onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+export interface SwitchLabelProps {
+  readonly id: string;
+  readonly htmlFor: string;
+}
+
+export interface SwitchDescriptionProps {
+  readonly id: string;
+}
+
+export function useSwitch(options: UseSwitchOptions = {}): UseSwitchResult {
+  const {
+    id,
+    name,
+    value = "on",
+    checked,
+    defaultChecked = false,
+    required = false,
+    disabled = false,
+    readOnly = false,
+    invalid = false,
+    hasLabel = true,
+    hasDescription = false,
+    describedByIds = [],
+    labelledByIds = [],
+    onCheckedChange
+  } = options;
+
+  const generatedId = useId();
+  const ids = useMemo<UseSwitchIds>(() => {
+    const inputId = id ?? `ara-switch-${generatedId}`;
+    return {
+      inputId,
+      labelId: `${inputId}-label`,
+      descriptionId: `${inputId}-description`
+    };
+  }, [generatedId, id]);
+
+  const appliedReadOnly = !disabled && readOnly;
+  const isControlled = checked !== undefined;
+  const [uncontrolledState, setUncontrolledState] = useState(defaultChecked);
+  const currentState = isControlled ? checked ?? false : uncontrolledState;
+  const stateRef = useRef(currentState);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const dataState: SwitchDataState = currentState ? "checked" : "unchecked";
+
+  const setCheckedState = useCallback(
+    (next: boolean) => {
+      stateRef.current = next;
+      if (!isControlled) {
+        setUncontrolledState(next);
+      }
+      onCheckedChange?.(next);
+    },
+    [isControlled, onCheckedChange]
+  );
+
+  const toggleState = useCallback(() => {
+    if (disabled || appliedReadOnly) return;
+    setCheckedState(!stateRef.current);
+  }, [appliedReadOnly, disabled, setCheckedState]);
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      if (event.defaultPrevented) return;
+      event.preventDefault();
+      toggleState();
+    },
+    [toggleState]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (event.defaultPrevented) return;
+      if (event.key === " " || event.key === "Spacebar" || event.key === "Enter") {
+        event.preventDefault();
+        toggleState();
+      }
+    },
+    [toggleState]
+  );
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+      toggleState();
+    },
+    [toggleState]
+  );
+
+  useEffect(() => {
+    stateRef.current = currentState;
+  }, [currentState]);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.checked = currentState;
+    }
+  }, [currentState]);
+
+  const ariaDescribedBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasDescription) idsToApply.push(ids.descriptionId);
+    if (describedByIds.length > 0) {
+      for (const describedById of describedByIds) {
+        if (describedById) idsToApply.push(describedById);
+      }
+    }
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [describedByIds, hasDescription, ids.descriptionId]);
+
+  const ariaLabelledBy = useMemo(() => {
+    const idsToApply: string[] = [];
+
+    if (hasLabel) idsToApply.push(ids.labelId);
+    if (labelledByIds.length > 0) {
+      for (const labelledById of labelledByIds) {
+        if (labelledById) idsToApply.push(labelledById);
+      }
+    }
+
+    return idsToApply.length > 0 ? idsToApply.join(" ") : undefined;
+  }, [hasLabel, labelledByIds, ids.labelId]);
+
+  const rootProps: SwitchRootProps = {
+    role: "switch",
+    tabIndex: disabled ? -1 : 0,
+    "aria-checked": currentState,
+    "aria-labelledby": ariaLabelledBy,
+    "aria-describedby": ariaDescribedBy,
+    "aria-required": required ? true : undefined,
+    "aria-invalid": invalid ? true : undefined,
+    "aria-readonly": appliedReadOnly ? true : undefined,
+    "aria-disabled": disabled ? true : undefined,
+    "data-state": dataState,
+    "data-disabled": disabled ? true : undefined,
+    "data-readonly": appliedReadOnly ? true : undefined,
+    "data-required": required ? true : undefined,
+    "data-invalid": invalid ? true : undefined,
+    onClick: handleClick,
+    onKeyDown: handleKeyDown
+  };
+
+  const inputProps: SwitchInputProps = {
+    id: ids.inputId,
+    name,
+    value,
+    type: "checkbox",
+    required: required || undefined,
+    disabled: disabled || undefined,
+    readOnly: appliedReadOnly || undefined,
+    checked: currentState,
+    ref: (node) => {
+      inputRef.current = node;
+    },
+    "aria-invalid": invalid ? true : undefined,
+    "aria-required": required ? true : undefined,
+    "aria-readonly": appliedReadOnly ? true : undefined,
+    "aria-disabled": disabled ? true : undefined,
+    "aria-describedby": ariaDescribedBy,
+    "aria-labelledby": ariaLabelledBy,
+    onChange: handleInputChange
+  };
+
+  const labelProps: SwitchLabelProps = {
+    id: ids.labelId,
+    htmlFor: ids.inputId
+  };
+
+  const descriptionProps: SwitchDescriptionProps = {
+    id: ids.descriptionId
+  };
+
+  return {
+    rootProps,
+    inputProps,
+    labelProps,
+    descriptionProps,
+    isChecked: currentState
+  };
+}


### PR DESCRIPTION
## Summary
- [x] switch 접근성 규격에 맞춘 headless `useSwitch` 훅을 추가했습니다.
- [x] label/description 병합, 제어/비제어 전환, disabled/readOnly 차단 등을 검증하는 테스트를 작성했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (WBS: W-000009, Task: T-000086)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다. (해당 없음)
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/core test`

## Screenshots
해당 없음

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69250e31642c8322a5025cfb7c38f74a)