### PR TITLE
Fix radio input ref typing

### DIFF
--- a/packages/core/src/use-radio.ts
+++ b/packages/core/src/use-radio.ts
@@ -34,6 +34,7 @@ interface UseRadioIds {
 export interface UseRadioResult {
   readonly rootProps: RadioRootProps;
   readonly inputProps: RadioInputProps;
+  readonly inputRef: (node: HTMLInputElement | null) => void;
   readonly labelProps: RadioLabelProps;
   readonly descriptionProps: RadioDescriptionProps;
   readonly isChecked: boolean;
@@ -127,6 +128,9 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
   const [tabIndex, setTabIndex] = useState(-1);
   const rootRef = useRef<HTMLElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const setInputRef = useCallback((node: HTMLInputElement | null) => {
+    inputRef.current = node;
+  }, []);
 
   const controller = useMemo(
     () => ({
@@ -264,9 +268,7 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
     disabled: isDisabled || undefined,
     readOnly: appliedReadOnly || undefined,
     checked: isChecked,
-    ref: (node) => {
-      inputRef.current = node;
-    },
+    ref: setInputRef,
     "aria-invalid": groupInvalid ? true : undefined,
     "aria-required": groupRequired ? true : undefined,
     "aria-readonly": appliedReadOnly ? true : undefined,
@@ -288,6 +290,7 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
   return {
     rootProps,
     inputProps,
+    inputRef: setInputRef,
     labelProps,
     descriptionProps,
     isChecked

--- a/packages/react/src/components/radio/Radio.tsx
+++ b/packages/react/src/components/radio/Radio.tsx
@@ -95,7 +95,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     return Array.isArray(labelledBy) ? [...labelledBy] : [labelledBy];
   }, [labelledBy]);
 
-  const { rootProps, inputProps, labelProps, descriptionProps } = useRadio({
+  const { rootProps, inputProps, inputRef, labelProps, descriptionProps } = useRadio({
     id,
     value,
     disabled,
@@ -116,15 +116,17 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     [onClick, onKeyDown, rootProps]
   );
 
+  const { ref: inputPropsRef, ...inputPropsWithoutRef } = inputProps;
+
   const mergedInputProps = useMemo(
     () => ({
-      ...inputProps,
+      ...inputPropsWithoutRef,
       onChange: composeEventHandlers(inputProps.onChange, onChange)
     }),
     [inputProps, onChange]
   );
 
-  const mergedInputRef = composeRefs(inputProps.ref, inputRefProp);
+  const mergedInputRef = composeRefs(inputPropsRef, inputRefProp);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- expose the radio input ref callback from `useRadio` to compose with external refs
- adjust the radio component to use the hook-provided ref while omitting ref from spread props

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692546d493f0832294163e8b7f22e093)