### PR TITLE
폼 컨트롤 스토리북 문서 추가

### DIFF
--- a/apps/storybook/stories/components/Checkbox.docs.mdx
+++ b/apps/storybook/stories/components/Checkbox.docs.mdx
@@ -1,0 +1,50 @@
+import { Meta, Title, Subtitle, Description, Canvas, Primary, Controls, ArgsTable } from "@storybook/blocks";
+import * as CheckboxStories from "./Checkbox.stories";
+
+<Meta of={CheckboxStories} />
+
+<Title>Checkbox</Title>
+
+<Subtitle>선택/해제/부분선택을 표현하는 기본 체크박스 컴포넌트입니다.</Subtitle>
+
+<Description>
+`Checkbox`는 tri-state(`checked`/`unchecked`/`indeterminate`) 상태를 지원하며, 라벨과 설명을 통해 스크린리더와 시각 사용자 모두에게
+동일한 정보를 제공합니다. 폼 제출 시 체크된 항목만 값이 전송되며, `required`/`invalid` 등의 상태는 `data-*`와 ARIA 속성으로 노출됩니다.
+</Description>
+
+## Playground
+
+<Primary of={CheckboxStories.Playground} />
+<Controls of={CheckboxStories.Playground} />
+
+## 상태 예시
+
+- 기본/선택/필수+오류/읽기 전용/비활성화 상태를 한 번에 비교합니다.
+- `required`와 `invalid`는 네이티브 검증 힌트와 연계할 수 있습니다.
+
+<Canvas of={CheckboxStories.States} />
+
+## Indeterminate
+
+폼에서 "일부 선택"을 나타낼 때 `checked="indeterminate"` 상태를 사용합니다. 상위 선택 토글과 연동하여 체크 해제 → 일부 → 전체
+순환하도록 구현할 수 있습니다.
+
+<Canvas of={CheckboxStories.Indeterminate} />
+
+## 그룹 선택
+
+여러 개의 체크박스를 묶어 채널/관심사 등 복수 선택을 구성할 수 있습니다. `name`/`value` 조합은 네이티브 폼 제출 시 배열처럼 반복되어
+전송됩니다.
+
+<Canvas of={CheckboxStories.Group} />
+
+## Props
+
+<ArgsTable of={CheckboxStories.Playground} />
+
+## 접근성 노트
+
+- 숨김 `<input type="checkbox">`에 `aria-checked`와 `indeterminate` 상태를 유지합니다.
+- 라벨/설명은 각각 `aria-labelledby`/`aria-describedby`로 연결되고, 외부 id를 `describedBy`/`labelledBy`로 병합할 수 있습니다.
+- `disabled`/`readOnly`/`required`/`invalid`는 ARIA 속성과 `data-*` 속성 모두로 노출됩니다.
+- 키보드 사용자는 Space/Enter로 토글하며, 포커스 링은 CSS 변수(`--ara-fc-focus-outline`, `--ara-fc-focus-ring`)로 커스터마이징할 수 있습니다.

