### PR TITLE
T-000092: 폼 컨트롤 상태/사이즈 CSS 변수 추가

### DIFF
--- a/packages/tokens/src/components/text-field.ts
+++ b/packages/tokens/src/components/text-field.ts
@@ -1,0 +1,130 @@
+import { colors } from "../colors.js";
+import { typography } from "../typography.js";
+
+type StateTokens<TStates extends readonly string[]> = {
+  readonly [State in TStates[number]]: string;
+};
+
+type TextFieldState = "default" | "hover" | "focus" | "disabled" | "invalid";
+
+type TextFieldToneTokens = {
+  readonly surface: StateTokens<readonly TextFieldState[]>;
+  readonly border: StateTokens<readonly TextFieldState[]>;
+  readonly text: StateTokens<readonly ["default", "disabled", "invalid"]>;
+};
+
+type TextFieldToneName = "primary" | "neutral" | "danger";
+type TextFieldToneMap = Record<TextFieldToneName, TextFieldToneTokens>;
+
+type TextFieldSizeToken = {
+  readonly height: string;
+  readonly paddingInline: string;
+  readonly paddingBlock: string;
+  readonly gap: string;
+  readonly fontSize: string;
+  readonly lineHeight: string;
+  readonly icon: string;
+  readonly clear: string;
+  readonly toggle: string;
+};
+
+type TextFieldSizeMap = Record<string, TextFieldSizeToken>;
+
+function createToneTokens(): TextFieldToneMap {
+  const lightRole = colors.role.light;
+  const dangerInteraction = lightRole.interactive.danger;
+
+  const toneSources = {
+    primary: lightRole.interactive.primary,
+    neutral: lightRole.interactive.neutral,
+    danger: dangerInteraction
+  } satisfies Record<TextFieldToneName, (typeof lightRole.interactive)[TextFieldToneName]>;
+
+  return Object.fromEntries(
+    Object.entries(toneSources).map(([toneName, interaction]) => {
+      const surface: TextFieldToneTokens["surface"] = {
+        default: lightRole.surface.surface,
+        hover: colors.palette.neutral["50"],
+        focus: lightRole.surface.surface,
+        disabled: interaction.disabled.background,
+        invalid: lightRole.surface.surface
+      } as const;
+
+      const border: TextFieldToneTokens["border"] = {
+        default: interaction.default.border,
+        hover: interaction.hover.border,
+        focus: lightRole.border.focus,
+        disabled: interaction.disabled.border,
+        invalid: dangerInteraction.default.border
+      } as const;
+
+      const text: TextFieldToneTokens["text"] = {
+        default: lightRole.text.primary,
+        disabled: colors.palette.neutral["400"],
+        invalid: colors.palette.danger["700"]
+      } as const;
+
+      return [toneName, { surface, border, text } satisfies TextFieldToneTokens];
+    })
+  ) as TextFieldToneMap;
+}
+
+function createSizeMap(): TextFieldSizeMap {
+  return {
+    sm: {
+      height: "2.25rem",
+      paddingInline: "0.5rem",
+      paddingBlock: "0.375rem",
+      gap: "0.375rem",
+      fontSize: typography.fontSize.sm,
+      lineHeight: "1.4",
+      icon: "1rem",
+      clear: "1.25rem",
+      toggle: "1.25rem"
+    },
+    md: {
+      height: "2.75rem",
+      paddingInline: "0.75rem",
+      paddingBlock: "0.5rem",
+      gap: "0.5rem",
+      fontSize: typography.fontSize.md,
+      lineHeight: typography.lineHeight.normal,
+      icon: "1.25rem",
+      clear: "1.25rem",
+      toggle: "1.25rem"
+    },
+    lg: {
+      height: "3.25rem",
+      paddingInline: "1rem",
+      paddingBlock: "0.75rem",
+      gap: "0.625rem",
+      fontSize: typography.fontSize.lg,
+      lineHeight: typography.lineHeight.normal,
+      icon: "1.35rem",
+      clear: "1.35rem",
+      toggle: "1.35rem"
+    }
+  } satisfies TextFieldSizeMap;
+}
+
+export const textField = {
+  font: {
+    family: typography.fontFamily.sans,
+    weight: typography.fontWeight.regular
+  },
+  radius: "0.5rem",
+  borderWidth: "1px",
+  disabled: {
+    opacity: 0.6
+  },
+  focus: {
+    outlineWidth: "2px",
+    outlineColor: colors.role.light.border.focus,
+    ringSize: "4px",
+    ringColor: "rgba(96, 165, 250, 0.2)"
+  },
+  tone: createToneTokens(),
+  size: createSizeMap()
+} as const;
+
+export type TextFieldTokens = typeof textField;

--- a/packages/tokens/src/css-vars.ts
+++ b/packages/tokens/src/css-vars.ts
@@ -118,6 +118,87 @@ function createLayoutVariables(theme: Tokens): CSSVariableMap {
   return variables;
 }
 
