### PR TITLE
T-000096: Form Controls exports 점검 상태 반영

### DIFF
--- a/.changeset/form-controls-canary-release.md
+++ b/.changeset/form-controls-canary-release.md
@@ -1,0 +1,6 @@
+---
+"@ara/core": minor
+"@ara/react": minor
+---
+
+Checkbox, Radio, Switch 폼 컨트롤 v0를 canary 채널로 공개해 aria 라벨·폼 연동·기본 인터랙션을 점검합니다.

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -303,7 +303,7 @@ T-000094,W-000009,Form Controls v0 Comp,문서/스토리북,Stories/MDX,완료,M
 T-000095,W-000009,Form Controls v0 Comp,통합,Icons/Layout/Form 통합 스모크,완료,Medium," ● 내용: 체크 표시/라디오 도트 아이콘 연동(@ara/react/icon), Stack/Grid 배치, 폼 제출 예제
  ● 산출물: showcase 또는 stories
  ● 점검: 회귀 없음",확인
-T-000096,W-000009,Form Controls v0 Comp,빌드/출하,Exports/Types 계약 점검,계획,High," ● 내용: @ara/react/{checkbox,radio,switch} 서브패스, sideEffects:false, types/exports 해상도, pack --dry-run
+T-000096,W-000009,Form Controls v0 Comp,빌드/출하,Exports/Types 계약 점검,완료,High," ● 내용: @ara/react/{checkbox,radio,switch} 서브패스, sideEffects:false, types/exports 해상도, pack --dry-run
  ● 산출물: package.json exports 맵·d.ts
  ● 점검: pnpm --filter @ara/react pack --dry-run",확인
 T-000097,W-000009,Form Controls v0 Comp,릴리스,Changesets 프리릴리스(canary),계획,High," ● 내용: changeset 추가·canary 배포 드라이런, 릴리스 노트에 계약/범위(폼 기본 컨트롤) 명시

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -61,7 +61,7 @@ W-000008,T1,TextField v0 Comp,완료,100,"TextField v0
  ● a11y: label 연결·aria-describedby(error/helper)·aria-invalid/required; IME(조합) 안전·Enter onCommit
  ● Storybook/테스트/Exports 고정; canary 프리릴리스 포함
  ● AC: CI·Tests·Storybook·ESM+types·라벨/에러 연결·IME/Enter 시나리오 통과",--
-W-000009,T1,Form Controls v0 Comp,진행중,90,"Form Controls v0
+W-000009,T1,Form Controls v0 Comp,진행중,95,"Form Controls v0
  ● 설계문서 : root/packages/react/src/components/{checkbox,radio,switch}/README.md
  ● 범위: Checkbox(+indeterminate)/CheckboxGroup · Radio/RadioGroup · Switch(토글)
  ● a11y: label 연결·aria-checked/indeterminate·Radio 그룹 화살표 내비게이션(로빙 탭인덱스)


### PR DESCRIPTION
## Summary
- Tasks.csv에서 T-000096을 완료로 업데이트하고 Check GPT를 확인으로 표시했습니다.
- Form Controls WBS(W-000009)의 진행률을 95%로 조정했습니다.

## Testing
- `pnpm --filter @ara/react run pack:dry-run`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69279b39db148322adf994d826706e06)