### PR TITLE
Fix focus guard focus direction when entering trap

### DIFF
--- a/packages/core/src/overlays/use-focus-trap.ts
+++ b/packages/core/src/overlays/use-focus-trap.ts
@@ -168,14 +168,14 @@ export function useFocusTrap(options: UseFocusTrapOptions = {}): UseFocusTrapRes
     tabIndex: 0,
     "aria-hidden": true,
     "data-ara-focus-guard": "before",
-    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus("last", event)
+    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus(event.shiftKey ? "last" : "first", event)
   }), [handleGuardFocus]);
 
   const afterFocusGuardProps = useMemo<FocusGuardProps>(() => ({
     tabIndex: 0,
     "aria-hidden": true,
     "data-ara-focus-guard": "after",
-    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus("first", event)
+    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus(event.shiftKey ? "last" : "first", event)
   }), [handleGuardFocus]);
 
   const containerProps = useMemo<FocusTrapContainerProps>(() => ({ ref: setContainer }), [setContainer]);

--- a/packages/core/src/overlays/use-focus-trap.ts
+++ b/packages/core/src/overlays/use-focus-trap.ts
@@ -108,6 +108,7 @@ export function useFocusTrap(options: UseFocusTrapOptions = {}): UseFocusTrapRes
   const reactId = useId();
   const trapId = useMemo(() => Symbol(`focus-trap-${reactId}`), [reactId]);
   const previousFocusedElementRef = useRef<HTMLElement | null>(null);
+  const lastTabDirectionRef = useRef<FocusDirection>("first");
 
   const setContainer = useCallback((node: HTMLElement | null) => {
     setContainerNode(node);
@@ -133,6 +134,22 @@ export function useFocusTrap(options: UseFocusTrapOptions = {}): UseFocusTrapRes
     },
     [resolvedContainer, trapId]
   );
+
+  useEffect(() => {
+    if (!active) return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Tab") {
+        lastTabDirectionRef.current = event.shiftKey ? "last" : "first";
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [active]);
 
   useEffect(() => {
     if (!active || !resolvedContainer) return undefined;
@@ -168,14 +185,14 @@ export function useFocusTrap(options: UseFocusTrapOptions = {}): UseFocusTrapRes
     tabIndex: 0,
     "aria-hidden": true,
     "data-ara-focus-guard": "before",
-    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus(event.shiftKey ? "last" : "first", event)
+    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus(lastTabDirectionRef.current, event)
   }), [handleGuardFocus]);
 
   const afterFocusGuardProps = useMemo<FocusGuardProps>(() => ({
     tabIndex: 0,
     "aria-hidden": true,
     "data-ara-focus-guard": "after",
-    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus(event.shiftKey ? "last" : "first", event)
+    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus(lastTabDirectionRef.current, event)
   }), [handleGuardFocus]);
 
   const containerProps = useMemo<FocusTrapContainerProps>(() => ({ ref: setContainer }), [setContainer]);


### PR DESCRIPTION
## Summary
- update focus guard handlers to choose focus target based on tab direction
- ensure entering a focus trap moves to the first item when tabbing forward and last when tabbing backward

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69312867576083229200b73d620fc298)