### PR TITLE
feat: add radio group components

### DIFF
--- a/packages/core/src/use-radio-group.ts
+++ b/packages/core/src/use-radio-group.ts
@@ -169,13 +169,13 @@ export function useRadioGroup(options: UseRadioGroupOptions = {}): UseRadioGroup
         const candidate = items[normalizedIndex];
         if (!candidate || candidate.isDisabled()) continue;
 
-        activeValueRef.current = candidate.value;
+        setValue(candidate.value);
         candidate.focus();
         updateTabStops();
         return;
       }
     },
-    [loop, updateTabStops]
+    [loop, setValue, updateTabStops]
   );
 
   const handleArrowNavigation = useCallback(

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,6 +57,11 @@
       "import": "./dist/components/checkbox/index.js",
       "default": "./dist/components/checkbox/index.js"
     },
+    "./components/radio": {
+      "types": "./dist/components/radio/index.d.ts",
+      "import": "./dist/components/radio/index.js",
+      "default": "./dist/components/radio/index.js"
+    },
     "./components/icon": {
       "types": "./dist/components/icon/index.d.ts",
       "import": "./dist/components/icon/index.js",
@@ -117,6 +122,11 @@
       "import": "./dist/components/checkbox/index.js",
       "default": "./dist/components/checkbox/index.js"
     },