--- a/apps/storybook/stories/components/Checkbox.stories.tsx
+++ b/apps/storybook/stories/components/Checkbox.stories.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import type { CheckboxState } from "@ara/core";
+import { AraProvider, AraThemeBoundary, Checkbox, Flex, Stack } from "@ara/react";
+
+const meta = {
+  title: "Components/Checkbox",
+  component: Checkbox,
+  decorators: [
+    (Story) => (
+      <AraProvider>
+        <AraThemeBoundary>
+          <Story />
+        </AraThemeBoundary>
+      </AraProvider>
+    )
+  ],
+  parameters: {
+    layout: "padded"
+  },
+  args: {
+    label: "이용 약관 동의",
+    description: "기본 체크박스입니다.",
+    required: false,
+    disabled: false
+  },
+  argTypes: {
+    onCheckedChange: { control: false },
+    describedBy: { control: false },
+    labelledBy: { control: false },
+    inputRef: { control: false },
+    controlClassName: { control: false }
+  },
+  tags: ["autodocs"]
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const spacingProps = { gap: "md", style: { maxWidth: "760px" } } as const;
+
+export const Playground: Story = {};
+
+export const States: Story = {
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack {...spacingProps}>
+      <Checkbox label="기본" description="라벨과 설명을 모두 포함합니다." />
+      <Checkbox label="선택됨" defaultChecked />
+      <Checkbox label="필수 + 오류" required invalid description="aria-invalid로 표시됩니다." />
+      <Checkbox label="읽기 전용" defaultChecked readOnly description="값을 바꿀 수 없습니다." />
+      <Checkbox label="비활성화" disabled description="포커스와 입력이 차단됩니다." />
+    </Stack>
+  )
+};
+
+const IndeterminateExample = () => {
+  const [state, setState] = useState<CheckboxState>("indeterminate");
+
+  const label = useMemo(() => {
+    if (state === "indeterminate") return "일부 선택됨";
+    return state === "checked" ? "전체 선택됨" : "선택 없음";
+  }, [state]);
+
+  return (
+    <Stack {...spacingProps}>
+      <Checkbox
+        label={label}
+        description="상태를 순환하며 indeterminate를 표시합니다."
+        checked={state}
+        onCheckedChange={setState}
+      />
+      <div style={{ color: "var(--ara-color-text-muted, #475569)" }}>
+        현재 상태: {state}
+      </div>
+    </Stack>
+  );
+};
+
+export const Indeterminate: Story = {
+  name: "Indeterminate 상태",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => <IndeterminateExample />
+};
+
+const CheckboxGroupExample = () => {
+  const [selected, setSelected] = useState<string[]>(["email"]);
+
+  const toggle = (value: string) => {
+    setSelected((prev) =>
+      prev.includes(value) ? prev.filter((item) => item !== value) : [...prev, value]
+    );
+  };
+
+  return (
+    <Stack {...spacingProps}>
+      <div style={{ fontWeight: 600 }}>알림 채널 선택</div>
+      <Flex orientation="vertical" gap="sm">
+        <Checkbox
+          name="channel"
+          value="email"
+          label="이메일"
+          description="프로모션/보안 알림을 메일로 받습니다."
+          checked={selected.includes("email") ? "checked" : "unchecked"}
+          onCheckedChange={() => toggle("email")}
+        />
+        <Checkbox
+          name="channel"
+          value="sms"
+          label="SMS"
+          description="휴대폰 문자로 긴급 알림을 전달합니다."
+          checked={selected.includes("sms") ? "checked" : "unchecked"}
+          onCheckedChange={() => toggle("sms")}
+        />
+        <Checkbox
+          name="channel"
+          value="push"
+          label="푸시"
+          description="앱 알림 배너로 메시지를 표시합니다."
+          checked={selected.includes("push") ? "checked" : "unchecked"}
+          onCheckedChange={() => toggle("push")}
+        />
+      </Flex>
+    </Stack>
+  );
+};
+
+export const Group: Story = {
+  name: "그룹 선택",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => <CheckboxGroupExample />
+};

