### PR TITLE
Improve radio layout and styling

### DIFF
--- a/apps/storybook/stories/components/Radio.docs.mdx
+++ b/apps/storybook/stories/components/Radio.docs.mdx
@@ -19,8 +19,9 @@ import * as RadioStories from "./Radio.stories";
 
 ## 레이아웃
 
-가로/세로 정렬을 모두 지원하며, Flex 컨테이너로 줄바꿈 시나리오도 구현할 수 있습니다.
+가로/세로 정렬을 모두 지원하며, Radio 항목에서도 inline/stacked 텍스트 배치를 고를 수 있습니다. Flex 컨테이너로 줄바꿈 시나리오도 구현할 수 있습니다.
 
+<Canvas of={RadioStories.Layouts} />
 <Canvas of={RadioStories.Orientation} />
 <Canvas of={RadioStories.HorizontalWrap} />
 

--- a/apps/storybook/stories/components/Radio.stories.tsx
+++ b/apps/storybook/stories/components/Radio.stories.tsx
@@ -21,7 +21,8 @@ const meta = {
     label: "옵션",
     description: "라디오 옵션입니다.",
     disabled: false,
-    value: ""
+    value: "",
+    layout: "inline"
   },
   argTypes: {
     value: { control: "text" },
@@ -29,7 +30,8 @@ const meta = {
     describedBy: { control: false },
     labelledBy: { control: false },
     inputRef: { control: false },
-    controlClassName: { control: false }
+    controlClassName: { control: false },
+    layout: { control: "inline-radio", options: ["inline", "stacked"] }
   },
   tags: ["autodocs"],
   render: (args) => (
@@ -48,6 +50,23 @@ type Story = StoryObj<typeof meta>;
 const spacingProps = { gap: "md", style: { maxWidth: "760px" } } as const;
 
 export const Playground: Story = { args: { ...meta.args } };
+
+export const Layouts: Story = {
+  name: "레이아웃 예시",
+  parameters: {
+    controls: { disable: true }
+  },
+  render: () => (
+    <Stack {...spacingProps}>
+      <RadioGroup name="layout-inline" label="인라인 텍스트" description="control 뒤에 텍스트">
+        <Radio value="inline" label="Option" description="inline" layout="inline" />
+      </RadioGroup>
+      <RadioGroup name="layout-stacked" label="스택 정렬" description="텍스트 위 정렬">
+        <Radio value="stacked" label="Option" description="stacked" layout="stacked" />
+      </RadioGroup>
+    </Stack>
+  )
+};
 
 export const Orientation: Story = {
   name: "가로/세로 그룹",

--- a/packages/react/src/components/radio/Radio.test.tsx
+++ b/packages/react/src/components/radio/Radio.test.tsx
@@ -148,4 +148,50 @@ describe("RadioGroup/Radio", () => {
     expect(first).toHaveAttribute("aria-checked", "true");
     expect(third).toHaveAttribute("aria-checked", "false");
   });
+
+  it("stacked 레이아웃에서 텍스트가 컨트롤 위에 표시된다", () => {
+    const { container } = render(
+      <RadioGroup label="위치">
+        <Radio value="top" label="위" layout="stacked" description="스택" />
+      </RadioGroup>
+    );
+
+    const text = container.querySelector(".ara-radio__text");
+    const control = container.querySelector(".ara-radio__control");
+
+    expect(text).not.toBeNull();
+    expect(control).not.toBeNull();
+    expect(text?.nextElementSibling).toBe(control);
+  });
+
+  it("inline 레이아웃에서는 컨트롤이 텍스트 앞에 위치한다", () => {
+    const { container } = render(
+      <RadioGroup label="위치">
+        <Radio value="inline" label="인라인" description="텍스트" />
+      </RadioGroup>
+    );
+
+    const text = container.querySelector(".ara-radio__text");
+    const control = container.querySelector(".ara-radio__control");
+
+    expect(control?.nextElementSibling).toBe(text);
+  });
+
+  it("라벨 및 설명 스타일을 회색 보조 텍스트로 렌더링한다", () => {
+    render(
+      <RadioGroup label="설명" description="조건 안내" required>
+        <Radio value="desc" label="옵션" description="부가 설명" />
+      </RadioGroup>
+    );
+
+    const description = screen.getByText("부가 설명");
+    const groupDescription = screen.getByText("조건 안내");
+    const requiredMark = screen.getByTestId("radio-group-required-indicator");
+
+    expect(description).toHaveStyle({ color: "var(--ara-radio-description, #6b7280)" });
+    expect(groupDescription).toHaveStyle({
+      color: "var(--ara-radio-group-description, #6b7280)"
+    });
+    expect(requiredMark).toHaveTextContent("*");
+  });
 });

--- a/packages/react/src/components/radio/Radio.tsx
+++ b/packages/react/src/components/radio/Radio.tsx
@@ -43,6 +43,7 @@ function composeEventHandlers<Event>(
 interface RadioOwnProps {
   readonly label?: ReactNode;
   readonly description?: ReactNode;
+  readonly layout?: "inline" | "stacked";
   readonly inputRef?: Ref<HTMLInputElement>;
   readonly describedBy?: string | readonly string[];
   readonly labelledBy?: string | readonly string[];
@@ -61,6 +62,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     value,
     disabled,
     readOnly,
+    layout = "inline",
     label,
     description,
     inputRef: inputRefProp,
@@ -114,12 +116,20 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
   const isDisabled = Boolean(rootProps["data-disabled"]);
   const isInvalid = Boolean(rootProps["data-invalid"]);
   const isChecked = rootProps["data-state"] === "checked";
+  const isStacked = layout === "stacked";
+  const hasText = Boolean(label || description);
 
   const labelColor = isDisabled
     ? tokens.labelColor.disabled
     : isInvalid
       ? tokens.labelColor.invalid
       : tokens.labelColor.default;
+  const descriptionColor = isDisabled
+    ? tokens.labelColor.disabled
+    : isInvalid
+      ? tokens.labelColor.invalid
+      : "var(--ara-radio-description, #6b7280)";
+  const descriptionFontSize = `var(--ara-radio-description-size, calc(${tokens.fontSize} * 0.92))`;
   const indicatorColor = isDisabled
     ? tokens.indicatorColor.disabled
     : isInvalid
@@ -140,7 +150,8 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
 
   const rootStyle: CSSProperties = {
     display: "inline-flex",
-    alignItems: "flex-start",
+    flexDirection: isStacked ? "column" : "row",
+    alignItems: isStacked ? "stretch" : "flex-start",
     gap: tokens.gap,
     fontSize: tokens.fontSize,
     lineHeight: tokens.lineHeight,
@@ -162,6 +173,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     alignItems: "center",
     justifyContent: "center",
     flexShrink: 0,
+    alignSelf: isStacked ? "flex-start" : undefined,
     transition: "background-color 120ms ease, border-color 120ms ease"
   };
 
@@ -192,6 +204,43 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
     ref: composeRefs(inputPropsRef, inputRefProp)
   };
 
+  const textContent =
+    hasText && (
+      <div
+        className="ara-radio__text"
+        style={{
+          color: labelColor,
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.2em"
+        }}
+      >
+        {label ? (
+          <label
+            {...labelProps}
+            className="ara-radio__label"
+            style={{ color: labelColor, fontWeight: 600 }}
+          >
+            {label}
+          </label>
+        ) : null}
+        {description ? (
+          <div
+            {...descriptionProps}
+            className="ara-radio__description"
+            style={{
+              color: descriptionColor,
+              fontSize: descriptionFontSize,
+              lineHeight: tokens.lineHeight,
+              fontWeight: 500
+            }}
+          >
+            {description}
+          </div>
+        ) : null}
+      </div>
+    );
+
   return (
     <div
       {...restProps}
@@ -208,6 +257,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
         tabIndex={-1}
         style={visuallyHiddenStyle}
       />
+      {isStacked ? textContent : null}
       <div
         {...mergedRootProps}
         className={mergeClassNames("ara-radio__control", controlClassName)}
@@ -218,28 +268,7 @@ export const Radio = forwardRef<HTMLDivElement, RadioProps>(function Radio(props
       >
         <span aria-hidden className="ara-radio__indicator" style={indicatorStyle} />
       </div>
-      {(label || description) && (
-        <div className="ara-radio__text" style={{ color: labelColor }}>
-          {label ? (
-            <label
-              {...labelProps}
-              className="ara-radio__label"
-              style={{ color: labelColor, fontWeight: 600 }}
-            >
-              {label}
-            </label>
-          ) : null}
-          {description ? (
-            <div
-              {...descriptionProps}
-              className="ara-radio__description"
-              style={{ color: labelColor, opacity: isDisabled ? 0.8 : 0.95 }}
-            >
-              {description}
-            </div>
-          ) : null}
-        </div>
-      )}
+      {!isStacked ? textContent : null}
     </div>
   );
 });

--- a/packages/react/src/components/radio/RadioGroup.tsx
+++ b/packages/react/src/components/radio/RadioGroup.tsx
@@ -3,6 +3,7 @@ import {
   forwardRef,
   useContext,
   useMemo,
+  type CSSProperties,
   type HTMLAttributes,
   type ReactNode
 } from "react";
@@ -134,7 +135,7 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(function R
     color: labelColor
   };
 
-  const itemsStyle = {
+  const itemsStyle: CSSProperties = {
     display: "flex",
     flexDirection: groupOrientation === "vertical" ? "column" : "row",
     gap: tokens.gap,

--- a/packages/react/src/components/radio/RadioGroup.tsx
+++ b/packages/react/src/components/radio/RadioGroup.tsx
@@ -8,6 +8,8 @@ import {
 } from "react";
 import { useRadioGroup, type UseRadioGroupResult } from "@ara/core";
 import type { RadioGroupOrientation } from "@ara/core";
+import { createFormControlStyleTokens } from "../form-control/formControlStyle.js";
+import { useAraTheme } from "../../theme/index.js";
 
 export type { RadioGroupOrientation } from "@ara/core";
 
@@ -112,6 +114,32 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(function R
 
   const { rootProps, labelProps, descriptionProps, loop: groupLoop, orientation: groupOrientation } =
     group;
+  const theme = useAraTheme();
+  const tokens = useMemo(() => createFormControlStyleTokens(theme), [theme]);
+
+  const labelColor = group.isDisabled
+    ? tokens.labelColor.disabled
+    : group.invalid
+      ? tokens.labelColor.invalid
+      : tokens.labelColor.default;
+
+  const requiredIndicatorColor = group.isDisabled
+    ? tokens.labelColor.disabled
+    : "var(--ara-radio-group-required, #d93025)";
+
+  const rootStyle = {
+    display: "flex",
+    flexDirection: "column" as const,
+    gap: "0.3em",
+    color: labelColor
+  };
+
+  const itemsStyle = {
+    display: "flex",
+    flexDirection: groupOrientation === "vertical" ? "column" : "row",
+    gap: tokens.gap,
+    flexWrap: "wrap" as const
+  };
 
   return (
     <RadioGroupContext.Provider value={{ group }}>
@@ -120,23 +148,59 @@ export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(function R
         {...restProps}
         ref={ref}
         className={mergeClassNames("ara-radio-group", className)}
-        style={style}
+        style={{ ...rootStyle, ...style }}
         data-disabled={rootProps["data-disabled"]}
         data-readonly={rootProps["data-readonly"]}
         data-orientation={groupOrientation}
         data-loop={groupLoop}
       >
         {label ? (
-          <label {...labelProps} className="ara-radio-group__label">
+          <label
+            {...labelProps}
+            className="ara-radio-group__label"
+            style={{
+              color: labelColor,
+              fontWeight: 600,
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.25em"
+            }}
+          >
             {label}
+            {group.required ? (
+              <span
+                aria-hidden
+                className="ara-radio-group__required"
+                data-testid="radio-group-required-indicator"
+                style={{
+                  color: requiredIndicatorColor,
+                  fontSize: "0.95em",
+                  fontWeight: 700,
+                  lineHeight: 1
+                }}
+              >
+                *
+              </span>
+            ) : null}
           </label>
         ) : null}
         {description ? (
-          <div {...descriptionProps} className="ara-radio-group__description">
+          <div
+            {...descriptionProps}
+            className="ara-radio-group__description"
+            style={{
+              color: "var(--ara-radio-group-description, #6b7280)",
+              fontSize: `var(--ara-radio-group-description-size, calc(${tokens.fontSize} * 0.92))`,
+              lineHeight: tokens.lineHeight,
+              fontWeight: 500
+            }}
+          >
             {description}
           </div>
         ) : null}
-        <div className="ara-radio-group__items">{children}</div>
+        <div className="ara-radio-group__items" style={itemsStyle}>
+          {children}
+        </div>
       </div>
     </RadioGroupContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add inline/stacked layout support to Radio with improved label and description styling
- style RadioGroup labels, descriptions, required indicator, and item arrangement for clearer layout
- document new layout examples in Storybook and extend tests to cover layout and styling

## Testing
- pnpm --filter @ara/react test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926a4383ed08322a9ea1e1f2e1db9d9)