+    "./radio": {
+      "types": "./dist/components/radio/index.d.ts",
+      "import": "./dist/components/radio/index.js",
+      "default": "./dist/components/radio/index.js"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -151,6 +161,9 @@
       "components/checkbox": [
         "dist/components/checkbox/index.d.ts"
       ],
+      "components/radio": [
+        "dist/components/radio/index.d.ts"
+      ],
       "components/text-field": [
         "dist/components/text-field/index.d.ts"
       ],
@@ -180,6 +193,9 @@
       ],
       "checkbox": [
         "dist/components/checkbox/index.d.ts"
+      ],
+      "radio": [
+        "dist/components/radio/index.d.ts"
       ],
       "theme": [
         "dist/theme/index.d.ts"

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -2,6 +2,7 @@ export * from "./button/index.js";
 export * from "./checkbox/index.js";
 export * from "./icon/index.js";
 export * from "./layout/index.js";
+export * from "./radio/index.js";
 export * from "./spacer/index.js";
 export * from "./theme-provider/index.js";
 export * from "./text-field/index.js";

--- a/packages/react/src/components/radio/Radio.test.tsx
+++ b/packages/react/src/components/radio/Radio.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Radio } from "./Radio.js";
+import { RadioGroup } from "./RadioGroup.js";
+
+describe("RadioGroup/Radio", () => {
+  it("그룹 내 단일 선택을 유지하고 변경 시 onValueChange를 호출한다", () => {
+    const handleChange = vi.fn();
+
+    render(
+      <RadioGroup defaultValue="b" onValueChange={handleChange} label="색상">
+        <Radio value="a" label="옵션 A" />
+        <Radio value="b" label="옵션 B" />
+      </RadioGroup>
+    );
+
+    const optionA = screen.getByRole("radio", { name: "옵션 A" });
+    const optionB = screen.getByRole("radio", { name: "옵션 B" });
+
+    expect(optionB).toHaveAttribute("aria-checked", "true");
+    expect(optionA).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(optionA);
+
+    expect(optionA).toHaveAttribute("aria-checked", "true");
+    expect(optionB).toHaveAttribute("aria-checked", "false");
+    expect(handleChange).toHaveBeenCalledWith("a");
+  });
+
+  it("화살표 키로 다음/이전 항목으로 이동하며 선택을 갱신한다", () => {
+    render(
+      <RadioGroup defaultValue="first" orientation="horizontal">
+        <Radio value="first" label="첫 번째" />
+        <Radio value="second" label="두 번째" />
+        <Radio value="third" label="세 번째" />
+      </RadioGroup>
+    );
+
+    const first = screen.getByRole("radio", { name: "첫 번째" });
+    const second = screen.getByRole("radio", { name: "두 번째" });
+
+    fireEvent.keyDown(first, { key: "ArrowRight" });
+
+    expect(second).toHaveAttribute("aria-checked", "true");
+    expect(first).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("비활성화된 그룹에서는 상호작용이 동작하지 않는다", () => {
+    render(
+      <RadioGroup defaultValue="x" disabled>
+        <Radio value="x" label="잠금" />
+        <Radio value="y" label="잠김" />
+      </RadioGroup>
+    );
+
+    const locked = screen.getByRole("radio", { name: "잠김" });
+
+    fireEvent.click(locked);
+
+    expect(locked).toHaveAttribute("aria-checked", "false");
+    expect(locked).toHaveAttribute("aria-disabled", "true");
+  });
+});

--- a/packages/react/src/components/radio/Radio.tsx
+++ b/packages/react/src/components/radio/Radio.tsx
@@ -7,7 +7,6 @@ import {
   type ReactNode,
   type Ref
 } from "react";
-import { composeRefs } from "@radix-ui/react-compose-refs";
 import { useRadio } from "@ara/core";
 import { useRadioGroupContext } from "./RadioGroup.js";
 
@@ -114,8 +113,6 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     [inputProps, onChange]
   );
 
-  const mergedInputRef = composeRefs(inputProps.ref, inputRef);
-
   return (
     <div
       {...restProps}
@@ -128,7 +125,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     >
       <input
         {...mergedInputProps}
-        ref={mergedInputRef}
+        ref={inputRef}
         aria-hidden
         tabIndex={-1}
         style={visuallyHiddenStyle}

--- a/packages/react/src/components/radio/Radio.tsx
+++ b/packages/react/src/components/radio/Radio.tsx
@@ -1,0 +1,161 @@
+import {
+  forwardRef,
+  useMemo,
+  type HTMLAttributes,
+  type InputHTMLAttributes,
+  type CSSProperties,
+  type ReactNode,
+  type Ref
+} from "react";
+import { composeRefs } from "@radix-ui/react-compose-refs";
+import { useRadio } from "@ara/core";
+import { useRadioGroupContext } from "./RadioGroup.js";
+
+function mergeClassNames(...values: Array<string | undefined | null | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+const visuallyHiddenStyle: CSSProperties = {
+  position: "absolute",
+  width: "1px",
+  height: "1px",
+  padding: 0,
+  margin: "-1px",
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0
+};
+
+function composeEventHandlers<Event>(
+  ours: ((event: Event) => void) | undefined,
+  theirs: ((event: Event) => void) | undefined
+): ((event: Event) => void) | undefined {
+  if (!ours && !theirs) return undefined;
+  return (event: Event) => {
+    ours?.(event);
+    theirs?.(event);
+  };
+}
+
+interface RadioOwnProps {
+  readonly label?: ReactNode;
+  readonly description?: ReactNode;
+  readonly inputRef?: Ref<HTMLInputElement>;
+  readonly describedBy?: string | readonly string[];
+  readonly labelledBy?: string | readonly string[];
+  readonly controlClassName?: string;
+}
+
+export type RadioProps = RadioOwnProps &
+  Omit<InputHTMLAttributes<HTMLInputElement>, "checked" | "defaultChecked" | "type" | "name"> &
+  Pick<HTMLAttributes<HTMLDivElement>, "className" | "style" | "onClick" | "onKeyDown"> & {
+    readonly value: string;
+  };
+
+export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props, ref) {
+  const {
+    id,
+    value,
+    disabled,
+    readOnly,
+    label,
+    description,
+    inputRef,
+    describedBy,
+    labelledBy,
+    className,
+    style,
+    controlClassName,
+    onChange,
+    onClick,
+    onKeyDown,
+    ...restProps
+  } = props;
+
+  const describedByIds = useMemo(() => {
+    if (!describedBy) return [] as string[];
+    return Array.isArray(describedBy) ? [...describedBy] : [describedBy];
+  }, [describedBy]);
+
+  const labelledByIds = useMemo(() => {
+    if (!labelledBy) return [] as string[];
+    return Array.isArray(labelledBy) ? [...labelledBy] : [labelledBy];
+  }, [labelledBy]);
+
+  const group = useRadioGroupContext();
+
+  const { rootProps, inputProps, labelProps, descriptionProps } = useRadio({
+    id,
+    value,
+    disabled,
+    readOnly,
+    hasLabel: Boolean(label),
+    hasDescription: Boolean(description),
+    describedByIds,
+    labelledByIds,
+    group
+  });
+
+  const mergedRootProps = useMemo(
+    () => ({
+      ...rootProps,
+      onClick: composeEventHandlers(rootProps.onClick, onClick),
+      onKeyDown: composeEventHandlers(rootProps.onKeyDown, onKeyDown)
+    }),
+    [onClick, onKeyDown, rootProps]
+  );
+
+  const mergedInputProps = useMemo(
+    () => ({
+      ...inputProps,
+      onChange: composeEventHandlers(inputProps.onChange, onChange)
+    }),
+    [inputProps, onChange]
+  );
+
+  const mergedInputRef = composeRefs(inputProps.ref, inputRef);
+
+  return (
+    <div
+      {...restProps}
+      ref={ref}
+      className={mergeClassNames("ara-radio", className)}
+      style={style}
+      data-state={rootProps["data-state"]}
+      data-disabled={rootProps["data-disabled"]}
+      data-readonly={rootProps["data-readonly"]}
+    >
+      <input
+        {...mergedInputProps}
+        ref={mergedInputRef}
+        aria-hidden
+        tabIndex={-1}
+        style={visuallyHiddenStyle}
+      />
+      <div
+        {...mergedRootProps}
+        className={mergeClassNames("ara-radio__control", controlClassName)}
+        data-state={rootProps["data-state"]}
+        data-disabled={rootProps["data-disabled"]}
+        data-readonly={rootProps["data-readonly"]}
+      >
+        <span aria-hidden className="ara-radio__indicator" />
+      </div>
+      {(label || description) && (
+        <div className="ara-radio__text">
+          {label ? (
+            <label {...labelProps} className="ara-radio__label">
+              {label}
+            </label>
+          ) : null}
+          {description ? (
+            <div {...descriptionProps} className="ara-radio__description">
+              {description}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/react/src/components/radio/RadioGroup.tsx
+++ b/packages/react/src/components/radio/RadioGroup.tsx
@@ -6,13 +6,10 @@ import {
   type HTMLAttributes,
   type ReactNode
 } from "react";
-import {
-  useRadioGroup,
-  type RadioGroupOrientation,
-  type UseRadioGroupResult
-} from "@ara/core";
+import { useRadioGroup, type UseRadioGroupResult } from "@ara/core";
+import type { RadioGroupOrientation } from "@ara/core";
 
-export type { RadioGroupOrientation };
+export type { RadioGroupOrientation } from "@ara/core";
 
 function mergeClassNames(...values: Array<string | undefined | null | false>): string {
   return values.filter(Boolean).join(" ");

--- a/packages/react/src/components/radio/RadioGroup.tsx
+++ b/packages/react/src/components/radio/RadioGroup.tsx
@@ -1,0 +1,144 @@
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useMemo,
+  type HTMLAttributes,
+  type ReactNode
+} from "react";
+import {
+  useRadioGroup,
+  type RadioGroupOrientation,
+  type UseRadioGroupResult
+} from "@ara/core";
+
+function mergeClassNames(...values: Array<string | undefined | null | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+interface RadioGroupContextValue {
+  readonly group: UseRadioGroupResult;
+}
+
+const RadioGroupContext = createContext<RadioGroupContextValue | null>(null);
+
+export function useRadioGroupContext(): UseRadioGroupResult {
+  const context = useContext(RadioGroupContext);
+
+  if (!context) {
+    throw new Error("Radio 컴포넌트는 RadioGroup 내부에서만 사용할 수 있습니다.");
+  }
+
+  return context.group;
+}
+
+interface RadioGroupOwnProps {
+  readonly children: ReactNode;
+  readonly label?: ReactNode;
+  readonly description?: ReactNode;
+  readonly loop?: boolean;
+  readonly orientation?: RadioGroupOrientation;
+  readonly describedBy?: string | readonly string[];
+  readonly labelledBy?: string | readonly string[];
+  readonly onValueChange?: (value: string) => void;
+}
+
+export type RadioGroupProps = RadioGroupOwnProps &
+  Pick<
+    HTMLAttributes<HTMLDivElement>,
+    "id" | "className" | "style" | "role" | "aria-labelledby" | "aria-describedby"
+  > & {
+    readonly name?: string;
+    readonly value?: string;
+    readonly defaultValue?: string;
+    readonly disabled?: boolean;
+    readonly readOnly?: boolean;
+    readonly required?: boolean;
+    readonly invalid?: boolean;
+  };
+
+export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(function RadioGroup(
+  props,
+  ref
+) {
+  const {
+    id,
+    children,
+    label,
+    description,
+    name,
+    value,
+    defaultValue,
+    disabled,
+    readOnly,
+    required,
+    invalid,
+    orientation,
+    loop,
+    describedBy,
+    labelledBy,
+    className,
+    style,
+    onValueChange,
+    ...restProps
+  } = props;
+
+  const describedByIds = useMemo(() => {
+    if (!describedBy) return [] as string[];
+    return Array.isArray(describedBy) ? [...describedBy] : [describedBy];
+  }, [describedBy]);
+
+  const labelledByIds = useMemo(() => {
+    if (!labelledBy) return [] as string[];
+    return Array.isArray(labelledBy) ? [...labelledBy] : [labelledBy];
+  }, [labelledBy]);
+
+  const group = useRadioGroup({
+    id,
+    name,
+    value,
+    defaultValue,
+    disabled,
+    readOnly,
+    required,
+    invalid,
+    orientation,
+    loop,
+    hasLabel: Boolean(label),
+    hasDescription: Boolean(description),
+    describedByIds,
+    labelledByIds,
+    onValueChange
+  });
+
+  const { rootProps, labelProps, descriptionProps, loop: groupLoop, orientation: groupOrientation } =
+    group;
+
+  return (
+    <RadioGroupContext.Provider value={{ group }}>
+      <div
+        {...rootProps}
+        {...restProps}
+        ref={ref}
+        className={mergeClassNames("ara-radio-group", className)}
+        style={style}
+        data-disabled={rootProps["data-disabled"]}
+        data-readonly={rootProps["data-readonly"]}
+        data-orientation={groupOrientation}
+        data-loop={groupLoop}
+      >
+        {label ? (
+          <label {...labelProps} className="ara-radio-group__label">
+            {label}
+          </label>
+        ) : null}
+        {description ? (
+          <div {...descriptionProps} className="ara-radio-group__description">
+            {description}
+          </div>
+        ) : null}
+        <div className="ara-radio-group__items">{children}</div>
+      </div>
+    </RadioGroupContext.Provider>
+  );
+});

--- a/packages/react/src/components/radio/RadioGroup.tsx
+++ b/packages/react/src/components/radio/RadioGroup.tsx
@@ -12,6 +12,8 @@ import {
   type UseRadioGroupResult
 } from "@ara/core";
 
+export type { RadioGroupOrientation };
+
 function mergeClassNames(...values: Array<string | undefined | null | false>): string {
   return values.filter(Boolean).join(" ");
 }

--- a/packages/react/src/components/radio/index.ts
+++ b/packages/react/src/components/radio/index.ts
@@ -3,5 +3,5 @@ export {
   RadioGroup,
   type RadioGroupProps,
   useRadioGroupContext,
-  type RadioGroupOrientation
 } from "./RadioGroup.js";
+export type { RadioGroupOrientation } from "@ara/core";

--- a/packages/react/src/components/radio/index.ts
+++ b/packages/react/src/components/radio/index.ts
@@ -1,0 +1,7 @@
+export { Radio, type RadioProps } from "./Radio.js";
+export {
+  RadioGroup,
+  type RadioGroupProps,
+  useRadioGroupContext,
+  type RadioGroupOrientation
+} from "./RadioGroup.js";

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -279,7 +279,7 @@ T-000086,W-000009,Form Controls v0 Comp,코어(headless),useSwitch 로직,완료
 T-000087,W-000009,Form Controls v0 Comp,React 구현,Checkbox 구현,완료,High," ● 내용: 숨김 input+커스텀 UI; data-state=""checked|unchecked|indeterminate""; indeterminate는 DOM 프로퍼티로 설정; label 클릭 연동
  ● 산출물: packages/react/src/components/checkbox/index.ts
  ● 점검: ref 포워딩·Props 스냅·indeterminate 표시",확인
-T-000088,W-000009,Form Controls v0 Comp,React 구현,Radio/RadioGroup 구현,계획,High," ● 내용: <RadioGroup> 컨텍스트·로빙 탭인덱스·화살표 이동; <Radio> 아이템 구현; aria-labelledby/role=""radiogroup""
+T-000088,W-000009,Form Controls v0 Comp,React 구현,Radio/RadioGroup 구현,완료,High," ● 내용: <RadioGroup> 컨텍스트·로빙 탭인덱스·화살표 이동; <Radio> 아이템 구현; aria-labelledby/role=""radiogroup""
  ● 산출물: packages/react/src/components/radio/{group,item}.tsx
  ● 점검: 키보드 이동·단일 선택 보장",확인
 T-000089,W-000009,Form Controls v0 Comp,React 구현,Switch 구현,계획,High," ● 내용: 트랙/썸 구조, 키보드 스페이스/클릭 토글, role=""switch""·aria-checked 적용, className 병합

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -61,7 +61,7 @@ W-000008,T1,TextField v0 Comp,완료,100,"TextField v0
  ● a11y: label 연결·aria-describedby(error/helper)·aria-invalid/required; IME(조합) 안전·Enter onCommit
  ● Storybook/테스트/Exports 고정; canary 프리릴리스 포함
  ● AC: CI·Tests·Storybook·ESM+types·라벨/에러 연결·IME/Enter 시나리오 통과",--
-W-000009,T1,Form Controls v0 Comp,진행중,40,"Form Controls v0
+W-000009,T1,Form Controls v0 Comp,진행중,50,"Form Controls v0
  ● 설계문서 : root/packages/react/src/components/{checkbox,radio,switch}/README.md
  ● 범위: Checkbox(+indeterminate)/CheckboxGroup · Radio/RadioGroup · Switch(토글)
  ● a11y: label 연결·aria-checked/indeterminate·Radio 그룹 화살표 내비게이션(로빙 탭인덱스)


### PR DESCRIPTION
## Summary
- add RadioGroup context provider and Radio component built on core radio hooks with hidden inputs and merged event handlers
- ensure arrow-key navigation updates selection in the core radio group hook and cover radio behaviors with unit tests
- expose radio exports, update packaging metadata, and mark Task T-000088 complete with WBS progress adjusted

## Testing
- pnpm --filter @ara/react test -- --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69252a30ab5083229e40b245688d0b29)