--- a/apps/storybook/stories/components/Radio.docs.mdx
+++ b/apps/storybook/stories/components/Radio.docs.mdx
@@ -1,0 +1,43 @@
+import { Meta, Title, Subtitle, Description, Canvas, Primary, Controls, ArgsTable } from "@storybook/blocks";
+import * as RadioStories from "./Radio.stories";
+
+<Meta of={RadioStories} />
+
+<Title>Radio</Title>
+
+<Subtitle>단일 선택만 허용하는 라디오 그룹과 항목을 제공합니다.</Subtitle>
+
+<Description>
+`RadioGroup`은 방향키 로빙과 loop 옵션을 갖춘 그룹 컨테이너이며, `Radio`는 개별 선택지를 담당합니다. 동일한 `name`으로 묶여 한 번에
+하나의 값만 제출되며, `orientation`과 `loop`로 배치와 키보드 이동 방식을 제어할 수 있습니다.
+</Description>
+
+## Playground
+
+<Primary of={RadioStories.Playground} />
+<Controls of={RadioStories.Playground} />
+
+## 레이아웃
+
+가로/세로 정렬을 모두 지원하며, Flex 컨테이너로 줄바꿈 시나리오도 구현할 수 있습니다.
+
+<Canvas of={RadioStories.Orientation} />
+<Canvas of={RadioStories.HorizontalWrap} />
+
+## 제어 모드 &amp; 상태
+
+외부 상태와 동기화하거나 전체 그룹을 `disabled`/`invalid`로 표시할 수 있습니다. 방향키(↑↓/←→)와 Home/End로 이동하며 단일 선택만 유지됩니다.
+
+<Canvas of={RadioStories.ControlledGroup} />
+<Canvas of={RadioStories.DisabledAndInvalid} />
+
+## Props
+
+<ArgsTable of={RadioStories.Playground} />
+
+## 접근성 노트
+
+- 그룹은 `role="radiogroup"`, 각 항목은 `role="radio"`로 노출되어 스크린리더가 단일 선택을 인지합니다.
+- `aria-labelledby`/`aria-describedby`가 그룹과 항목에 적절히 연결되며, `label`/`description` 제공 여부에 따라 자동으로 id를 생성합니다.
+- 포커스는 그룹 내에서 로빙 탭인덱스로 이동하며, Arrow/Home/End 입력을 처리합니다.
+- `disabled`/`readOnly`/`required`/`invalid` 상태는 ARIA와 `data-*` 속성으로 중복 표기되어 스타일과 접근성을 함께 지원합니다.

--- a/apps/storybook/stories/components/Radio.stories.tsx
+++ b/apps/storybook/stories/components/Radio.stories.tsx
@@ -1,0 +1,149 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { AraProvider, AraThemeBoundary, Flex, Radio, RadioGroup, Stack } from "@ara/react";
+
+const meta = {
+  title: "Components/Radio",
+  component: Radio,
+  decorators: [
+    (Story) => (
+      <AraProvider>
+        <AraThemeBoundary>
+          <Story />
+        </AraThemeBoundary>
+      </AraProvider>
+    )
+  ],
+  parameters: {
+    layout: "padded"
+  },
+  args: {
+    label: "옵션",
+    description: "라디오 옵션입니다.",
+    disabled: false
+  },
+  argTypes: {
+    value: { control: "text" },
+    onChange: { control: false },
+    describedBy: { control: false },
+    labelledBy: { control: false },
+    inputRef: { control: false },
+    controlClassName: { control: false }
+  },
+  tags: ["autodocs"],
+  render: (args) => (
+    <RadioGroup name="sample" label="라디오 옵션" description="기본 Radio 컴포넌트입니다.">
+      <Radio {...args} value="a" />
+      <Radio {...args} value="b" label="옵션 B" />
+      <Radio {...args} value="c" label="옵션 C" description="보조 설명 포함" />
+    </RadioGroup>
+  )
+} satisfies Meta<typeof Radio>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const spacingProps = { gap: "md", style: { maxWidth: "760px" } } as const;
+
+export const Playground: Story = {};
+
+export const Orientation: Story = {
+  name: "가로/세로 그룹",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack {...spacingProps}>
+      <RadioGroup
+        name="direction-horizontal"
+        label="가로 정렬"
+        description="orientation=\"horizontal\" 로 나란히 배치"
+        orientation="horizontal"
+      >
+        <Radio value="left" label="왼쪽" />
+        <Radio value="center" label="가운데" />
+        <Radio value="right" label="오른쪽" />
+      </RadioGroup>
+      <RadioGroup
+        name="direction-vertical"
+        label="세로 정렬"
+        description="orientation=\"vertical\" 기본 방향"
+      >
+        <Radio value="top" label="위" />
+        <Radio value="middle" label="중간" />
+        <Radio value="bottom" label="아래" />
+      </RadioGroup>
+    </Stack>
+  )
+};
+
+const RadioGroupStateExample = () => {
+  const [value, setValue] = useState("apple");
+
+  return (
+    <Stack {...spacingProps}>
+      <RadioGroup
+        name="fruits"
+        label="선호 과일"
+        description="방향키로 이동하며 단일 선택만 허용합니다."
+        value={value}
+        onValueChange={setValue}
+      >
+        <Radio value="apple" label="사과" />
+        <Radio value="banana" label="바나나" description="노란색 과일" />
+        <Radio value="grape" label="포도" />
+      </RadioGroup>
+      <div style={{ color: "var(--ara-color-text-muted, #475569)" }}>현재 선택: {value}</div>
+    </Stack>
+  );
+};
+
+export const ControlledGroup: Story = {
+  name: "제어 모드 그룹",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => <RadioGroupStateExample />
+};
+
+export const DisabledAndInvalid: Story = {
+  name: "상태 사례",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack {...spacingProps}>
+      <RadioGroup name="disabled" label="비활성 그룹" description="전체 disabled">
+        <Radio value="off" label="선택 불가" disabled />
+        <Radio value="off2" label="두 번째 옵션" disabled />
+      </RadioGroup>
+      <RadioGroup name="invalid" label="검증 오류" description="aria-invalid=true 를 표시합니다." invalid required>
+        <Radio value="x" label="옵션 X" />
+        <Radio value="y" label="옵션 Y" />
+      </RadioGroup>
+    </Stack>
+  )
+};
+
+export const HorizontalWrap: Story = {
+  name: "여러 줄 가로 나열",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <RadioGroup
+      name="layout"
+      label="여러 항목"
+      description="Flex 기반으로 줄바꿈됩니다."
+      orientation="horizontal"
+      style={{ maxWidth: "820px" }}
+    >
+      <Flex orientation="horizontal" gap="md" wrap="wrap">
+        {["서울", "부산", "대구", "광주", "대전", "수원"].map((city) => (
+          <Radio key={city} value={city} label={city} />
+        ))}
+      </Flex>
+    </RadioGroup>
+  )
+};

