### PR TITLE
Fix Radio story typings

### DIFF
--- a/apps/storybook/stories/components/Radio.stories.tsx
+++ b/apps/storybook/stories/components/Radio.stories.tsx
@@ -25,6 +25,7 @@ const meta = {
     layout: "padded"
   },
   args: {
+    children: null,
     label: "옵션 선택",
     description:
       "Your password must be 8-20 characters long, contain letters and numbers and must not contain spaces, special characters or emoji.",
@@ -43,10 +44,9 @@ const meta = {
     optionLabels: { name: "optionLabels", control: "object" },
     orientation: { control: "inline-radio", options: ["vertical", "horizontal"] },
     value: { control: "text" },
-    onChange: { control: false },
+    onValueChange: { control: false },
     describedBy: { control: false },
     labelledBy: { control: false },
-    inputRef: { control: false },
     controlClassName: { control: false },
     layout: { control: "inline-radio", options: ["inline", "stacked"] }
   },
@@ -91,6 +91,7 @@ export const Layouts: Story = {
   parameters: {
     controls: { disable: true }
   },
+  args: { ...meta.args },
   render: () => (
     <Stack {...spacingProps}>
       <RadioGroup name="layout-inline" label="인라인 텍스트" description="control 뒤에 텍스트">


### PR DESCRIPTION
## Summary
- add default children args to satisfy RadioGroup required props in Radio stories
- align Storybook argTypes with onValueChange and provide args for layout story to meet typings
- remove unsupported inputRef argType from Radio story to satisfy Meta typing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926b848b6ac832298b61840821a11ea)