### PR TITLE
Fix vitest alias for icons package

### DIFF
--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const tokensRoot = path.resolve(__dirname, "../tokens/src");
+const iconsRoot = path.resolve(__dirname, "../icons/src");
 
 export default defineConfig({
   plugins: [react()],
@@ -21,6 +22,10 @@ export default defineConfig({
       {
         find: "@ara/tokens",
         replacement: path.resolve(tokensRoot, "index.ts")
+      },
+      {
+        find: "@ara/icons",
+        replacement: path.resolve(iconsRoot, "index.ts")
       }
     ]
   },


### PR DESCRIPTION
## Summary
- add an alias for `@ara/icons` in the React package Vitest configuration
- allow icon imports to resolve during test runs

## Testing
- pnpm --filter @ara/react test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69251efe94e48322ab92730aefe247d8)