### PR TITLE
Adjust radio input ref handling

### DIFF
--- a/packages/core/src/use-radio.ts
+++ b/packages/core/src/use-radio.ts
@@ -34,6 +34,7 @@ interface UseRadioIds {
 export interface UseRadioResult {
   readonly rootProps: RadioRootProps;
   readonly inputProps: RadioInputProps;
+  readonly inputRef: (node: HTMLInputElement | null) => void;
   readonly labelProps: RadioLabelProps;
   readonly descriptionProps: RadioDescriptionProps;
   readonly isChecked: boolean;
@@ -127,6 +128,9 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
   const [tabIndex, setTabIndex] = useState(-1);
   const rootRef = useRef<HTMLElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const setInputRef = useCallback((node: HTMLInputElement | null) => {
+    inputRef.current = node;
+  }, []);
 
   const controller = useMemo(
     () => ({
@@ -264,9 +268,7 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
     disabled: isDisabled || undefined,
     readOnly: appliedReadOnly || undefined,
     checked: isChecked,
-    ref: (node) => {
-      inputRef.current = node;
-    },
+    ref: setInputRef,
     "aria-invalid": groupInvalid ? true : undefined,
     "aria-required": groupRequired ? true : undefined,
     "aria-readonly": appliedReadOnly ? true : undefined,
@@ -288,6 +290,7 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
   return {
     rootProps,
     inputProps,
+    inputRef: setInputRef,
     labelProps,
     descriptionProps,
     isChecked

--- a/packages/react/src/components/radio/Radio.tsx
+++ b/packages/react/src/components/radio/Radio.tsx
@@ -116,15 +116,14 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     [onClick, onKeyDown, rootProps]
   );
 
-  const mergedInputProps = useMemo(
-    () => ({
-      ...inputProps,
-      onChange: composeEventHandlers(inputProps.onChange, onChange)
-    }),
-    [inputProps, onChange]
-  );
+  const { ref: inputPropsRef, onChange: inputOnChange, ...inputPropsWithoutRef } =
+    inputProps as RadioInputProps & { ref?: Ref<HTMLInputElement> };
 
-  const mergedInputRef = composeRefs(inputProps.ref, inputRefProp);
+  const mergedInputProps = {
+    ...inputPropsWithoutRef,
+    onChange: composeEventHandlers(inputOnChange, onChange),
+    ref: composeRefs(inputPropsRef, inputRefProp)
+  };
 
   return (
     <div
@@ -138,7 +137,6 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     >
       <input
         {...mergedInputProps}
-        ref={mergedInputRef}
         aria-hidden
         tabIndex={-1}
         style={visuallyHiddenStyle}


### PR DESCRIPTION
## Summary
- simplify radio input prop composition without destructuring hook result refs
- compose the hook-provided input ref with external refs via inline props

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692546d493f0832294163e8b7f22e093)