### PR TITLE
Add form control accessibility guide

### DIFF
--- a/docs/form-controls-a11y.md
+++ b/docs/form-controls-a11y.md
@@ -1,0 +1,39 @@
+# Form Controls v0 접근성 가이드
+
+> 대상: `Checkbox`, `CheckboxGroup`, `Radio`, `RadioGroup`, `Switch`
+> 위치: `packages/react/src/components/{checkbox,radio,switch}`
+
+## 필수 연결 규칙
+
+- **레이블 → 컨트롤**
+  - 모든 컴포넌트는 시각적 `label`을 `for/id`로 연결하고, 커스텀 UI의 `aria-labelledby`에 포함한다.
+  - 그룹(`CheckboxGroup`/`RadioGroup`)은 컨테이너에 `role`과 함께 `aria-labelledby`를 부여해 스크린 리더가 그룹 레이블을 먼저 읽는다.
+- **설명/에러 → 컨트롤**
+  - `description`(helper/error 용)을 제공하면 `aria-describedby`에 연결해 상태/보조 메시지가 스크린 리더에 노출된다.
+  - 그룹 설명은 개별 항목과 병합되어 전달된다.
+- **상태 ARIA**
+  - `required` → `aria-required="true"`
+  - `invalid` → `aria-invalid="true"`
+  - `disabled` → `aria-disabled="true"` (포커스/상호작용 차단)
+  - `readOnly` → `aria-readonly="true"` (포커스 허용, 토글만 차단)
+- **역할(Role)**
+  - 체크박스/그룹: 커스텀 UI에 `role="checkbox"`, 그룹 컨테이너는 div(기본) 유지.
+  - 라디오/그룹: 항목에 `role="radio"`, 그룹 컨테이너에 `role="radiogroup"`.
+  - 스위치: 커스텀 UI에 `role="switch"` + 숨김 `<input type="checkbox">`.
+
+## 키보드/포커스 규정
+
+- **Checkbox/Switch**: `Space`/`Enter`로 토글, `Tab`으로 기본 포커스 이동. `disabled` 시 포커스/토글 모두 차단, `readOnly` 시 토글만 차단.
+- **RadioGroup**: `Tab` 진입 시 선택된 항목(없으면 첫 항목)에 포커스. `ArrowLeft/ArrowRight`(가로) 또는 `ArrowUp/ArrowDown`(세로)로 다음 항목으로 이동하면서 선택을 갱신한다. `loop` 여부에 따라 끝에서 순환 여부를 결정한다.
+- **레이블 클릭/포커스**: 모든 컴포넌트는 시각적 레이블 클릭으로 포커스를 위임하고 상태를 변경한다.
+
+## 테스트 커버리지
+
+- `Checkbox.test.tsx`
+  - 기본/indeterminate 토글, 레이블 클릭, `aria-labelledby`/`aria-describedby`/`aria-required`/`aria-invalid`/`aria-readonly` 검증.
+- `Radio.test.tsx`
+  - 그룹 단일 선택 유지, 화살표 키 이동 시 선택 갱신, 그룹 `aria-labelledby`/`aria-describedby`/상태 ARIA 검증.
+- `Switch.test.tsx`
+  - 클릭/Space/Enter 토글, 레이블/설명 연결, `disabled`/`readOnly` 차단, 제어형(onCheckedChange) 흐름 검증.
+
+> 위 규칙과 테스트는 label-for/id 연결, `aria-describedby`(helper/error), 필수/오류 상태, 그룹 라벨링, 키보드 내비게이션 요구사항을 모두 포괄한다.

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -285,7 +285,7 @@ T-000088,W-000009,Form Controls v0 Comp,React 구현,Radio/RadioGroup 구현,완
 T-000089,W-000009,Form Controls v0 Comp,React 구현,Switch 구현,완료,High," ● 내용: 트랙/썸 구조, 키보드 스페이스/클릭 토글, role=""switch""·aria-checked 적용, className 병합
  ● 산출물: packages/react/src/components/switch/index.tsx
  ● 점검: 포커스 링·상태 전환 스냅",확인
-T-000090,W-000009,Form Controls v0 Comp,접근성/A11y,Label/ARIA/키보드 규정 적용,계획,High," ● 내용: label-for/id 연결, aria-describedby(error/helper) 연결, required/invalid 반영, 그룹 role/라벨링 규칙 문서화
+T-000090,W-000009,Form Controls v0 Comp,접근성/A11y,Label/ARIA/키보드 규정 적용,완료,High," ● 내용: label-for/id 연결, aria-describedby(error/helper) 연결, required/invalid 반영, 그룹 role/라벨링 규칙 문서화
  ● 산출물: A11y 가이드와 테스트 케이스
  ● 점검: 스크린리더 라벨/에러 읽힘·탭 순서 정상",확인
 T-000091,W-000009,Form Controls v0 Comp,폼 연동,네이티브 폼 제출/리셋/이름 규약,계획,Medium," ● 내용: name/value 제출·defaultChecked/checked 동작, form reset 대응, Radio name 강제, Switch의 폼 값 전략

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -61,7 +61,7 @@ W-000008,T1,TextField v0 Comp,완료,100,"TextField v0
  ● a11y: label 연결·aria-describedby(error/helper)·aria-invalid/required; IME(조합) 안전·Enter onCommit
  ● Storybook/테스트/Exports 고정; canary 프리릴리스 포함
  ● AC: CI·Tests·Storybook·ESM+types·라벨/에러 연결·IME/Enter 시나리오 통과",--
-W-000009,T1,Form Controls v0 Comp,진행중,55,"Form Controls v0
+W-000009,T1,Form Controls v0 Comp,진행중,60,"Form Controls v0
  ● 설계문서 : root/packages/react/src/components/{checkbox,radio,switch}/README.md
  ● 범위: Checkbox(+indeterminate)/CheckboxGroup · Radio/RadioGroup · Switch(토글)
  ● a11y: label 연결·aria-checked/indeterminate·Radio 그룹 화살표 내비게이션(로빙 탭인덱스)


### PR DESCRIPTION
## Summary
- add a form controls accessibility guide covering labeling, aria relationships, and keyboard flows
- document existing checkbox, radio, and switch test coverage for the accessibility rules
- mark Task T-000090 complete and update WBS progress accordingly

## Testing
- not run (documentation and planning updates only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692542b4c4a08322a210fd545431774d)