### PR TITLE
Restore Radio story props for controlClassName and inputRef

### DIFF
--- a/apps/storybook/stories/components/Radio.stories.tsx
+++ b/apps/storybook/stories/components/Radio.stories.tsx
@@ -4,7 +4,7 @@ import { AraProvider, AraThemeBoundary, Flex, Radio, RadioGroup, Stack } from "@
 import type { RadioGroupProps, RadioProps } from "@ara/react";
 
 type RadioPlaygroundArgs = RadioGroupProps &
-  Pick<RadioProps, "layout" | "disabled"> & {
+  Pick<RadioProps, "layout" | "disabled" | "controlClassName" | "inputRef"> & {
     optionCount: number;
     optionLabels: string[];
   };
@@ -25,6 +25,7 @@ const meta = {
     layout: "padded"
   },
   args: {
+    children: null,
     label: "옵션 선택",
     description:
       "Your password must be 8-20 characters long, contain letters and numbers and must not contain spaces, special characters or emoji.",
@@ -43,15 +44,23 @@ const meta = {
     optionLabels: { name: "optionLabels", control: "object" },
     orientation: { control: "inline-radio", options: ["vertical", "horizontal"] },
     value: { control: "text" },
-    onChange: { control: false },
+    onValueChange: { control: false },
     describedBy: { control: false },
     labelledBy: { control: false },
+    controlClassName: { name: "controlClassName", control: "text" },
     inputRef: { control: false },
-    controlClassName: { control: false },
     layout: { control: "inline-radio", options: ["inline", "stacked"] }
   },
   tags: ["autodocs"],
-  render: ({ optionCount = 3, optionLabels = [], layout, disabled, ...groupProps }) => {
+  render: ({
+    optionCount = 3,
+    optionLabels = [],
+    layout,
+    disabled,
+    controlClassName,
+    inputRef,
+    ...groupProps
+  }) => {
     const count = Math.max(1, Math.min(Number(optionCount) || 0, 12));
     const labels = Array.isArray(optionLabels) ? optionLabels : [];
     const options = Array.from({ length: count }, (_, index) => {
@@ -71,6 +80,8 @@ const meta = {
             label={option.label}
             layout={layout}
             disabled={disabled}
+            controlClassName={controlClassName}
+            inputRef={inputRef}
           />
         ))}
       </RadioGroup>
@@ -91,6 +102,7 @@ export const Layouts: Story = {
   parameters: {
     controls: { disable: true }
   },
+  args: { ...meta.args },
   render: () => (
     <Stack {...spacingProps}>
       <RadioGroup name="layout-inline" label="인라인 텍스트" description="control 뒤에 텍스트">


### PR DESCRIPTION
## Summary
- extend Radio story args to include controlClassName and inputRef so they align with component props instead of being removed
- pass the radio-specific props through the playground render to keep Storybook controls functional while satisfying typing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926b848b6ac832298b61840821a11ea)