### PR TITLE
Update planning for useSwitch task completion

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -273,7 +273,7 @@ T-000084,W-000009,Form Controls v0 Comp,코어(headless),useCheckbox 로직,완�
 T-000085,W-000009,Form Controls v0 Comp,코어(headless),useRadio/useRadioGroup 로직,완료,High," ● 내용: 단일 선택·name 공유·로빙 탭인덱스, 화살표(←→/↑↓)로 이동·스페이스로 확정, orientation 지원
  ● 산출물: packages/core/use-radio, use-radio-group + 테스트 골격
  ● 점검: 그룹 내 키보드 내비게이션 시나리오 통과",확인
-T-000086,W-000009,Form Controls v0 Comp,코어(headless),useSwitch 로직,계획,High," ● 내용: checkbox语義 기반 토글을 role=""switch""+aria-checked로 노출(폼 제출은 input[type=checkbox] 재사용)
+T-000086,W-000009,Form Controls v0 Comp,코어(headless),useSwitch 로직,완료,High," ● 내용: checkbox语義 기반 토글을 role=""switch""+aria-checked로 노출(폼 제출은 input[type=checkbox] 재사용)
  ● 산출물: packages/core/use-switch + 테스트 골격
  ● 점검: role/aria 일치·폼 값 반영",확인
 T-000087,W-000009,Form Controls v0 Comp,React 구현,Checkbox 구현,계획,High," ● 내용: 숨김 input+커스텀 UI; data-state=""checked|unchecked|indeterminate""; indeterminate는 DOM 프로퍼티로 설정; label 클릭 연동

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -61,7 +61,7 @@ W-000008,T1,TextField v0 Comp,완료,100,"TextField v0
  ● a11y: label 연결·aria-describedby(error/helper)·aria-invalid/required; IME(조합) 안전·Enter onCommit
  ● Storybook/테스트/Exports 고정; canary 프리릴리스 포함
  ● AC: CI·Tests·Storybook·ESM+types·라벨/에러 연결·IME/Enter 시나리오 통과",--
-W-000009,T1,Form Controls v0 Comp,진행중,25,"Form Controls v0
+W-000009,T1,Form Controls v0 Comp,진행중,30,"Form Controls v0
  ● 설계문서 : root/packages/react/src/components/{checkbox,radio,switch}/README.md
  ● 범위: Checkbox(+indeterminate)/CheckboxGroup · Radio/RadioGroup · Switch(토글)
  ● a11y: label 연결·aria-checked/indeterminate·Radio 그룹 화살표 내비게이션(로빙 탭인덱스)


### PR DESCRIPTION
## Summary
- mark task T-000086 useSwitch logic as completed with GPT check
- adjust W-000009 Form Controls progress to reflect updated completion

## Testing
- pnpm --filter @ara/core test -- --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69250f58f06c8322b6111f910be26e14)