### PR TITLE
Reset focus trap tab direction on activation

### DIFF
--- a/packages/core/src/overlays/use-focus-trap.ts
+++ b/packages/core/src/overlays/use-focus-trap.ts
@@ -108,6 +108,7 @@ export function useFocusTrap(options: UseFocusTrapOptions = {}): UseFocusTrapRes
   const reactId = useId();
   const trapId = useMemo(() => Symbol(`focus-trap-${reactId}`), [reactId]);
   const previousFocusedElementRef = useRef<HTMLElement | null>(null);
+  const lastTabDirectionRef = useRef<FocusDirection>("first");
 
   const setContainer = useCallback((node: HTMLElement | null) => {
     setContainerNode(node);
@@ -133,6 +134,24 @@ export function useFocusTrap(options: UseFocusTrapOptions = {}): UseFocusTrapRes
     },
     [resolvedContainer, trapId]
   );
+
+  useEffect(() => {
+    if (!active) return undefined;
+
+    lastTabDirectionRef.current = "first";
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Tab") {
+        lastTabDirectionRef.current = event.shiftKey ? "last" : "first";
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [active]);
 
   useEffect(() => {
     if (!active || !resolvedContainer) return undefined;
@@ -168,14 +187,14 @@ export function useFocusTrap(options: UseFocusTrapOptions = {}): UseFocusTrapRes
     tabIndex: 0,
     "aria-hidden": true,
     "data-ara-focus-guard": "before",
-    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus("last", event)
+    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus(lastTabDirectionRef.current, event)
   }), [handleGuardFocus]);
 
   const afterFocusGuardProps = useMemo<FocusGuardProps>(() => ({
     tabIndex: 0,
     "aria-hidden": true,
     "data-ara-focus-guard": "after",
-    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus("first", event)
+    onFocus: (event: FocusEvent<HTMLElement>) => handleGuardFocus(lastTabDirectionRef.current, event)
   }), [handleGuardFocus]);
 
   const containerProps = useMemo<FocusTrapContainerProps>(() => ({ ref: setContainer }), [setContainer]);


### PR DESCRIPTION
## Summary
- reset the stored tab direction to forward whenever a focus trap activates so guard entry is predictable
- keep tracking Tab key direction via keydown to direct focus guards appropriately

## Testing
- pnpm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69312867576083229200b73d620fc298)