### PR TITLE
[T-000100] useFocusTrap 훅 추가

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/overlays/use-portal.js",
       "default": "./dist/overlays/use-portal.js"
     },
+    "./overlays/use-focus-trap": {
+      "types": "./dist/overlays/use-focus-trap.d.ts",
+      "import": "./dist/overlays/use-focus-trap.js",
+      "default": "./dist/overlays/use-focus-trap.js"
+    },
     "./use-switch": {
       "types": "./dist/use-switch.d.ts",
       "import": "./dist/use-switch.js",
@@ -51,6 +56,9 @@
       ],
       "overlays/use-portal": [
         "dist/overlays/use-portal.d.ts"
+      ],
+      "overlays/use-focus-trap": [
+        "dist/overlays/use-focus-trap.d.ts"
       ],
       "use-button": [
         "dist/use-button.d.ts"
@@ -106,6 +114,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@ara/tsconfig": "workspace:*",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,3 +62,10 @@ export type {
 export { useRadioGroup } from "./use-radio-group.js";
 export type { UsePortalOptions, UsePortalResult } from "./overlays/use-portal.js";
 export { usePortal } from "./overlays/use-portal.js";
+export type {
+  FocusGuardProps,
+  FocusTrapContainerProps,
+  UseFocusTrapOptions,
+  UseFocusTrapResult
+} from "./overlays/use-focus-trap.js";
+export { useFocusTrap } from "./overlays/use-focus-trap.js";

--- a/packages/core/src/overlays/use-focus-trap.test.tsx
+++ b/packages/core/src/overlays/use-focus-trap.test.tsx
@@ -1,0 +1,130 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useFocusTrap } from "./use-focus-trap.js";
+
+describe("useFocusTrap", () => {
+  const user = userEvent.setup();
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("loops focus within the container using focus guards", async () => {
+    function Trap() {
+      const { containerProps, beforeFocusGuardProps, afterFocusGuardProps } = useFocusTrap();
+
+      return (
+        <div>
+          <span data-testid="before" {...beforeFocusGuardProps} />
+          <div data-testid="container" {...containerProps}>
+            <button data-testid="first">first</button>
+            <button data-testid="last">last</button>
+          </div>
+          <span data-testid="after" {...afterFocusGuardProps} />
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<Trap />);
+
+    const first = getByTestId("first");
+    const last = getByTestId("last");
+
+    await act(async () => {});
+
+    expect(first).toHaveFocus();
+
+    await act(async () => {
+      await user.tab();
+    });
+
+    expect(last).toHaveFocus();
+
+    await act(async () => {
+      await user.tab();
+    });
+
+    expect(first).toHaveFocus();
+  });
+
+  it("restores the previously focused element on cleanup", async () => {
+    const outsideButton = document.createElement("button");
+    document.body.appendChild(outsideButton);
+
+    outsideButton.focus();
+
+    function Trap() {
+      const { containerProps, beforeFocusGuardProps, afterFocusGuardProps } = useFocusTrap();
+
+      return (
+        <div>
+          <span data-testid="before" {...beforeFocusGuardProps} />
+          <div data-testid="container" {...containerProps}>
+            <button data-testid="inside">inside</button>
+          </div>
+          <span data-testid="after" {...afterFocusGuardProps} />
+        </div>
+      );
+    }
+
+    const { unmount, getByTestId } = render(<Trap />);
+
+    await act(async () => {});
+
+    expect(getByTestId("inside")).toHaveFocus();
+
+    unmount();
+
+    expect(outsideButton).toHaveFocus();
+
+    outsideButton.remove();
+  });
+
+  it("only the top-most trap responds when multiple traps are active", async () => {
+    function MultiTrap() {
+      const outer = useFocusTrap();
+      const inner = useFocusTrap();
+
+      return (
+        <div>
+          <span data-testid="outer-before" {...outer.beforeFocusGuardProps} />
+          <div data-testid="outer" {...outer.containerProps}>
+            <button data-testid="outer-first">outer-first</button>
+            <span data-testid="inner-before" {...inner.beforeFocusGuardProps} />
+            <div data-testid="inner" {...inner.containerProps}>
+              <button data-testid="inner-first">inner-first</button>
+              <button data-testid="inner-last">inner-last</button>
+            </div>
+            <span data-testid="inner-after" {...inner.afterFocusGuardProps} />
+            <button data-testid="outer-last">outer-last</button>
+          </div>
+          <span data-testid="outer-after" {...outer.afterFocusGuardProps} />
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<MultiTrap />);
+
+    const innerFirst = getByTestId("inner-first");
+    const innerLast = getByTestId("inner-last");
+
+    await act(async () => {});
+
+    expect(innerFirst).toHaveFocus();
+
+    await act(async () => {
+      await user.tab();
+    });
+
+    expect(innerLast).toHaveFocus();
+
+    await act(async () => {
+      await user.tab();
+    });
+
+    expect(innerFirst).toHaveFocus();
+  });
+});

--- a/packages/core/src/overlays/use-focus-trap.ts
+++ b/packages/core/src/overlays/use-focus-trap.ts
@@ -1,0 +1,188 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent
+} from "react";
+
+export interface UseFocusTrapOptions {
+  readonly active?: boolean;
+  readonly container?: HTMLElement | null;
+  readonly initialFocus?: FocusTarget;
+  readonly restoreFocus?: boolean;
+}
+
+export interface UseFocusTrapResult {
+  readonly containerProps: FocusTrapContainerProps;
+  readonly beforeFocusGuardProps: FocusGuardProps;
+  readonly afterFocusGuardProps: FocusGuardProps;
+}
+
+export interface FocusTrapContainerProps {
+  readonly ref: (node: HTMLElement | null) => void;
+}
+
+export interface FocusGuardProps {
+  readonly tabIndex: 0;
+  readonly "aria-hidden": true;
+  readonly "data-ara-focus-guard": string;
+  readonly onFocus: (event: FocusEvent<HTMLElement>) => void;
+}
+
+type FocusTarget = HTMLElement | null | (() => HTMLElement | null);
+
+type FocusDirection = "first" | "last";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]:not([tabindex='-1']):not([inert])",
+  "button:not([disabled]):not([tabindex='-1']):not([inert])",
+  "input:not([disabled]):not([tabindex='-1']):not([type='hidden']):not([inert])",
+  "select:not([disabled]):not([tabindex='-1']):not([inert])",
+  "textarea:not([disabled]):not([tabindex='-1']):not([inert])",
+  "[tabindex]:not([tabindex='-1']):not([disabled]):not([inert])"
+].join(",");
+
+const focusTrapStack: Array<symbol> = [];
+
+function pushTrap(id: symbol) {
+  focusTrapStack.push(id);
+}
+
+function removeTrap(id: symbol) {
+  const index = focusTrapStack.indexOf(id);
+  if (index >= 0) {
+    focusTrapStack.splice(index, 1);
+  }
+}
+
+function isTopTrap(id: symbol): boolean {
+  return focusTrapStack[focusTrapStack.length - 1] === id;
+}
+
+function resolveFocusTarget(target: FocusTarget): HTMLElement | null {
+  return typeof target === "function" ? target() : target ?? null;
+}
+
+function isHTMLElement(node: unknown): node is HTMLElement {
+  return node instanceof HTMLElement;
+}
+
+function focusNode(node: HTMLElement | null): boolean {
+  if (!node) return false;
+  node.focus({ preventScroll: true });
+  return document.activeElement === node;
+}
+
+function isFocusable(node: HTMLElement | null): node is HTMLElement {
+  if (!node) return false;
+  if (node.tabIndex >= 0) return true;
+  return isHTMLElement(node) && !!node.getAttribute("href");
+}
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (element) => !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true"
+  );
+}
+
+function focusElementInContainer(container: HTMLElement | null, direction: FocusDirection): boolean {
+  if (!container) return false;
+  const focusable = getFocusableElements(container);
+  const target = direction === "first" ? focusable[0] : focusable[focusable.length - 1];
+
+  if (focusNode(target ?? null)) return true;
+  if (isFocusable(container)) {
+    return focusNode(container);
+  }
+
+  return false;
+}
+
+export function useFocusTrap(options: UseFocusTrapOptions = {}): UseFocusTrapResult {
+  const { active = true, container, initialFocus, restoreFocus = true } = options;
+  const [containerNode, setContainerNode] = useState<HTMLElement | null>(null);
+  const resolvedContainer = container ?? containerNode;
+  const reactId = useId();
+  const trapId = useMemo(() => Symbol(`focus-trap-${reactId}`), [reactId]);
+  const previousFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  const setContainer = useCallback((node: HTMLElement | null) => {
+    setContainerNode(node);
+  }, []);
+
+  const focusInitialNode = useCallback(() => {
+    if (!resolvedContainer) return;
+
+    const target = initialFocus ? resolveFocusTarget(initialFocus) : null;
+    if (target && resolvedContainer.contains(target) && focusNode(target)) return;
+
+    if (focusElementInContainer(resolvedContainer, "first")) return;
+
+    focusNode(resolvedContainer);
+  }, [initialFocus, resolvedContainer]);
+
+  const handleGuardFocus = useCallback(
+    (direction: FocusDirection, event: FocusEvent<HTMLElement>) => {
+      if (!isTopTrap(trapId) || event.defaultPrevented) return;
+      event.preventDefault();
+      event.stopPropagation();
+      focusElementInContainer(resolvedContainer, direction);
+    },
+    [resolvedContainer, trapId]
+  );
+
+  useEffect(() => {
+    if (!active || !resolvedContainer) return undefined;
+
+    const activeElement = document.activeElement;
+    previousFocusedElementRef.current = isHTMLElement(activeElement)
+      ? activeElement
+      : previousFocusedElementRef.current;
+
+    pushTrap(trapId);
+    focusInitialNode();
+
+    return () => {
+      const wasTop = isTopTrap(trapId);
+      removeTrap(trapId);
+
+      if (wasTop && restoreFocus !== false) {
+        const previousElement = previousFocusedElementRef.current;
+        if (previousElement && document.contains(previousElement)) {
+          focusNode(previousElement);
+        }
+      }
+    };
+  }, [active, focusInitialNode, resolvedContainer, restoreFocus, trapId]);
+
+  useEffect(() => {
+    if (!active || !resolvedContainer || !isTopTrap(trapId)) return undefined;
+    focusInitialNode();
+    return undefined;
+  }, [active, focusInitialNode, resolvedContainer, trapId]);
+
+  const beforeFocusGuardProps = useMemo<FocusGuardProps>(() => ({
+    tabIndex: 0,
+    "aria-hidden": true,
+    "data-ara-focus-guard": "before",
+    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus("last", event)
+  }), [handleGuardFocus]);
+
+  const afterFocusGuardProps = useMemo<FocusGuardProps>(() => ({
+    tabIndex: 0,
+    "aria-hidden": true,
+    "data-ara-focus-guard": "after",
+    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus("first", event)
+  }), [handleGuardFocus]);
+
+  const containerProps = useMemo<FocusTrapContainerProps>(() => ({ ref: setContainer }), [setContainer]);
+
+  return {
+    containerProps,
+    beforeFocusGuardProps,
+    afterFocusGuardProps
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.0.1
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.5.2(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.26
@@ -4036,6 +4039,10 @@ snapshots:
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
+
+  '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@trysound/sax@0.2.0': {}
 


### PR DESCRIPTION
## Summary
- [x] WBS: W-000010 / Task: T-000100 - 포커스 트랩 훅(useFocusTrap) 추가
- [x] 포커스 가드/스택 기반 루프·초기 진입·포커스 복귀 로직 구현
- [x] 중첩 트랩 대응 및 포커스 복원 시나리오를 포함한 테스트 추가 및 패키지 익스포트/타입 매핑 업데이트

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다. (패키지 exports/typesVersions 반영)
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/core test`

## Screenshots
- 해당 사항 없음


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69311d471e608322aaa9fa72f4ee8e20)