### PR TITLE
Handle @ara/icons subpath resolution in Vitest

### DIFF
--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -5,6 +5,7 @@ import react from "@vitejs/plugin-react";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const tokensRoot = path.resolve(__dirname, "../tokens/src");
+const iconsRoot = path.resolve(__dirname, "../icons/src");
 
 export default defineConfig({
   plugins: [react()],
@@ -21,6 +22,14 @@ export default defineConfig({
       {
         find: "@ara/tokens",
         replacement: path.resolve(tokensRoot, "index.ts")
+      },
+      {
+        find: /^@ara\/icons\/(.*)$/,
+        replacement: path.resolve(iconsRoot, "$1")
+      },
+      {
+        find: "@ara/icons",
+        replacement: path.resolve(iconsRoot, "index.ts")
       }
     ]
   },


### PR DESCRIPTION
## Summary
- add a regex alias so @ara/icons subpath imports resolve to the icons source directory
- keep the base @ara/icons alias pointing to the package index for root imports

## Testing
- pnpm --filter @ara/react test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69251efe94e48322ab92730aefe247d8)