### PR TITLE
Fix Storybook radio, checkbox, and theme story typings

### DIFF
--- a/apps/storybook/stories/components/Checkbox.stories.tsx
+++ b/apps/storybook/stories/components/Checkbox.stories.tsx
@@ -40,12 +40,13 @@ type Story = StoryObj<typeof meta>;
 
 const spacingProps = { gap: "md", style: { maxWidth: "760px" } } as const;
 
-export const Playground: Story = {};
+export const Playground: Story = { args: { ...meta.args } };
 
 export const States: Story = {
   parameters: {
     controls: { disable: true }
   },
+  args: { ...meta.args },
   render: () => (
     <Stack {...spacingProps}>
       <Checkbox label="기본" description="라벨과 설명을 모두 포함합니다." />
@@ -62,7 +63,7 @@ const IndeterminateExample = () => {
 
   const label = useMemo(() => {
     if (state === "indeterminate") return "일부 선택됨";
-    return state === "checked" ? "전체 선택됨" : "선택 없음";
+    return state ? "전체 선택됨" : "선택 없음";
   }, [state]);
 
   return (
@@ -85,6 +86,7 @@ export const Indeterminate: Story = {
   parameters: {
     controls: { disable: true }
   },
+  args: { ...meta.args },
   render: () => <IndeterminateExample />
 };
 

--- a/apps/storybook/stories/components/Radio.stories.tsx
+++ b/apps/storybook/stories/components/Radio.stories.tsx
@@ -20,7 +20,8 @@ const meta = {
   args: {
     label: "옵션",
     description: "라디오 옵션입니다.",
-    disabled: false
+    disabled: false,
+    value: ""
   },
   argTypes: {
     value: { control: "text" },
@@ -46,33 +47,34 @@ type Story = StoryObj<typeof meta>;
 
 const spacingProps = { gap: "md", style: { maxWidth: "760px" } } as const;
 
-export const Playground: Story = {};
+export const Playground: Story = { args: { ...meta.args } };
 
 export const Orientation: Story = {
   name: "가로/세로 그룹",
   parameters: {
     controls: { disable: true }
   },
+  args: { ...meta.args },
   render: () => (
     <Stack {...spacingProps}>
       <RadioGroup
-        name="direction-horizontal"
-        label="가로 정렬"
-        description="orientation=\"horizontal\" 로 나란히 배치"
-        orientation="horizontal"
-      >
-        <Radio value="left" label="왼쪽" />
-        <Radio value="center" label="가운데" />
-        <Radio value="right" label="오른쪽" />
-      </RadioGroup>
-      <RadioGroup
-        name="direction-vertical"
-        label="세로 정렬"
-        description="orientation=\"vertical\" 기본 방향"
-      >
-        <Radio value="top" label="위" />
-        <Radio value="middle" label="중간" />
-        <Radio value="bottom" label="아래" />
+          name="direction-horizontal"
+          label="가로 정렬"
+          description={"orientation=\"horizontal\" 로 나란히 배치"}
+          orientation="horizontal"
+        >
+          <Radio value="left" label="왼쪽" />
+          <Radio value="center" label="가운데" />
+          <Radio value="right" label="오른쪽" />
+        </RadioGroup>
+        <RadioGroup
+          name="direction-vertical"
+          label="세로 정렬"
+          description={"orientation=\"vertical\" 기본 방향"}
+        >
+          <Radio value="top" label="위" />
+          <Radio value="middle" label="중간" />
+          <Radio value="bottom" label="아래" />
       </RadioGroup>
     </Stack>
   )
@@ -104,6 +106,7 @@ export const ControlledGroup: Story = {
   parameters: {
     controls: { disable: true }
   },
+  args: { ...meta.args },
   render: () => <RadioGroupStateExample />
 };
 
@@ -112,6 +115,7 @@ export const DisabledAndInvalid: Story = {
   parameters: {
     controls: { disable: true }
   },
+  args: { ...meta.args },
   render: () => (
     <Stack {...spacingProps}>
       <RadioGroup name="disabled" label="비활성 그룹" description="전체 disabled">
@@ -131,6 +135,7 @@ export const HorizontalWrap: Story = {
   parameters: {
     controls: { disable: true }
   },
+  args: { ...meta.args },
   render: () => (
     <RadioGroup
       name="layout"

--- a/apps/storybook/stories/foundation/Theme.stories.tsx
+++ b/apps/storybook/stories/foundation/Theme.stories.tsx
@@ -20,8 +20,9 @@ const meta = {
   args: {
     mode: "system" as const,
     defaultMode: "light" as const,
-    storageKey: null as const,
-    asChild: false
+    storageKey: null,
+    asChild: false,
+    children: undefined
   },
   argTypes: {
     mode: {
@@ -86,7 +87,7 @@ function ThemePlayground() {
           name: key,
           value: variables[key]
         }))
-        .filter((entry): entry is { name: string; value: string } => Boolean(entry.value));
+        .filter((entry) => Boolean(entry.value)) as { name: (typeof keys)[number]; value: string }[];
     },
     [mode, variables]
   );
@@ -307,9 +308,9 @@ function getReadableText(hex: string): string {
   const g = Number.parseInt(sanitized.slice(2, 4), 16) / 255;
   const b = Number.parseInt(sanitized.slice(4, 6), 16) / 255;
 
-  const [lr, lg, lb] = [r, g, b].map((value) =>
-    value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
-  );
+    const [lr, lg, lb] = [r, g, b].map((value) =>
+      value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4
+    ) as [number, number, number];
   const luminance = 0.2126 * lr + 0.7152 * lg + 0.0722 * lb;
   return luminance > 0.6 ? "#0F172A" : "#F8FAFC";
 }
@@ -562,6 +563,7 @@ const midnightTheme: ThemeOverrides = {
 };
 
 export const Playground: Story = {
+  args: { ...meta.args },
   render: (args) => (
     <ThemeProvider {...args}>
       <ThemePlayground />
@@ -570,6 +572,7 @@ export const Playground: Story = {
 };
 
 export const ColorPalette: Story = {
+  args: { ...meta.args },
   render: (args) => (
     <ThemeProvider {...args}>
       <ColorPalettePreview />
@@ -583,6 +586,7 @@ export const ColorPalette: Story = {
 };
 
 export const TypographyScale: Story = {
+  args: { ...meta.args },
   render: (args) => (
     <ThemeProvider {...args}>
       <TypographyPreview />
@@ -596,6 +600,7 @@ export const TypographyScale: Story = {
 };
 
 export const LayoutTokens: Story = {
+  args: { ...meta.args },
   render: (args) => (
     <ThemeProvider {...args}>
       <LayoutPreview />
@@ -610,6 +615,7 @@ export const LayoutTokens: Story = {
 
 export const CustomTheme: Story = {
   args: {
+    ...meta.args,
     mode: "dark",
     defaultMode: "dark",
     storageKey: null,


### PR DESCRIPTION
## Summary
- supply required args defaults for radio, checkbox, and theme stories and adjust radio description strings
- align Checkbox indeterminate label handling with actual CheckboxState values
- clean up ThemeProvider story helpers for stricter type checking

## Testing
- pnpm exec tsc --noEmit --project apps/storybook/tsconfig.json

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692560c6da808322a807b5738f67863c)