### PR TITLE
[T-000089] Switch 컴포넌트 추가

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,6 +62,11 @@
       "import": "./dist/components/radio/index.js",
       "default": "./dist/components/radio/index.js"
     },
+    "./components/switch": {
+      "types": "./dist/components/switch/index.d.ts",
+      "import": "./dist/components/switch/index.js",
+      "default": "./dist/components/switch/index.js"
+    },
     "./components/icon": {
       "types": "./dist/components/icon/index.d.ts",
       "import": "./dist/components/icon/index.js",
@@ -127,6 +132,11 @@
       "import": "./dist/components/radio/index.js",
       "default": "./dist/components/radio/index.js"
     },
+    "./switch": {
+      "types": "./dist/components/switch/index.d.ts",
+      "import": "./dist/components/switch/index.js",
+      "default": "./dist/components/switch/index.js"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -164,6 +174,9 @@
       "components/radio": [
         "dist/components/radio/index.d.ts"
       ],
+      "components/switch": [
+        "dist/components/switch/index.d.ts"
+      ],
       "components/text-field": [
         "dist/components/text-field/index.d.ts"
       ],
@@ -196,6 +209,9 @@
       ],
       "radio": [
         "dist/components/radio/index.d.ts"
+      ],
+      "switch": [
+        "dist/components/switch/index.d.ts"
       ],
       "theme": [
         "dist/theme/index.d.ts"

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -3,6 +3,7 @@ export * from "./checkbox/index.js";
 export * from "./icon/index.js";
 export * from "./layout/index.js";
 export * from "./radio/index.js";
+export * from "./switch/index.js";
 export * from "./spacer/index.js";
 export * from "./theme-provider/index.js";
 export * from "./text-field/index.js";

--- a/packages/react/src/components/switch/Switch.test.tsx
+++ b/packages/react/src/components/switch/Switch.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Switch } from "./Switch.js";
+
+describe("Switch", () => {
+  it("트랙/썸 UI와 aria/data 속성을 동기화하며 토글된다", () => {
+    render(<Switch label="전원" defaultChecked={false} />);
+
+    const switchControl = screen.getByRole("switch");
+    const input = document.querySelector("input[type='checkbox']") as HTMLInputElement;
+
+    expect(switchControl).toHaveAttribute("aria-checked", "false");
+    expect(switchControl).toHaveAttribute("data-state", "unchecked");
+    expect(input.checked).toBe(false);
+
+    fireEvent.click(switchControl);
+
+    expect(switchControl).toHaveAttribute("aria-checked", "true");
+    expect(switchControl).toHaveAttribute("data-state", "checked");
+    expect(input.checked).toBe(true);
+
+    fireEvent.keyDown(switchControl, { key: " " });
+
+    expect(switchControl).toHaveAttribute("aria-checked", "false");
+    expect(switchControl).toHaveAttribute("data-state", "unchecked");
+    expect(input.checked).toBe(false);
+  });
+
+  it("레이블 클릭으로 토글되고 aria 연결을 유지한다", () => {
+    render(<Switch label="라벨" description="설명" />);
+
+    const switchControl = screen.getByRole("switch");
+    const label = screen.getByText("라벨");
+    const description = screen.getByText("설명");
+
+    expect(switchControl.getAttribute("aria-labelledby")).toContain(label.getAttribute("id"));
+    expect(switchControl.getAttribute("aria-describedby")).toContain(description.getAttribute("id"));
+
+    fireEvent.click(label);
+
+    expect(switchControl).toHaveAttribute("data-state", "checked");
+  });
+
+  it("disabled/readOnly 상태에서는 토글되지 않는다", () => {
+    render(<Switch label="비활성" disabled defaultChecked={false} />);
+
+    const disabledSwitch = screen.getByRole("switch");
+
+    fireEvent.click(disabledSwitch);
+
+    expect(disabledSwitch).toHaveAttribute("data-state", "unchecked");
+
+    render(<Switch label="읽기전용" readOnly defaultChecked />);
+
+    const readOnlySwitch = screen.getAllByRole("switch")[1];
+
+    fireEvent.keyDown(readOnlySwitch, { key: "Enter" });
+
+    expect(readOnlySwitch).toHaveAttribute("data-state", "checked");
+  });
+});

