### PR TITLE
Fix radio input ref wiring

### DIFF
--- a/packages/core/src/use-radio.ts
+++ b/packages/core/src/use-radio.ts
@@ -34,6 +34,7 @@ interface UseRadioIds {
 export interface UseRadioResult {
   readonly rootProps: RadioRootProps;
   readonly inputProps: RadioInputProps;
+  readonly inputRef: (node: HTMLInputElement | null) => void;
   readonly labelProps: RadioLabelProps;
   readonly descriptionProps: RadioDescriptionProps;
   readonly isChecked: boolean;
@@ -127,6 +128,9 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
   const [tabIndex, setTabIndex] = useState(-1);
   const rootRef = useRef<HTMLElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const setInputRef = useCallback((node: HTMLInputElement | null) => {
+    inputRef.current = node;
+  }, []);
 
   const controller = useMemo(
     () => ({
@@ -264,9 +268,7 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
     disabled: isDisabled || undefined,
     readOnly: appliedReadOnly || undefined,
     checked: isChecked,
-    ref: (node) => {
-      inputRef.current = node;
-    },
+    ref: setInputRef,
     "aria-invalid": groupInvalid ? true : undefined,
     "aria-required": groupRequired ? true : undefined,
     "aria-readonly": appliedReadOnly ? true : undefined,
@@ -288,6 +290,7 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
   return {
     rootProps,
     inputProps,
+    inputRef: setInputRef,
     labelProps,
     descriptionProps,
     isChecked

--- a/packages/react/src/components/radio/Radio.tsx
+++ b/packages/react/src/components/radio/Radio.tsx
@@ -95,7 +95,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     return Array.isArray(labelledBy) ? [...labelledBy] : [labelledBy];
   }, [labelledBy]);
 
-  const { rootProps, inputProps, labelProps, descriptionProps } = useRadio({
+  const { rootProps, inputProps, inputRef, labelProps, descriptionProps } = useRadio({
     id,
     value,
     disabled,
@@ -116,15 +116,13 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     [onClick, onKeyDown, rootProps]
   );
 
-  const mergedInputProps = useMemo(
-    () => ({
-      ...inputProps,
-      onChange: composeEventHandlers(inputProps.onChange, onChange)
-    }),
-    [inputProps, onChange]
-  );
+  const { ref: inputPropsRef, onChange: inputOnChange, ...inputPropsWithoutRef } = inputProps;
 
-  const mergedInputRef = composeRefs(inputProps.ref, inputRefProp);
+  const mergedInputProps = {
+    ...inputPropsWithoutRef,
+    onChange: composeEventHandlers(inputOnChange, onChange),
+    ref: composeRefs(inputPropsRef, composeRefs(inputRef, inputRefProp))
+  };
 
   return (
     <div
@@ -138,7 +136,6 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     >
       <input
         {...mergedInputProps}
-        ref={mergedInputRef}
         aria-hidden
         tabIndex={-1}
         style={visuallyHiddenStyle}


### PR DESCRIPTION
## Summary
- compose the radio input ref using the hook-provided callback alongside external refs
- simplify radio input prop handling by removing the cast to RadioInputProps

## Testing
- pnpm tsc --noEmit --pretty false --project packages/react/tsconfig.json *(fails: rootDir excludes other packages in workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692546d493f0832294163e8b7f22e093)