--- a/apps/storybook/stories/components/Switch.docs.mdx
+++ b/apps/storybook/stories/components/Switch.docs.mdx
@@ -1,0 +1,47 @@
+import { Meta, Title, Subtitle, Description, Canvas, Primary, Controls, ArgsTable } from "@storybook/blocks";
+import * as SwitchStories from "./Switch.stories";
+
+<Meta of={SwitchStories} />
+
+<Title>Switch</Title>
+
+<Subtitle>on/off 상태를 전환하는 토글 스위치입니다. 체크박스 시맨틱을 유지하면서 `role="switch"`를 제공합니다.</Subtitle>
+
+<Description>
+`Switch`는 숨김 체크박스와 커스텀 트랙/썸 UI를 결합한 컴포넌트입니다. Space/Enter/클릭으로 토글되며, `name`/`value`로 폼 제출에
+참여합니다. 라벨과 설명을 연결해 의미를 전달하고, `readOnly`/`disabled`/`invalid` 등의 상태도 ARIA와 data 속성으로 노출됩니다.
+</Description>
+
+## Playground
+
+<Primary of={SwitchStories.Playground} />
+<Controls of={SwitchStories.Playground} />
+
+## 상태
+
+읽기 전용, 비활성화, 오류/필수 상태를 포함한 다양한 사례를 보여줍니다.
+
+<Canvas of={SwitchStories.States} />
+
+## 크기
+
+디폴트 레이아웃은 중간 크기이며, CSS 변수나 transform 스케일을 통해 섬세한 크기 조절이 가능합니다.
+
+<Canvas of={SwitchStories.Sizes} />
+
+## 제어 모드
+
+외부 상태와 동기화해 여러 토글을 동시에 제어할 수 있습니다.
+
+<Canvas of={SwitchStories.Controlled} />
+
+## Props
+
+<ArgsTable of={SwitchStories.Playground} />
+
+## 접근성 노트
+
+- 커스텀 루트에 `role="switch"`와 `aria-checked`가 설정되어 스크린리더가 on/off 상태를 읽습니다.
+- 숨김 `<input type="checkbox">`를 유지해 폼 제출 및 키보드 포커스 동작을 그대로 제공합니다.
+- `aria-disabled`/`aria-readonly`/`aria-required`/`aria-invalid`가 상태별로 적용되고, 동일한 정보가 `data-*` 속성으로도 노출됩니다.
+- 트랙과 썸 스타일은 `--ara-fc-*` 토큰(예: `--ara-fc-focus-ring`, `--ara-fc-size-md-track-width`)을 오버라이드해 커스터마이징할 수 있습니다.

