### PR TITLE
Show required indicator on checkbox labels

### DIFF
--- a/packages/react/src/components/checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/checkbox/Checkbox.test.tsx
@@ -81,6 +81,15 @@ describe("Checkbox", () => {
     expect(input).toHaveAttribute("aria-readonly", "true");
   });
 
+  it("required 옵션일 때 빨간색 표시를 렌더링한다", () => {
+    render(<Checkbox label="필수" required />);
+
+    const requiredMark = screen.getByTestId("checkbox-required-indicator");
+
+    expect(requiredMark).toHaveTextContent("*");
+    expect(requiredMark).toHaveStyle({ color: "var(--ara-checkbox-required, #d93025)" });
+  });
+
   it("disabled 시 상호작용을 차단한다", () => {
     render(<Checkbox label="비활성" disabled defaultChecked={false} />);
 
@@ -146,5 +155,20 @@ describe("Checkbox", () => {
 
     expect(checkbox).toHaveAttribute("data-state", "unchecked");
     expect(handleChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("스택 레이아웃에서 라벨과 설명을 컨트롤 위로 배치한다", () => {
+    render(<Checkbox layout="stacked" label="레이블" description="세부설명" />);
+
+    const checkbox = screen.getByRole("checkbox");
+    const label = screen.getByText("레이블");
+    const description = screen.getByText("세부설명");
+    const root = checkbox.parentElement as HTMLElement;
+    const textBlock = label.parentElement as HTMLElement;
+
+    expect(root.style.flexDirection).toBe("column");
+    expect(root.contains(textBlock)).toBe(true);
+    expect(textBlock.compareDocumentPosition(checkbox) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(description.compareDocumentPosition(checkbox) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- add a red required asterisk next to checkbox labels with inline alignment
- expose a customizable required indicator color that respects disabled state
- cover required marker rendering with a dedicated checkbox test

## Testing
- pnpm --filter @ara/react test -- --runInBand packages/react/src/components/checkbox/Checkbox.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926422676408322ab6b5522fe9855c1)