### PR TITLE
Remove unused inputRef from Radio component

### DIFF
--- a/packages/react/src/components/radio/Radio.tsx
+++ b/packages/react/src/components/radio/Radio.tsx
@@ -95,7 +95,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     return Array.isArray(labelledBy) ? [...labelledBy] : [labelledBy];
   }, [labelledBy]);
 
-  const { rootProps, inputProps, inputRef, labelProps, descriptionProps } = useRadio({
+  const { rootProps, inputProps, labelProps, descriptionProps } = useRadio({
     id,
     value,
     disabled,


### PR DESCRIPTION
## Summary
- remove unused inputRef destructuring from Radio component

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69254ffe2aac8322923db5aaa3478252)