+function createTextFieldVariables(theme: Tokens): CSSVariableMap {
+  const variables: CSSVariableMap = {} as CSSVariableMap;
+  const textField = theme.component.textField;
+
+  assignVariable(variables, "--ara-tf-font", textField.font.family);
+  assignVariable(variables, "--ara-tf-font-weight", textField.font.weight);
+  assignVariable(variables, "--ara-tf-radius", textField.radius);
+  assignVariable(variables, "--ara-tf-border-width", textField.borderWidth);
+  assignVariable(variables, "--ara-tf-disabled-opacity", textField.disabled.opacity);
+  assignVariable(
+    variables,
+    "--ara-tf-outline" as CSSVariableName,
+    `${textField.focus.outlineWidth} solid ${textField.focus.outlineColor}`
+  );
+  assignVariable(
+    variables,
+    "--ara-tf-shadow-focus" as CSSVariableName,
+    `0 0 0 ${textField.focus.ringSize} ${textField.focus.ringColor}`
+  );
+
+  for (const [toneName, toneTokens] of Object.entries(textField.tone)) {
+    const tonePrefix = `--ara-tf-tone-${toneName}`;
+
+    for (const [stateName, value] of Object.entries(toneTokens.surface)) {
+      assignVariable(
+        variables,
+        `${tonePrefix}-surface-${stateName}` as CSSVariableName,
+        value
+      );
+    }
+
+    for (const [stateName, value] of Object.entries(toneTokens.border)) {
+      assignVariable(
+        variables,
+        `${tonePrefix}-border-${stateName}` as CSSVariableName,
+        value
+      );
+    }
+
+    for (const [stateName, value] of Object.entries(toneTokens.text)) {
+      assignVariable(
+        variables,
+        `${tonePrefix}-text-${stateName}` as CSSVariableName,
+        value
+      );
+    }
+  }
+
+  const defaultTone = textField.tone.neutral;
+
+  assignVariable(variables, "--ara-tf-surface-default" as CSSVariableName, defaultTone.surface.default);
+  assignVariable(variables, "--ara-tf-surface-hover" as CSSVariableName, defaultTone.surface.hover);
+  assignVariable(variables, "--ara-tf-surface-focus" as CSSVariableName, defaultTone.surface.focus);
+  assignVariable(variables, "--ara-tf-surface-disabled" as CSSVariableName, defaultTone.surface.disabled);
+  assignVariable(variables, "--ara-tf-surface-invalid" as CSSVariableName, defaultTone.surface.invalid);
+  assignVariable(variables, "--ara-tf-border-default" as CSSVariableName, defaultTone.border.default);
+  assignVariable(variables, "--ara-tf-border-hover" as CSSVariableName, defaultTone.border.hover);
+  assignVariable(variables, "--ara-tf-border-focus" as CSSVariableName, defaultTone.border.focus);
+  assignVariable(variables, "--ara-tf-border-disabled" as CSSVariableName, defaultTone.border.disabled);
+  assignVariable(variables, "--ara-tf-border-invalid" as CSSVariableName, defaultTone.border.invalid);
+  assignVariable(variables, "--ara-tf-text-default" as CSSVariableName, defaultTone.text.default);
+  assignVariable(variables, "--ara-tf-text-disabled" as CSSVariableName, defaultTone.text.disabled);
+  assignVariable(variables, "--ara-tf-text-invalid" as CSSVariableName, defaultTone.text.invalid);
+
+  for (const [sizeName, sizeTokens] of Object.entries(textField.size)) {
+    const sizePrefix = `--ara-tf-size-${sizeName}`;
+
+    assignVariable(variables, `${sizePrefix}-height` as CSSVariableName, sizeTokens.height);
+    assignVariable(variables, `${sizePrefix}-px` as CSSVariableName, sizeTokens.paddingInline);
+    assignVariable(variables, `${sizePrefix}-py` as CSSVariableName, sizeTokens.paddingBlock);
+    assignVariable(variables, `${sizePrefix}-gap` as CSSVariableName, sizeTokens.gap);
+    assignVariable(variables, `${sizePrefix}-font-size` as CSSVariableName, sizeTokens.fontSize);
+    assignVariable(variables, `${sizePrefix}-line-height` as CSSVariableName, sizeTokens.lineHeight);
+    assignVariable(variables, `${sizePrefix}-icon` as CSSVariableName, sizeTokens.icon);
+    assignVariable(variables, `${sizePrefix}-clear` as CSSVariableName, sizeTokens.clear);
+    assignVariable(variables, `${sizePrefix}-toggle` as CSSVariableName, sizeTokens.toggle);
+  }
+
+  return variables;
+}
+
 function createButtonVariables(theme: Tokens): CSSVariableMap {
   const variables: CSSVariableMap = {} as CSSVariableMap;
   const button = theme.component.button;
@@ -329,7 +410,8 @@ export function createCSSVariableTable(theme: Tokens): ThemeCSSVariableTable {
     createTypographyVariables(theme),
     createLayoutVariables(theme),
     createButtonVariables(theme),
-    createIconVariables(theme)
+    createIconVariables(theme),
+    createTextFieldVariables(theme)
   );
 
   const themes = createThemeCSSVariables(theme);

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,6 +1,7 @@
 import { colors } from "./colors.js";
 import { button } from "./components/button.js";
 import { icon } from "./components/icon.js";
+import { textField } from "./components/text-field.js";
 import { layout } from "./layout.js";
 import { typography } from "./typography.js";
 
@@ -9,6 +10,7 @@ export * from "./typography.js";
 export * from "./layout.js";
 export * from "./components/button.js";
 export * from "./components/icon.js";
+export * from "./components/text-field.js";
 export * from "./css-vars.js";
 
 export const tokens = {
@@ -17,7 +19,8 @@ export const tokens = {
   typography,
   component: {
     button,
-    icon
+    icon,
+    textField
   }
 } as const;
 


### PR DESCRIPTION
## Summary
- [x] 텍스트 필드 상태/톤/사이즈 토큰을 정의하고 CSS 변수 매핑을 추가했습니다.
- [x] 기본 톤 기반 전역 CSS 변수를 노출해 폼 컨트롤 커스터마이즈 범위를 확장했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [ ] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] pnpm --filter @ara/tokens build

## Screenshots
- 없음

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692554cbedc0832282bc45848d848255)