--- a/apps/storybook/stories/components/Switch.stories.tsx
+++ b/apps/storybook/stories/components/Switch.stories.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { AraProvider, AraThemeBoundary, Flex, Stack, Switch } from "@ara/react";
+
+const meta = {
+  title: "Components/Switch",
+  component: Switch,
+  decorators: [
+    (Story) => (
+      <AraProvider>
+        <AraThemeBoundary>
+          <Story />
+        </AraThemeBoundary>
+      </AraProvider>
+    )
+  ],
+  parameters: {
+    layout: "padded"
+  },
+  args: {
+    label: "푸시 알림",
+    description: "알림을 켜거나 끕니다.",
+    disabled: false,
+    required: false
+  },
+  argTypes: {
+    onCheckedChange: { control: false },
+    describedBy: { control: false },
+    labelledBy: { control: false },
+    inputRef: { control: false },
+    trackClassName: { control: false },
+    thumbClassName: { control: false }
+  },
+  tags: ["autodocs"],
+  render: (args) => <Switch {...args} />
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const spacingProps = { gap: "md", style: { maxWidth: "760px" } } as const;
+
+export const Playground: Story = {};
+
+export const States: Story = {
+  name: "상태",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack {...spacingProps}>
+      <Switch label="기본" description="언제든 토글할 수 있습니다." />
+      <Switch label="체크됨" defaultChecked description="초기 상태를 on으로 시작" />
+      <Switch label="읽기 전용" defaultChecked readOnly description="포커스는 가능하지만 토글 불가" />
+      <Switch label="필수 + 오류" required invalid description="aria-invalid 상태" />
+      <Switch label="비활성화" disabled description="포커스와 입력이 차단됩니다." />
+    </Stack>
+  )
+};
+
+const SizeShowcase = () => {
+  const sizePresets = [
+    { label: "작은 크기", scale: 0.9 },
+    { label: "기본 크기", scale: 1 },
+    { label: "큰 크기", scale: 1.1 }
+  ];
+
+  return (
+    <Stack {...spacingProps}>
+      {sizePresets.map((preset) => (
+        <div key={preset.label} style={{ transform: `scale(${preset.scale})`, transformOrigin: "left center" }}>
+          <Switch label={preset.label} description={`scale=${preset.scale} 배율 예시`} defaultChecked />
+        </div>
+      ))}
+    </Stack>
+  );
+};
+
+export const Sizes: Story = {
+  name: "크기 데모",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => <SizeShowcase />
+};
+
+const SwitchControlExample = () => {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <Stack {...spacingProps}>
+      <Switch
+        label={checked ? "알림이 켜짐" : "알림이 꺼짐"}
+        description="Space/Enter 또는 클릭으로 토글"
+        checked={checked}
+        onCheckedChange={setChecked}
+      />
+      <Flex orientation="horizontal" gap="sm" align="center">
+        <Switch
+          label="연동된 토글"
+          description="상태 공유"
+          checked={checked}
+          onCheckedChange={setChecked}
+        />
+        <span style={{ color: "var(--ara-color-text-muted, #475569)" }}>
+          현재 상태: {checked ? "on" : "off"}
+        </span>
+      </Flex>
+    </Stack>
+  );
+};
+
+export const Controlled: Story = {
+  name: "제어 모드",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => <SwitchControlExample />
+};


### PR DESCRIPTION
## 요약
- Checkbox/Radio/Switch 스토리와 MDX 문서로 상태별 데모와 사용 패턴을 추가했습니다.
- 제어 모드, 그룹/배치 변형, 접근성 노트를 포함해 폼 컨트롤 커스터마이징 힌트를 정리했습니다.

## 테스트
- 실행 안 함 (스토리/문서 변경)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69255c1b44588322ad7dc89f81f15d5c)