### PR TITLE
feat: usePositioner 훅 추가

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,11 @@
       "import": "./dist/overlays/use-focus-trap.js",
       "default": "./dist/overlays/use-focus-trap.js"
     },
+    "./overlays/use-positioner": {
+      "types": "./dist/overlays/use-positioner.d.ts",
+      "import": "./dist/overlays/use-positioner.js",
+      "default": "./dist/overlays/use-positioner.js"
+    },
     "./use-switch": {
       "types": "./dist/use-switch.d.ts",
       "import": "./dist/use-switch.js",
@@ -67,6 +72,9 @@
       ],
       "overlays/use-focus-trap": [
         "dist/overlays/use-focus-trap.d.ts"
+      ],
+      "overlays/use-positioner": [
+        "dist/overlays/use-positioner.d.ts"
       ],
       "use-button": [
         "dist/use-button.d.ts"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,6 +64,8 @@ export type { UsePortalOptions, UsePortalResult } from "./overlays/use-portal.js
 export { usePortal } from "./overlays/use-portal.js";
 export type { UseDismissableLayerOptions, UseDismissableLayerResult, DismissableLayerContainerProps, DismissableLayerEvent } from "./overlays/use-dismissable-layer.js";
 export { useDismissableLayer } from "./overlays/use-dismissable-layer.js";
+export type { Placement, PositionerAnchorProps, PositionerFloatingProps, UsePositionerOptions, UsePositionerResult } from "./overlays/use-positioner.js";
+export { usePositioner } from "./overlays/use-positioner.js";
 export type {
   FocusGuardProps,
   FocusTrapContainerProps,

--- a/packages/core/src/overlays/use-positioner.test.tsx
+++ b/packages/core/src/overlays/use-positioner.test.tsx
@@ -1,0 +1,162 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePositioner, type Placement } from "./use-positioner.js";
+
+type RectInit = { x: number; y: number; width: number; height: number };
+
+function createRect({ x, y, width, height }: RectInit): DOMRect {
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+    toJSON: () => ({ x, y, width, height })
+  } as DOMRect;
+}
+
+function setupElements(anchorRect: DOMRect, floatingRect: DOMRect) {
+  const anchor = document.createElement("div");
+  const floating = document.createElement("div");
+
+  anchor.getBoundingClientRect = vi.fn(() => anchorRect);
+  floating.getBoundingClientRect = vi.fn(() => floatingRect);
+
+  document.body.appendChild(anchor);
+  document.body.appendChild(floating);
+
+  return { anchor, floating };
+}
+
+describe("usePositioner", () => {
+  beforeEach(() => {
+    Object.defineProperty(document.documentElement, "clientWidth", { value: 1024, configurable: true });
+    Object.defineProperty(document.documentElement, "clientHeight", { value: 768, configurable: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  it("기본 배치를 anchor 기준 하단 시작점으로 계산한다", async () => {
+    const anchorRect = createRect({ x: 100, y: 100, width: 50, height: 40 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 80, height: 30 });
+    const { anchor, floating } = setupElements(anchorRect, floatingRect);
+
+    const { result } = renderHook(() => usePositioner());
+
+    act(() => {
+      result.current.anchorProps.ref(anchor);
+      result.current.floatingProps.ref(floating);
+    });
+
+    await waitFor(() => {
+      expect(result.current.floatingProps.style.left).toBeCloseTo(100);
+      expect(result.current.floatingProps.style.top).toBeCloseTo(140);
+    });
+  });
+
+  it("placement 옵션을 반영해 원하는 정렬에 배치한다", async () => {
+    const anchorRect = createRect({ x: 100, y: 100, width: 50, height: 40 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 80, height: 30 });
+    const { anchor, floating } = setupElements(anchorRect, floatingRect);
+
+    const { result } = renderHook(() => usePositioner({ placement: "top-end" } satisfies { placement: Placement }));
+
+    act(() => {
+      result.current.anchorProps.ref(anchor);
+      result.current.floatingProps.ref(floating);
+    });
+
+    await waitFor(() => {
+      expect(result.current.floatingProps.style.left).toBeCloseTo(70);
+      expect(result.current.floatingProps.style.top).toBeCloseTo(70);
+      expect(result.current.placement).toBe("top-end");
+    });
+  });
+
+  it("offset 값만큼 주축 방향으로 간격을 둔다", async () => {
+    const anchorRect = createRect({ x: 200, y: 200, width: 80, height: 40 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 60, height: 20 });
+    const { anchor, floating } = setupElements(anchorRect, floatingRect);
+
+    const { result } = renderHook(() => usePositioner({ offset: 8 }));
+
+    act(() => {
+      result.current.anchorProps.ref(anchor);
+      result.current.floatingProps.ref(floating);
+    });
+
+    await waitFor(() => {
+      expect(result.current.floatingProps.style.left).toBeCloseTo(200);
+      expect(result.current.floatingProps.style.top).toBeCloseTo(248);
+    });
+  });
+
+  it("뷰포트 밖으로 나갈 경우 반대편으로 뒤집는다", async () => {
+    const anchorRect = createRect({ x: 300, y: 700, width: 60, height: 50 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 80, height: 40 });
+    const { anchor, floating } = setupElements(anchorRect, floatingRect);
+
+    const { result } = renderHook(() => usePositioner({ placement: "bottom-start" }));
+
+    act(() => {
+      result.current.anchorProps.ref(anchor);
+      result.current.floatingProps.ref(floating);
+    });
+
+    await waitFor(() => {
+      expect(result.current.floatingProps.style.top).toBeCloseTo(660);
+      expect(result.current.placement).toBe("top-start");
+    });
+  });
+
+  it("교차 축으로 시프트해 뷰포트 안에 유지한다", async () => {
+    const anchorRect = createRect({ x: -20, y: 100, width: 20, height: 40 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 100, height: 20 });
+    const { anchor, floating } = setupElements(anchorRect, floatingRect);
+
+    const { result } = renderHook(() => usePositioner());
+
+    act(() => {
+      result.current.anchorProps.ref(anchor);
+      result.current.floatingProps.ref(floating);
+    });
+
+    await waitFor(() => {
+      expect(result.current.floatingProps.style.left).toBeCloseTo(0);
+      expect(result.current.floatingProps.style.top).toBeCloseTo(140);
+    });
+  });
+
+  it("스크롤/리사이즈 시 위치를 다시 계산한다", async () => {
+    let anchorRect = createRect({ x: 10, y: 10, width: 40, height: 30 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 50, height: 20 });
+    const { anchor, floating } = setupElements(anchorRect, floatingRect);
+
+    const { result } = renderHook(() => usePositioner());
+
+    act(() => {
+      result.current.anchorProps.ref(anchor);
+      result.current.floatingProps.ref(floating);
+    });
+
+    await waitFor(() => expect(result.current.floatingProps.style.left).toBeCloseTo(10));
+
+    anchor.getBoundingClientRect = vi.fn(() => anchorRect);
+
+    act(() => {
+      anchorRect = createRect({ x: 200, y: 10, width: 40, height: 30 });
+      window.dispatchEvent(new Event("scroll"));
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    await waitFor(() => expect(result.current.floatingProps.style.left).toBeCloseTo(200));
+  });
+});

--- a/packages/core/src/overlays/use-positioner.ts
+++ b/packages/core/src/overlays/use-positioner.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
+
+type Side = "top" | "bottom" | "left" | "right";
+type Align = "start" | "center" | "end";
+
+export type Placement = `${Side}-${Align}`;
+
+export interface UsePositionerOptions {
+  readonly anchor?: HTMLElement | null;
+  readonly floating?: HTMLElement | null;
+  readonly placement?: Placement;
+  readonly offset?: number;
+  readonly flip?: boolean;
+  readonly shift?: boolean;
+}
+
+export interface UsePositionerResult {
+  readonly anchorProps: PositionerAnchorProps;
+  readonly floatingProps: PositionerFloatingProps;
+  readonly placement: Placement;
+}
+
+export interface PositionerAnchorProps {
+  readonly ref: (node: HTMLElement | null) => void;
+}
+
+export interface PositionerFloatingProps {
+  readonly ref: (node: HTMLElement | null) => void;
+  readonly style: CSSProperties;
+}
+
+interface PositionState {
+  readonly x: number | undefined;
+  readonly y: number | undefined;
+  readonly placement: Placement;
+}
+
+const DEFAULT_PLACEMENT: Placement = "bottom-start";
+const DEFAULT_OFFSET = 0;
+
+function parsePlacement(placement: Placement): { side: Side; align: Align } {
+  const [side, align] = placement.split("-") as [Side, Align];
+  return { side, align };
+}
+
+function flipSide(side: Side): Side {
+  switch (side) {
+    case "top":
+      return "bottom";
+    case "bottom":
+      return "top";
+    case "left":
+      return "right";
+    case "right":
+      return "left";
+    default:
+      return side;
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function computeBasePosition(
+  side: Side,
+  align: Align,
+  anchorRect: DOMRect,
+  floatingRect: DOMRect,
+  offset: number
+): { x: number; y: number } {
+  switch (side) {
+    case "bottom": {
+      const x =
+        align === "start"
+          ? anchorRect.left
+          : align === "center"
+            ? anchorRect.left + anchorRect.width / 2 - floatingRect.width / 2
+            : anchorRect.right - floatingRect.width;
+      const y = anchorRect.bottom + offset;
+      return { x, y };
+    }
+    case "top": {
+      const x =
+        align === "start"
+          ? anchorRect.left
+          : align === "center"
+            ? anchorRect.left + anchorRect.width / 2 - floatingRect.width / 2
+            : anchorRect.right - floatingRect.width;
+      const y = anchorRect.top - floatingRect.height - offset;
+      return { x, y };
+    }
+    case "right": {
+      const x = anchorRect.right + offset;
+      const y =
+        align === "start"
+          ? anchorRect.top
+          : align === "center"
+            ? anchorRect.top + anchorRect.height / 2 - floatingRect.height / 2
+            : anchorRect.bottom - floatingRect.height;
+      return { x, y };
+    }
+    case "left":
+    default: {
+      const x = anchorRect.left - floatingRect.width - offset;
+      const y =
+        align === "start"
+          ? anchorRect.top
+          : align === "center"
+            ? anchorRect.top + anchorRect.height / 2 - floatingRect.height / 2
+            : anchorRect.bottom - floatingRect.height;
+      return { x, y };
+    }
+  }
+}
+
+function computePosition(
+  placement: Placement,
+  anchorRect: DOMRect,
+  floatingRect: DOMRect,
+  options: { flip: boolean; shift: boolean; offset: number }
+): PositionState {
+  const { side: initialSide, align } = parsePlacement(placement);
+  const viewportWidth = document.documentElement?.clientWidth ?? window.innerWidth ?? 0;
+  const viewportHeight = document.documentElement?.clientHeight ?? window.innerHeight ?? 0;
+  const scrollX = window.scrollX ?? window.pageXOffset ?? 0;
+  const scrollY = window.scrollY ?? window.pageYOffset ?? 0;
+
+  const resolvePositionForSide = (side: Side) => computeBasePosition(side, align, anchorRect, floatingRect, options.offset);
+
+  let side = initialSide;
+  let { x, y } = resolvePositionForSide(side);
+
+  if (options.flip) {
+    const overflows = {
+      top: y < 0,
+      bottom: y + floatingRect.height > viewportHeight,
+      left: x < 0,
+      right: x + floatingRect.width > viewportWidth
+    };
+
+    if ((side === "top" && overflows.top) || (side === "bottom" && overflows.bottom)) {
+      side = flipSide(side);
+      ({ x, y } = resolvePositionForSide(side));
+    } else if ((side === "left" && overflows.left) || (side === "right" && overflows.right)) {
+      side = flipSide(side);
+      ({ x, y } = resolvePositionForSide(side));
+    }
+  }
+
+  if (options.shift) {
+    if (side === "top" || side === "bottom") {
+      x = clamp(x, 0, Math.max(viewportWidth - floatingRect.width, 0));
+    } else {
+      y = clamp(y, 0, Math.max(viewportHeight - floatingRect.height, 0));
+    }
+  }
+
+  return {
+    x: x + scrollX,
+    y: y + scrollY,
+    placement: `${side}-${align}` as Placement
+  };
+}
+
+export function usePositioner(options: UsePositionerOptions = {}): UsePositionerResult {
+  const { anchor, floating, placement = DEFAULT_PLACEMENT, offset = DEFAULT_OFFSET, flip = true, shift = true } = options;
+  const [anchorNode, setAnchorNode] = useState<HTMLElement | null>(null);
+  const [floatingNode, setFloatingNode] = useState<HTMLElement | null>(null);
+  const [position, setPosition] = useState<PositionState>({ x: undefined, y: undefined, placement });
+
+  const resolvedAnchor = anchor ?? anchorNode;
+  const resolvedFloating = floating ?? floatingNode;
+
+  const updatePosition = useCallback(() => {
+    if (!resolvedAnchor || !resolvedFloating) return;
+    const anchorRect = resolvedAnchor.getBoundingClientRect();
+    const floatingRect = resolvedFloating.getBoundingClientRect();
+    setPosition((prev) => {
+      const next = computePosition(placement, anchorRect, floatingRect, { flip, shift, offset });
+      if (prev.x === next.x && prev.y === next.y && prev.placement === next.placement) {
+        return prev;
+      }
+      return next;
+    });
+  }, [flip, offset, placement, resolvedAnchor, resolvedFloating, shift]);
+
+  useEffect(() => {
+    if (!resolvedAnchor || !resolvedFloating) return undefined;
+
+    updatePosition();
+
+    const handleScroll = () => updatePosition();
+    const handleResize = () => updatePosition();
+
+    window.addEventListener("scroll", handleScroll, true);
+    window.addEventListener("resize", handleResize);
+
+    const resizeObserver = typeof ResizeObserver !== "undefined" ? new ResizeObserver(() => updatePosition()) : null;
+    resizeObserver?.observe(resolvedAnchor);
+    resizeObserver?.observe(resolvedFloating);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll, true);
+      window.removeEventListener("resize", handleResize);
+      resizeObserver?.disconnect();
+    };
+  }, [resolvedAnchor, resolvedFloating, updatePosition]);
+
+  useEffect(() => {
+    updatePosition();
+  }, [placement, updatePosition]);
+
+  const setAnchor = useCallback((node: HTMLElement | null) => setAnchorNode(node), []);
+  const setFloating = useCallback((node: HTMLElement | null) => setFloatingNode(node), []);
+
+  const anchorProps = useMemo<PositionerAnchorProps>(() => ({ ref: setAnchor }), [setAnchor]);
+
+  const floatingProps = useMemo<PositionerFloatingProps>(() => ({
+    ref: setFloating,
+    style: {
+      position: "absolute",
+      left: position.x,
+      top: position.y
+    }
+  }), [position.x, position.y, setFloating]);
+
+  return { anchorProps, floatingProps, placement: position.placement };
+}


### PR DESCRIPTION
## Summary
- placement, offset, flip, shift 옵션을 갖춘 usePositioner 훅으로 앵커-플로팅 배치 계산을 구현했습니다.
- 스크롤·리사이즈 이벤트와 ResizeObserver를 통해 위치를 재계산하도록 했습니다.
- 신규 훅을 공개 API에 노출하고 타입 경로를 추가했으며 동작을 검증하는 테스트를 작성했습니다.

## Testing
- pnpm --filter @ara/core test
- pnpm exec vitest run src/overlays/use-positioner.test.tsx --reporter=verbose --runInBand


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693138646ae8832285b4bc36850605de)