### PR TITLE
Add base styling for checkbox, radio, and switch

### DIFF
--- a/packages/core/src/use-radio.ts
+++ b/packages/core/src/use-radio.ts
@@ -47,11 +47,15 @@ export interface RadioRootProps {
   readonly "aria-checked": boolean;
   readonly "aria-labelledby"?: string;
   readonly "aria-describedby"?: string;
+  readonly "aria-required"?: true;
+  readonly "aria-invalid"?: true;
   readonly "aria-disabled"?: true;
   readonly "aria-readonly"?: true;
   readonly "data-state": RadioDataState;
   readonly "data-disabled"?: true;
   readonly "data-readonly"?: true;
+  readonly "data-required"?: true;
+  readonly "data-invalid"?: true;
   readonly onClick: (event: MouseEvent<HTMLElement>) => void;
   readonly onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
   readonly ref: (node: HTMLElement | null) => void;
@@ -247,11 +251,15 @@ export function useRadio(options: UseRadioOptions): UseRadioResult {
     "aria-checked": isChecked,
     "aria-labelledby": ariaLabelledBy,
     "aria-describedby": ariaDescribedBy,
+    "aria-required": groupRequired ? true : undefined,
+    "aria-invalid": groupInvalid ? true : undefined,
     "aria-disabled": isDisabled ? true : undefined,
     "aria-readonly": appliedReadOnly ? true : undefined,
     "data-state": isChecked ? "checked" : "unchecked",
     "data-disabled": isDisabled ? true : undefined,
     "data-readonly": appliedReadOnly ? true : undefined,
+    "data-required": groupRequired ? true : undefined,
+    "data-invalid": groupInvalid ? true : undefined,
     onClick: handleClick,
     onKeyDown: handleKeyDown,
     ref: (node) => {

--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -9,6 +9,8 @@ import {
 } from "react";
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { useCheckbox, type CheckboxState } from "@ara/core";
+import { createFormControlStyleTokens } from "../form-control/formControlStyle.js";
+import { useAraTheme } from "../../theme/index.js";
 
 const visuallyHiddenStyle: CSSProperties = {
   position: "absolute",
@@ -87,6 +89,9 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(function Check
     ...restProps
   } = props;
 
+  const theme = useAraTheme();
+  const tokens = useMemo(() => createFormControlStyleTokens(theme), [theme]);
+
   const describedByIds = useMemo(() => {
     if (!describedBy) return [] as string[];
     return Array.isArray(describedBy) ? [...describedBy] : [describedBy];
@@ -114,6 +119,75 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(function Check
     onCheckedChange
   });
 
+  const isDisabled = Boolean(rootProps["data-disabled"]);
+  const isInvalid = Boolean(rootProps["data-invalid"]);
+  const labelColor = isDisabled
+    ? tokens.labelColor.disabled
+    : isInvalid
+      ? tokens.labelColor.invalid
+      : tokens.labelColor.default;
+  const indicatorColor = isDisabled
+    ? tokens.indicatorColor.disabled
+    : isInvalid
+      ? tokens.indicatorColor.invalid
+      : tokens.indicatorColor.default;
+  const controlBackground = isDisabled
+    ? tokens.controlColor.disabled
+    : isInvalid
+      ? tokens.controlColor.invalid
+      : tokens.controlColor.default;
+  const controlBorder = isDisabled
+    ? tokens.borderColor.disabled
+    : isInvalid
+      ? tokens.borderColor.invalid
+      : tokens.borderColor.default;
+
+  const rootStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "flex-start",
+    gap: tokens.gap,
+    fontSize: tokens.fontSize,
+    lineHeight: tokens.lineHeight,
+    color: labelColor,
+    cursor: isDisabled ? "not-allowed" : "pointer",
+    userSelect: "none",
+    opacity: isDisabled ? tokens.disabledOpacity : 1
+  };
+
+  const controlStyle: CSSProperties = {
+    width: tokens.controlSize,
+    height: tokens.controlSize,
+    borderRadius: tokens.radius,
+    borderWidth: tokens.borderWidth,
+    borderStyle: "solid",
+    backgroundColor: controlBackground,
+    borderColor: controlBorder,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    transition: "background-color 120ms ease, border-color 120ms ease"
+  };
+
+  const indicatorBase: CSSProperties = isIndeterminate
+    ? {
+        width: "60%",
+        height: "2px",
+        borderRadius: "999px",
+        backgroundColor: indicatorColor,
+        transform: isIndeterminate ? "scaleX(1)" : "scaleX(0)",
+        transition: "transform 120ms ease"
+      }
+    : {
+        width: "45%",
+        height: "70%",
+        borderRight: `2px solid ${indicatorColor}`,
+        borderBottom: `2px solid ${indicatorColor}`,
+        transform: rootProps["data-state"] === "checked" ? "rotate(45deg) scale(1)" : "rotate(45deg) scale(0)",
+        transformOrigin: "center",
+        transition: "transform 120ms ease"
+      };
+
   const mergedRootProps = useMemo(
     () => ({
       ...rootProps,
@@ -130,7 +204,7 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(function Check
       {...restProps}
       ref={ref}
       className={mergeClassNames("ara-checkbox", className)}
-      style={style}
+      style={{ ...rootStyle, ...style }}
       data-state={rootProps["data-state"]}
       data-disabled={rootProps["data-disabled"]}
       data-readonly={rootProps["data-readonly"]}
@@ -148,18 +222,32 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(function Check
       <div
         {...mergedRootProps}
         className={mergeClassNames("ara-checkbox__control", controlClassName)}
+        style={controlStyle}
       >
-        <span aria-hidden className="ara-checkbox__indicator" data-indeterminate={isIndeterminate || undefined} />
+        <span
+          aria-hidden
+          className="ara-checkbox__indicator"
+          data-indeterminate={isIndeterminate || undefined}
+          style={indicatorBase}
+        />
       </div>
       {(label || description) && (
-        <div className="ara-checkbox__text">
+        <div className="ara-checkbox__text" style={{ color: labelColor }}>
           {label ? (
-            <label {...labelProps} className="ara-checkbox__label">
+            <label
+              {...labelProps}
+              className="ara-checkbox__label"
+              style={{ color: labelColor, fontWeight: 600 }}
+            >
               {label}
             </label>
           ) : null}
           {description ? (
-            <div {...descriptionProps} className="ara-checkbox__description">
+            <div
+              {...descriptionProps}
+              className="ara-checkbox__description"
+              style={{ color: labelColor, opacity: isDisabled ? 0.8 : 0.95 }}
+            >
               {description}
             </div>
           ) : null}

--- a/packages/react/src/components/form-control/formControlStyle.ts
+++ b/packages/react/src/components/form-control/formControlStyle.ts
@@ -1,0 +1,118 @@
+import type { Theme } from "@ara/core";
+
+type FormControlSize = "sm" | "md" | "lg";
+
+const DEFAULT_SIZE: FormControlSize = "md";
+
+const cssVar = (name: string, fallback: string) => `var(${name}, ${fallback})`;
+
+export interface FormControlStyleTokens {
+  readonly gap: string;
+  readonly fontSize: string;
+  readonly lineHeight: string;
+  readonly controlSize: string;
+  readonly trackWidth: string;
+  readonly trackHeight: string;
+  readonly thumbSize: string;
+  readonly radius: string;
+  readonly borderWidth: string;
+  readonly disabledOpacity: string;
+  readonly focusOutline: string;
+  readonly focusOutlineOffset: string;
+  readonly focusRing: string;
+  readonly controlColor: Record<"default" | "hover" | "focus" | "disabled" | "invalid", string>;
+  readonly borderColor: Record<"default" | "hover" | "focus" | "disabled" | "invalid", string>;
+  readonly indicatorColor: Record<"default" | "disabled" | "invalid", string>;
+  readonly labelColor: Record<"default" | "disabled" | "invalid", string>;
+}
+
+export function createFormControlStyleTokens(
+  theme: Theme,
+  size: FormControlSize = DEFAULT_SIZE
+): FormControlStyleTokens {
+  const formControl = theme.component.formControl;
+  const sizeTokens = formControl.size[size];
+
+  const gap = cssVar("--ara-fc-gap", cssVar(`--ara-fc-size-${size}-gap`, sizeTokens.gap));
+  const fontSize = cssVar(
+    "--ara-fc-font-size",
+    cssVar(`--ara-fc-size-${size}-font-size`, sizeTokens.fontSize)
+  );
+  const lineHeight = cssVar(
+    "--ara-fc-line-height",
+    cssVar(`--ara-fc-size-${size}-line-height`, sizeTokens.lineHeight)
+  );
+  const controlSize = cssVar(
+    "--ara-fc-control-size",
+    cssVar(`--ara-fc-size-${size}-control`, sizeTokens.control)
+  );
+  const trackWidth = cssVar(
+    "--ara-fc-track-width",
+    cssVar(`--ara-fc-size-${size}-track-width`, sizeTokens.trackWidth)
+  );
+  const trackHeight = cssVar(
+    "--ara-fc-track-height",
+    cssVar(`--ara-fc-size-${size}-track-height`, sizeTokens.trackHeight)
+  );
+  const thumbSize = cssVar(
+    "--ara-fc-thumb-size",
+    cssVar(`--ara-fc-size-${size}-thumb`, sizeTokens.thumb)
+  );
+  const radius = cssVar("--ara-fc-radius", formControl.radius);
+  const borderWidth = cssVar("--ara-fc-border-width", formControl.borderWidth);
+  const disabledOpacity = cssVar("--ara-fc-disabled-opacity", `${formControl.disabled.opacity}`);
+  const focusOutline = cssVar(
+    "--ara-fc-focus-outline",
+    `${formControl.focus.outlineWidth} solid ${formControl.focus.outlineColor}`
+  );
+  const focusOutlineOffset = cssVar("--ara-fc-focus-outline-offset", formControl.focus.outlineOffset);
+  const focusRing = cssVar(
+    "--ara-fc-focus-ring",
+    `0 0 0 ${formControl.focus.ringSize} ${formControl.focus.ringColor}`
+  );
+
+  const controlTone = formControl.tone.neutral.control;
+  const borderTone = formControl.tone.neutral.border;
+  const indicatorTone = formControl.tone.neutral.indicator;
+  const labelTone = formControl.tone.neutral.label;
+
+  return {
+    gap,
+    fontSize,
+    lineHeight,
+    controlSize,
+    trackWidth,
+    trackHeight,
+    thumbSize,
+    radius,
+    borderWidth,
+    disabledOpacity,
+    focusOutline,
+    focusOutlineOffset,
+    focusRing,
+    controlColor: {
+      default: cssVar("--ara-fc-control-default", controlTone.default),
+      hover: cssVar("--ara-fc-control-hover", controlTone.hover),
+      focus: cssVar("--ara-fc-control-focus", controlTone.focus),
+      disabled: cssVar("--ara-fc-control-disabled", controlTone.disabled),
+      invalid: cssVar("--ara-fc-control-invalid", controlTone.invalid)
+    },
+    borderColor: {
+      default: cssVar("--ara-fc-border-default", borderTone.default),
+      hover: cssVar("--ara-fc-border-hover", borderTone.hover),
+      focus: cssVar("--ara-fc-border-focus", borderTone.focus),
+      disabled: cssVar("--ara-fc-border-disabled", borderTone.disabled),
+      invalid: cssVar("--ara-fc-border-invalid", borderTone.invalid)
+    },
+    indicatorColor: {
+      default: cssVar("--ara-fc-indicator-default", indicatorTone.default),
+      disabled: cssVar("--ara-fc-indicator-disabled", indicatorTone.disabled),
+      invalid: cssVar("--ara-fc-indicator-invalid", indicatorTone.invalid)
+    },
+    labelColor: {
+      default: cssVar("--ara-fc-label-default", labelTone.default),
+      disabled: cssVar("--ara-fc-label-disabled", labelTone.disabled),
+      invalid: cssVar("--ara-fc-label-invalid", labelTone.invalid)
+    }
+  };
+}

--- a/packages/react/src/components/radio/Radio.tsx
+++ b/packages/react/src/components/radio/Radio.tsx
@@ -10,6 +10,8 @@ import {
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { useRadio, type RadioInputProps } from "@ara/core";
 import { useRadioGroupContext } from "./RadioGroup.js";
+import { createFormControlStyleTokens } from "../form-control/formControlStyle.js";
+import { useAraTheme } from "../../theme/index.js";
 
 function mergeClassNames(...values: Array<string | undefined | null | false>): string {
   return values.filter(Boolean).join(" ");
@@ -74,6 +76,8 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
   } = props;
 
   const group = useRadioGroupContext();
+  const theme = useAraTheme();
+  const tokens = useMemo(() => createFormControlStyleTokens(theme), [theme]);
 
   const describedByIds = useMemo(() => {
     const ids: string[] = [];
@@ -107,6 +111,69 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     group
   });
 
+  const isDisabled = Boolean(rootProps["data-disabled"]);
+  const isInvalid = Boolean(rootProps["data-invalid"]);
+  const isChecked = rootProps["data-state"] === "checked";
+
+  const labelColor = isDisabled
+    ? tokens.labelColor.disabled
+    : isInvalid
+      ? tokens.labelColor.invalid
+      : tokens.labelColor.default;
+  const indicatorColor = isDisabled
+    ? tokens.indicatorColor.disabled
+    : isInvalid
+      ? tokens.indicatorColor.invalid
+      : tokens.indicatorColor.default;
+  const controlBackground = isDisabled
+    ? tokens.controlColor.disabled
+    : isInvalid
+      ? tokens.controlColor.invalid
+      : tokens.controlColor.default;
+  const controlBorder = isDisabled
+    ? tokens.borderColor.disabled
+    : isInvalid
+      ? tokens.borderColor.invalid
+      : isChecked
+        ? indicatorColor
+        : tokens.borderColor.default;
+
+  const rootStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "flex-start",
+    gap: tokens.gap,
+    fontSize: tokens.fontSize,
+    lineHeight: tokens.lineHeight,
+    color: labelColor,
+    cursor: isDisabled ? "not-allowed" : "pointer",
+    userSelect: "none",
+    opacity: isDisabled ? tokens.disabledOpacity : 1
+  };
+
+  const controlStyle: CSSProperties = {
+    width: tokens.controlSize,
+    height: tokens.controlSize,
+    borderRadius: "999px",
+    borderWidth: tokens.borderWidth,
+    borderStyle: "solid",
+    backgroundColor: controlBackground,
+    borderColor: controlBorder,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexShrink: 0,
+    transition: "background-color 120ms ease, border-color 120ms ease"
+  };
+
+  const indicatorStyle: CSSProperties = {
+    width: "55%",
+    height: "55%",
+    borderRadius: "999px",
+    backgroundColor: indicatorColor,
+    transform: isChecked ? "scale(1)" : "scale(0)",
+    transition: "transform 120ms ease"
+  };
+
   const mergedRootProps = useMemo(
     () => ({
       ...rootProps,
@@ -130,7 +197,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
       {...restProps}
       ref={ref}
       className={mergeClassNames("ara-radio", className)}
-      style={style}
+      style={{ ...rootStyle, ...style }}
       data-state={rootProps["data-state"]}
       data-disabled={rootProps["data-disabled"]}
       data-readonly={rootProps["data-readonly"]}
@@ -147,18 +214,27 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
         data-state={rootProps["data-state"]}
         data-disabled={rootProps["data-disabled"]}
         data-readonly={rootProps["data-readonly"]}
+        style={controlStyle}
       >
-        <span aria-hidden className="ara-radio__indicator" />
+        <span aria-hidden className="ara-radio__indicator" style={indicatorStyle} />
       </div>
       {(label || description) && (
-        <div className="ara-radio__text">
+        <div className="ara-radio__text" style={{ color: labelColor }}>
           {label ? (
-            <label {...labelProps} className="ara-radio__label">
+            <label
+              {...labelProps}
+              className="ara-radio__label"
+              style={{ color: labelColor, fontWeight: 600 }}
+            >
               {label}
             </label>
           ) : null}
           {description ? (
-            <div {...descriptionProps} className="ara-radio__description">
+            <div
+              {...descriptionProps}
+              className="ara-radio__description"
+              style={{ color: labelColor, opacity: isDisabled ? 0.8 : 0.95 }}
+            >
               {description}
             </div>
           ) : null}

--- a/packages/react/src/components/switch/Switch.tsx
+++ b/packages/react/src/components/switch/Switch.tsx
@@ -9,6 +9,8 @@ import {
 } from "react";
 import { composeRefs } from "@radix-ui/react-compose-refs";
 import { useSwitch } from "@ara/core";
+import { createFormControlStyleTokens } from "../form-control/formControlStyle.js";
+import { useAraTheme } from "../../theme/index.js";
 
 const visuallyHiddenStyle: CSSProperties = {
   position: "absolute",
@@ -87,6 +89,9 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(function Switch(pr
     ...restProps
   } = props;
 
+  const theme = useAraTheme();
+  const tokens = useMemo(() => createFormControlStyleTokens(theme), [theme]);
+
   const describedByIds = useMemo(() => {
     if (!describedBy) return [] as string[];
     return Array.isArray(describedBy) ? [...describedBy] : [describedBy];
@@ -114,6 +119,74 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(function Switch(pr
     onCheckedChange
   });
 
+  const isDisabled = Boolean(rootProps["data-disabled"]);
+  const isInvalid = Boolean(rootProps["data-invalid"]);
+  const isChecked = rootProps["data-state"] === "checked";
+
+  const labelColor = isDisabled
+    ? tokens.labelColor.disabled
+    : isInvalid
+      ? tokens.labelColor.invalid
+      : tokens.labelColor.default;
+  const indicatorColor = isDisabled
+    ? tokens.indicatorColor.disabled
+    : isInvalid
+      ? tokens.indicatorColor.invalid
+      : tokens.indicatorColor.default;
+  const controlBackground = isDisabled
+    ? tokens.controlColor.disabled
+    : isInvalid
+      ? tokens.controlColor.invalid
+      : tokens.controlColor.default;
+  const trackBorder = isDisabled
+    ? tokens.borderColor.disabled
+    : isInvalid
+      ? tokens.borderColor.invalid
+      : isChecked
+        ? indicatorColor
+        : tokens.borderColor.default;
+
+  const rootStyle: CSSProperties = {
+    display: "inline-flex",
+    alignItems: "flex-start",
+    gap: tokens.gap,
+    fontSize: tokens.fontSize,
+    lineHeight: tokens.lineHeight,
+    color: labelColor,
+    cursor: isDisabled ? "not-allowed" : "pointer",
+    userSelect: "none",
+    opacity: isDisabled ? tokens.disabledOpacity : 1
+  };
+
+  const thumbOffset = `calc((${tokens.trackHeight} - ${tokens.thumbSize}) / 2)`;
+
+  const trackStyle: CSSProperties = {
+    width: tokens.trackWidth,
+    height: tokens.trackHeight,
+    borderRadius: `calc(${tokens.trackHeight} / 2)`,
+    borderWidth: tokens.borderWidth,
+    borderStyle: "solid",
+    backgroundColor: isChecked ? indicatorColor : controlBackground,
+    borderColor: trackBorder,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: isChecked ? "flex-end" : "flex-start",
+    paddingInline: thumbOffset,
+    paddingBlock: thumbOffset,
+    flexShrink: 0,
+    transition: "background-color 150ms ease, border-color 150ms ease"
+  };
+
+  const thumbStyle: CSSProperties = {
+    width: tokens.thumbSize,
+    height: tokens.thumbSize,
+    borderRadius: "999px",
+    backgroundColor: isDisabled ? controlBackground : "white",
+    boxShadow: "0 1px 2px rgba(15, 23, 42, 0.18)",
+    transition: "transform 150ms ease, background-color 150ms ease",
+    transform: "translateZ(0)"
+  };
+
   const mergedRootProps = useMemo(
     () => ({
       ...rootProps,
@@ -130,7 +203,7 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(function Switch(pr
       {...restProps}
       ref={ref}
       className={mergeClassNames("ara-switch", className)}
-      style={style}
+      style={{ ...rootStyle, ...style }}
       data-state={rootProps["data-state"]}
       data-disabled={rootProps["data-disabled"]}
       data-readonly={rootProps["data-readonly"]}
@@ -145,18 +218,34 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(function Switch(pr
         style={visuallyHiddenStyle}
         data-state={rootProps["data-state"]}
       />
-      <div {...mergedRootProps} className={mergeClassNames("ara-switch__track", trackClassName)}>
-        <span aria-hidden className={mergeClassNames("ara-switch__thumb", thumbClassName)} />
+      <div
+        {...mergedRootProps}
+        className={mergeClassNames("ara-switch__track", trackClassName)}
+        style={trackStyle}
+      >
+        <span
+          aria-hidden
+          className={mergeClassNames("ara-switch__thumb", thumbClassName)}
+          style={thumbStyle}
+        />
       </div>
       {(label || description) && (
-        <div className="ara-switch__text">
+        <div className="ara-switch__text" style={{ color: labelColor }}>
           {label ? (
-            <label {...labelProps} className="ara-switch__label">
+            <label
+              {...labelProps}
+              className="ara-switch__label"
+              style={{ color: labelColor, fontWeight: 600 }}
+            >
               {label}
             </label>
           ) : null}
           {description ? (
-            <div {...descriptionProps} className="ara-switch__description">
+            <div
+              {...descriptionProps}
+              className="ara-switch__description"
+              style={{ color: labelColor, opacity: isDisabled ? 0.8 : 0.95 }}
+            >
               {description}
             </div>
           ) : null}


### PR DESCRIPTION
## Summary
- add shared helper to expose form control style tokens based on the active theme
- apply inline styling to checkbox, radio, and switch components so form controls render with visible UI in Storybook

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925638d6d548322a5f10f82232d1056)