--- a/packages/react/src/components/switch/Switch.tsx
+++ b/packages/react/src/components/switch/Switch.tsx
@@ -1,0 +1,165 @@
+import {
+  forwardRef,
+  useMemo,
+  type CSSProperties,
+  type HTMLAttributes,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type Ref
+} from "react";
+import { composeRefs } from "@radix-ui/react-compose-refs";
+import { useSwitch } from "@ara/core";
+
+const visuallyHiddenStyle: CSSProperties = {
+  position: "absolute",
+  width: "1px",
+  height: "1px",
+  padding: 0,
+  margin: "-1px",
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0
+};
+
+function mergeClassNames(...values: Array<string | undefined | null | false>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+function composeEventHandlers<Event>(
+  ours: ((event: Event) => void) | undefined,
+  theirs: ((event: Event) => void) | undefined
+): ((event: Event) => void) | undefined {
+  if (!ours && !theirs) return undefined;
+  return (event: Event) => {
+    ours?.(event);
+    theirs?.(event);
+  };
+}
+
+interface SwitchOwnProps {
+  readonly label?: ReactNode;
+  readonly description?: ReactNode;
+  readonly invalid?: boolean;
+  readonly inputRef?: Ref<HTMLInputElement>;
+  readonly describedBy?: string | readonly string[];
+  readonly labelledBy?: string | readonly string[];
+  readonly trackClassName?: string;
+  readonly thumbClassName?: string;
+}
+
+export type SwitchProps = SwitchOwnProps &
+  Omit<
+    Pick<
+      InputHTMLAttributes<HTMLInputElement>,
+      "id" | "name" | "checked" | "defaultChecked" | "required" | "disabled" | "readOnly" | "value"
+    >,
+    "checked" | "defaultChecked"
+  > &
+  Pick<HTMLAttributes<HTMLDivElement>, "className" | "style" | "onClick" | "onKeyDown"> & {
+    readonly checked?: boolean;
+    readonly defaultChecked?: boolean;
+  };
+
+export const Switch = forwardRef<HTMLDivElement, SwitchProps>(function Switch(props, ref) {
+  const {
+    id,
+    name,
+    value,
+    checked,
+    defaultChecked,
+    required,
+    disabled,
+    readOnly,
+    invalid,
+    label,
+    description,
+    inputRef,
+    describedBy,
+    labelledBy,
+    className,
+    style,
+    trackClassName,
+    thumbClassName,
+    onClick,
+    onKeyDown,
+    ...restProps
+  } = props;
+
+  const describedByIds = useMemo(() => {
+    if (!describedBy) return [] as string[];
+    return Array.isArray(describedBy) ? [...describedBy] : [describedBy];
+  }, [describedBy]);
+
+  const labelledByIds = useMemo(() => {
+    if (!labelledBy) return [] as string[];
+    return Array.isArray(labelledBy) ? [...labelledBy] : [labelledBy];
+  }, [labelledBy]);
+
+  const { rootProps, inputProps, labelProps, descriptionProps } = useSwitch({
+    id,
+    name,
+    value,
+    checked,
+    defaultChecked,
+    required,
+    disabled,
+    readOnly,
+    invalid,
+    hasLabel: Boolean(label),
+    hasDescription: Boolean(description),
+    describedByIds,
+    labelledByIds
+  });
+
+  const mergedRootProps = useMemo(
+    () => ({
+      ...rootProps,
+      onClick: composeEventHandlers(rootProps.onClick, onClick),
+      onKeyDown: composeEventHandlers(rootProps.onKeyDown, onKeyDown)
+    }),
+    [onClick, onKeyDown, rootProps]
+  );
+
+  const mergedInputRef = composeRefs(inputProps.ref, inputRef);
+
+  return (
+    <div
+      {...restProps}
+      ref={ref}
+      className={mergeClassNames("ara-switch", className)}
+      style={style}
+      data-state={rootProps["data-state"]}
+      data-disabled={rootProps["data-disabled"]}
+      data-readonly={rootProps["data-readonly"]}
+      data-required={rootProps["data-required"]}
+      data-invalid={rootProps["data-invalid"]}
+    >
+      <input
+        {...inputProps}
+        ref={mergedInputRef}
+        aria-hidden
+        tabIndex={-1}
+        style={visuallyHiddenStyle}
+        data-state={rootProps["data-state"]}
+      />
+      <div {...mergedRootProps} className={mergeClassNames("ara-switch__track", trackClassName)}>
+        <span aria-hidden className={mergeClassNames("ara-switch__thumb", thumbClassName)} />
+      </div>
+      {(label || description) && (
+        <div className="ara-switch__text">
+          {label ? (
+            <label {...labelProps} className="ara-switch__label">
+              {label}
+            </label>
+          ) : null}
+          {description ? (
+            <div {...descriptionProps} className="ara-switch__description">
+              {description}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/packages/react/src/components/switch/Switch.tsx
+++ b/packages/react/src/components/switch/Switch.tsx
@@ -48,14 +48,13 @@ interface SwitchOwnProps {
   readonly thumbClassName?: string;
 }
 
+type SwitchInputProps = Pick<
+  InputHTMLAttributes<HTMLInputElement>,
+  "id" | "name" | "required" | "disabled" | "readOnly"
+> & { readonly value?: string };
+
 export type SwitchProps = SwitchOwnProps &
-  Omit<
-    Pick<
-      InputHTMLAttributes<HTMLInputElement>,
-      "id" | "name" | "checked" | "defaultChecked" | "required" | "disabled" | "readOnly" | "value"
-    >,
-    "checked" | "defaultChecked"
-  > &
+  SwitchInputProps &
   Pick<HTMLAttributes<HTMLDivElement>, "className" | "style" | "onClick" | "onKeyDown"> & {
     readonly checked?: boolean;
     readonly defaultChecked?: boolean;

--- a/packages/react/src/components/switch/index.ts
+++ b/packages/react/src/components/switch/index.ts
@@ -1,0 +1,1 @@
+export { Switch, type SwitchProps } from "./Switch.js";


### PR DESCRIPTION
## Summary
- [x] useSwitch 기반의 트랙/썸 UI와 라벨·설명 텍스트를 포함한 Switch 컴포넌트를 추가했습니다.
- [x] 클릭/키보드 토글, disabled/readOnly 차단, aria 연결을 검증하는 Switch 테스트를 작성했습니다.
- [x] 새 컴포넌트를 패키지 exports와 컴포넌트 인덱스에 등록했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (WBS: W-000009 / Task: T-000089)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다. (해당 없음)
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.** (없음)

## Testing
- [x] `pnpm --filter @ara/react test -- --testNamePattern Switch` (Node 20 환경에서 엔진 버전 경고만 발생)

## Screenshots
- 없음

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69252f9a895883228370212dbf9a0963)