### PR TITLE
Refine checkbox indicator sizing and switch contrast

### DIFF
--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -179,10 +179,10 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(function Check
         transition: "transform 120ms ease"
       }
     : {
-        width: "45%",
-        height: "70%",
-        borderRight: `2px solid ${indicatorColor}`,
-        borderBottom: `2px solid ${indicatorColor}`,
+        width: "52%",
+        height: "56%",
+        borderRight: `1.75px solid ${indicatorColor}`,
+        borderBottom: `1.75px solid ${indicatorColor}`,
         transform: rootProps["data-state"] === "checked" ? "rotate(45deg) scale(1)" : "rotate(45deg) scale(0)",
         transformOrigin: "center",
         transition: "transform 120ms ease"

--- a/packages/react/src/components/switch/Switch.tsx
+++ b/packages/react/src/components/switch/Switch.tsx
@@ -138,13 +138,14 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(function Switch(pr
     : isInvalid
       ? tokens.controlColor.invalid
       : tokens.controlColor.default;
+  const inactiveTrackBackground = isDisabled ? controlBackground : tokens.controlColor.hover;
   const trackBorder = isDisabled
     ? tokens.borderColor.disabled
     : isInvalid
       ? tokens.borderColor.invalid
       : isChecked
         ? indicatorColor
-        : tokens.borderColor.default;
+        : tokens.borderColor.hover;
 
   const rootStyle: CSSProperties = {
     display: "inline-flex",
@@ -166,7 +167,7 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(function Switch(pr
     borderRadius: `calc(${tokens.trackHeight} / 2)`,
     borderWidth: tokens.borderWidth,
     borderStyle: "solid",
-    backgroundColor: isChecked ? indicatorColor : controlBackground,
+    backgroundColor: isChecked ? indicatorColor : inactiveTrackBackground,
     borderColor: trackBorder,
     display: "inline-flex",
     alignItems: "center",


### PR DESCRIPTION
## Summary
- slimmed down the checkbox checkmark to look more balanced in the control
- increased contrast for unchecked switches by using a clearer track background and border

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263c5b28908322b01b9f7eca429224)