### PR TITLE
T-000099: SSR-safe Portal 훅 추가

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,11 @@
       "import": "./dist/use-checkbox.js",
       "default": "./dist/use-checkbox.js"
     },
+    "./overlays/use-portal": {
+      "types": "./dist/overlays/use-portal.d.ts",
+      "import": "./dist/overlays/use-portal.js",
+      "default": "./dist/overlays/use-portal.js"
+    },
     "./use-switch": {
       "types": "./dist/use-switch.d.ts",
       "import": "./dist/use-switch.js",
@@ -43,6 +48,9 @@
     "*": {
       "theme": [
         "dist/theme.d.ts"
+      ],
+      "overlays/use-portal": [
+        "dist/overlays/use-portal.d.ts"
       ],
       "use-button": [
         "dist/use-button.d.ts"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,3 +60,5 @@ export type {
   UseRadioGroupResult
 } from "./use-radio-group.js";
 export { useRadioGroup } from "./use-radio-group.js";
+export type { UsePortalOptions, UsePortalResult } from "./overlays/use-portal.js";
+export { usePortal } from "./overlays/use-portal.js";

--- a/packages/core/src/overlays/use-portal.test.tsx
+++ b/packages/core/src/overlays/use-portal.test.tsx
@@ -1,0 +1,68 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import { usePortal } from "./use-portal.js";
+
+const PORTAL_SELECTOR = "[data-ara-portal-container]";
+
+describe("usePortal", () => {
+  afterEach(() => {
+    cleanup();
+    document.querySelectorAll(PORTAL_SELECTOR).forEach((node) => node.remove());
+  });
+
+  it("creates a default portal container when none is provided", async () => {
+    const { result } = renderHook(() => usePortal());
+
+    await waitFor(() => expect(result.current.container).not.toBeNull());
+
+    const container = result.current.container;
+    expect(container).not.toBeNull();
+    expect(container).toHaveAttribute("data-ara-portal-container", "");
+    expect(document.body.contains(container!)).toBe(true);
+  });
+
+  it("cleans up the default portal container on unmount", async () => {
+    const { result, unmount } = renderHook(() => usePortal());
+
+    await waitFor(() => expect(result.current.container).not.toBeNull());
+    const container = result.current.container!;
+
+    unmount();
+
+    expect(document.body.contains(container)).toBe(false);
+  });
+
+  it("prefers a user-provided container and avoids creating a default one", async () => {
+    const customContainer = document.createElement("div");
+    document.body.appendChild(customContainer);
+
+    const { result, unmount } = renderHook(() => usePortal({ container: customContainer }));
+
+    await waitFor(() => expect(result.current.container).toBe(customContainer));
+    expect(document.body.querySelector(PORTAL_SELECTOR)).toBeNull();
+
+    unmount();
+
+    expect(document.body.contains(customContainer)).toBe(true);
+  });
+
+  it("skips portal creation when disabled", async () => {
+    const { result } = renderHook(() => usePortal({ disabled: true }));
+
+    await waitFor(() => expect(result.current.container).toBeNull());
+    expect(document.body.querySelector(PORTAL_SELECTOR)).toBeNull();
+  });
+
+  it("notifies once when the container becomes available", async () => {
+    const onContainerChange = vi.fn();
+    const { result } = renderHook(() => usePortal({ onContainerChange }));
+
+    await waitFor(() => expect(result.current.container).not.toBeNull());
+    const container = result.current.container!;
+
+    expect(onContainerChange).toHaveBeenCalledTimes(1);
+    expect(onContainerChange).toHaveBeenCalledWith(container);
+  });
+});

--- a/packages/core/src/overlays/use-portal.ts
+++ b/packages/core/src/overlays/use-portal.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface UsePortalOptions {
+  readonly container?: HTMLElement | null;
+  readonly disabled?: boolean;
+  readonly onContainerChange?: (node: HTMLElement) => void;
+}
+
+export interface UsePortalResult {
+  readonly container: HTMLElement | null;
+}
+
+const DEFAULT_PORTAL_SELECTOR = "data-ara-portal-container";
+
+function createDefaultContainer(): HTMLElement | null {
+  if (typeof document === "undefined") return null;
+  const { body } = document;
+  if (!body) return null;
+
+  const element = document.createElement("div");
+  element.setAttribute(DEFAULT_PORTAL_SELECTOR, "");
+  body.appendChild(element);
+  return element;
+}
+
+function removeContainer(node: HTMLElement | null) {
+  node?.remove();
+}
+
+export function usePortal(options: UsePortalOptions = {}): UsePortalResult {
+  const { container, disabled = false, onContainerChange } = options;
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
+  const createdContainerRef = useRef<HTMLElement | null>(null);
+  const notifiedContainerRef = useRef<HTMLElement | null>(null);
+  const onContainerChangeRef = useRef(onContainerChange);
+
+  useEffect(() => {
+    onContainerChangeRef.current = onContainerChange;
+  }, [onContainerChange]);
+
+  useEffect(() => {
+    const cleanupCreatedContainer = () => {
+      removeContainer(createdContainerRef.current);
+      createdContainerRef.current = null;
+    };
+
+    if (disabled) {
+      cleanupCreatedContainer();
+      setPortalContainer(null);
+      return cleanupCreatedContainer;
+    }
+
+    let resolvedContainer = container ?? null;
+
+    if (!resolvedContainer) {
+      resolvedContainer = createDefaultContainer();
+      createdContainerRef.current = resolvedContainer;
+    }
+
+    setPortalContainer(resolvedContainer);
+
+    if (resolvedContainer && notifiedContainerRef.current !== resolvedContainer) {
+      notifiedContainerRef.current = resolvedContainer;
+      onContainerChangeRef.current?.(resolvedContainer);
+    }
+
+    return cleanupCreatedContainer;
+  }, [container, disabled]);
+
+  return { container: portalContainer };
+}


### PR DESCRIPTION
## Summary
- [x] W-000010 / T-000099: SSR-safe 포털 컨테이너 생성을 담당하는 `usePortal` 훅을 추가했습니다.
- [x] 사용자 지정 컨테이너 우선 사용, 기본 컨테이너 생성·정리, 컨테이너 준비 콜백 흐름을 구현했습니다.
- [x] 기본/사용자 컨테이너 처리와 콜백 호출 동작을 검증하는 테스트를 추가했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다. (해당 없음)
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.** (없음)

## Testing
- [x] `pnpm --filter @ara/core test -- src/overlays/use-portal.test.tsx`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693119fb452483228f4cfc8be5d9da1f)