### PR TITLE
Adjust checkbox indicator and switch track contrast

### DIFF
--- a/packages/react/src/components/checkbox/Checkbox.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.tsx
@@ -179,11 +179,14 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(function Check
         transition: "transform 120ms ease"
       }
     : {
-        width: "52%",
-        height: "56%",
-        borderRight: `1.75px solid ${indicatorColor}`,
-        borderBottom: `1.75px solid ${indicatorColor}`,
-        transform: rootProps["data-state"] === "checked" ? "rotate(45deg) scale(1)" : "rotate(45deg) scale(0)",
+        width: "56%",
+        height: "58%",
+        borderRight: `2px solid ${indicatorColor}`,
+        borderBottom: `2px solid ${indicatorColor}`,
+        transform:
+          rootProps["data-state"] === "checked"
+            ? "translate(-4%, 2%) rotate(45deg) scale(1)"
+            : "translate(-4%, 2%) rotate(45deg) scale(0)",
         transformOrigin: "center",
         transition: "transform 120ms ease"
       };

--- a/packages/react/src/components/switch/Switch.tsx
+++ b/packages/react/src/components/switch/Switch.tsx
@@ -138,7 +138,7 @@ export const Switch = forwardRef<HTMLDivElement, SwitchProps>(function Switch(pr
     : isInvalid
       ? tokens.controlColor.invalid
       : tokens.controlColor.default;
-  const inactiveTrackBackground = isDisabled ? controlBackground : tokens.controlColor.hover;
+  const inactiveTrackBackground = isDisabled ? controlBackground : tokens.borderColor.hover;
   const trackBorder = isDisabled
     ? tokens.borderColor.disabled
     : isInvalid


### PR DESCRIPTION
## Summary
- refine the checkbox checkmark proportions and positioning for a closer visual match to the desired style
- increase contrast on the switch by using a neutral hover border color for the inactive track background

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69263fefc2a883228a16c87d51e2f0cb)