### PR TITLE
T-000090: 폼 컨트롤 ARIA 테스트 보강

### DIFF
--- a/packages/react/src/components/checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.test.tsx
@@ -47,6 +47,37 @@ describe("Checkbox", () => {
     expect(checkbox).toHaveAttribute("data-state", "checked");
   });
 
+  it("aria 레이블/설명 및 상태 속성을 연결한다", () => {
+    render(
+      <Checkbox
+        label="동의"
+        description="설명"
+        required
+        invalid
+        readOnly
+        value="agree"
+      />
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    const label = screen.getByText("동의");
+    const description = screen.getByText("설명");
+    const input = document.querySelector("input[type='checkbox']")!;
+
+    expect(checkbox.getAttribute("aria-labelledby")).toBe(label.id);
+    expect(checkbox.getAttribute("aria-describedby")).toBe(description.id);
+    expect(checkbox).toHaveAttribute("aria-required", "true");
+    expect(checkbox).toHaveAttribute("aria-invalid", "true");
+    expect(checkbox).toHaveAttribute("aria-readonly", "true");
+
+    expect(input).toHaveAttribute("id", label.htmlFor);
+    expect(input.getAttribute("aria-labelledby")).toBe(label.id);
+    expect(input.getAttribute("aria-describedby")).toBe(description.id);
+    expect(input).toHaveAttribute("aria-required", "true");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAttribute("aria-readonly", "true");
+  });
+
   it("disabled 시 상호작용을 차단한다", () => {
     render(<Checkbox label="비활성" disabled defaultChecked={false} />);
 

--- a/packages/react/src/components/radio/Radio.test.tsx
+++ b/packages/react/src/components/radio/Radio.test.tsx
@@ -14,8 +14,8 @@ describe("RadioGroup/Radio", () => {
       </RadioGroup>
     );
 
-    const optionA = screen.getByRole("radio", { name: "옵션 A" });
-    const optionB = screen.getByRole("radio", { name: "옵션 B" });
+    const optionA = screen.getByRole("radio", { name: /옵션 A/ });
+    const optionB = screen.getByRole("radio", { name: /옵션 B/ });
 
     expect(optionB).toHaveAttribute("aria-checked", "true");
     expect(optionA).toHaveAttribute("aria-checked", "false");
@@ -59,5 +59,29 @@ describe("RadioGroup/Radio", () => {
 
     expect(locked).toHaveAttribute("aria-checked", "false");
     expect(locked).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("그룹 레이블/설명 및 상태 aria 속성을 연결한다", () => {
+    render(
+      <RadioGroup label="색상" description="색상 설명" required invalid readOnly>
+        <Radio value="red" label="빨강" />
+        <Radio value="blue" label="파랑" />
+      </RadioGroup>
+    );
+
+    const group = screen.getByRole("radiogroup");
+    const label = screen.getByText("색상");
+    const description = screen.getByText("색상 설명");
+    const red = screen.getByRole("radio", { name: /빨강/ });
+    const redLabel = screen.getByText("빨강");
+
+    expect(group.getAttribute("aria-labelledby")).toBe(label.id);
+    expect(group.getAttribute("aria-describedby")).toBe(description.id);
+    expect(group).toHaveAttribute("aria-required", "true");
+    expect(group).toHaveAttribute("aria-invalid", "true");
+    expect(group).toHaveAttribute("aria-readonly", "true");
+
+    expect(red.getAttribute("aria-labelledby")).toBe(redLabel.id);
+    expect(red.getAttribute("aria-describedby")).toBe(description.id);
   });
 });

--- a/packages/react/src/components/radio/Radio.tsx
+++ b/packages/react/src/components/radio/Radio.tsx
@@ -72,17 +72,27 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     ...restProps
   } = props;
 
+  const group = useRadioGroupContext();
+
   const describedByIds = useMemo(() => {
-    if (!describedBy) return [] as string[];
-    return Array.isArray(describedBy) ? [...describedBy] : [describedBy];
-  }, [describedBy]);
+    const ids: string[] = [];
+    const groupDescribedBy = group.rootProps["aria-describedby"];
+
+    if (groupDescribedBy) {
+      ids.push(...groupDescribedBy.split(" ").filter(Boolean));
+    }
+
+    if (describedBy) {
+      ids.push(...(Array.isArray(describedBy) ? describedBy : [describedBy]));
+    }
+
+    return ids;
+  }, [describedBy, group.rootProps]);
 
   const labelledByIds = useMemo(() => {
     if (!labelledBy) return [] as string[];
     return Array.isArray(labelledBy) ? [...labelledBy] : [labelledBy];
   }, [labelledBy]);
-
-  const group = useRadioGroupContext();
 
   const { rootProps, inputProps, labelProps, descriptionProps } = useRadio({
     id,


### PR DESCRIPTION
## Summary
- [x] T-000090 Form Controls A11y 검증을 위해 Checkbox/Radio의 레이블·설명·상태 ARIA 연결 테스트를 보강했습니다.
- [x] Radio 컴포넌트가 그룹 aria-describedby 정보를 각 항목에도 병합하도록 개선했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] pnpm --filter @ara/react test -- --runInBand (엔진 요구 사항 경고 존재)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69253602370c8322b4e9809cd95f5e89)