### PR TITLE
feat: Portal 컴포넌트 추가

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,6 +37,11 @@
       "import": "./dist/components/spacer/index.js",
       "default": "./dist/components/spacer/index.js"
     },
+    "./components/portal": {
+      "types": "./dist/components/portal/index.d.ts",
+      "import": "./dist/components/portal/index.js",
+      "default": "./dist/components/portal/index.js"
+    },
     "./components/flex": {
       "types": "./dist/components/layout/Flex.d.ts",
       "import": "./dist/components/layout/Flex.js",
@@ -91,6 +96,11 @@
       "types": "./dist/components/text-field/index.d.ts",
       "import": "./dist/components/text-field/index.js",
       "default": "./dist/components/text-field/index.js"
+    },
+    "./portal": {
+      "types": "./dist/components/portal/index.d.ts",
+      "import": "./dist/components/portal/index.js",
+      "default": "./dist/components/portal/index.js"
     },
     "./icon": {
       "types": "./dist/components/icon/index.d.ts",
@@ -159,6 +169,9 @@
       "components/spacer": [
         "dist/components/spacer/index.d.ts"
       ],
+      "components/portal": [
+        "dist/components/portal/index.d.ts"
+      ],
       "components/flex": [
         "dist/components/layout/Flex.d.ts"
       ],
@@ -194,6 +207,9 @@
       ],
       "spacer": [
         "dist/components/spacer/index.d.ts"
+      ],
+      "portal": [
+        "dist/components/portal/index.d.ts"
       ],
       "flex": [
         "dist/components/layout/Flex.d.ts"

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -2,6 +2,7 @@ export * from "./button/index.js";
 export * from "./checkbox/index.js";
 export * from "./icon/index.js";
 export * from "./layout/index.js";
+export * from "./portal/index.js";
 export * from "./radio/index.js";
 export * from "./switch/index.js";
 export * from "./spacer/index.js";

--- a/packages/react/src/components/portal/README.md
+++ b/packages/react/src/components/portal/README.md
@@ -1,0 +1,34 @@
+# Portal
+
+React 트리의 외부(DOM 계층 최상단 등)로 자식 노드를 이동시키는 컴포넌트입니다. 오버레이/모달과 같이 시맨틱 트리 밖에서 렌더링해야
+하는 UI를 단순한 API로 구성합니다.
+
+## 사용 방법
+
+```tsx
+import { Portal } from "@ara/react";
+
+function TooltipContent() {
+  return (
+    <Portal>
+      <div role="tooltip">툴팁 내용</div>
+    </Portal>
+  );
+}
+```
+
+## Props
+
+| 이름 | 타입 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **container** | `HTMLElement \| null` | 자동 생성 | 포털이 렌더링될 DOM 노드. 지정하지 않으면 `data-ara-portal-container`를 가진 `div`를 `document.body`에 생성합니다. |
+| **disablePortal** | `boolean` | `false` | `true`일 경우 포털을 사용하지 않고 자식을 현재 위치에 그대로 렌더링합니다. SSR 환경에서 `document`가 없는 경우에도 자연스럽게 동작합니다. |
+| **className** | `string` | — | 포털 컨테이너에 병합될 클래스 이름. 기존 클래스는 보존되며 `ara-portal` 기본 클래스와 함께 적용됩니다. |
+| **children** | `ReactNode` | — | 포털로 이동시킬 콘텐츠. |
+
+## 동작/고려 사항
+
+- 컨테이너를 전달하지 않으면 `usePortal` 훅이 기본 컨테이너를 생성·정리합니다.
+- 전달한 컨테이너가 StrictMode에서 중복 생성되지 않도록 `usePortal`의 내부 정리 로직을 따릅니다.
+- `className`은 컨테이너의 기존 클래스와 병합하며, 컴포넌트가 언마운트되면 원래 클래스 상태로 복원합니다.
+- 포털을 비활성화(`disablePortal`)하면 DOM 이동 없이 자식이 현재 트리에 머무르므로, SSR이나 간단한 레이아웃에서 손쉽게 폴백할 수 있습니다.

--- a/packages/react/src/components/portal/index.test.tsx
+++ b/packages/react/src/components/portal/index.test.tsx
@@ -1,0 +1,78 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import { describe, expect, it } from "vitest";
+
+import { Portal } from "./index.js";
+
+const DEFAULT_PORTAL_SELECTOR = "[data-ara-portal-container]";
+
+describe("Portal", () => {
+  afterEach(() => {
+    cleanup();
+    document.querySelectorAll(DEFAULT_PORTAL_SELECTOR).forEach((node) => node.remove());
+  });
+
+  it("기본 컨테이너를 생성해 포털로 렌더링한다", async () => {
+    render(
+      <Portal>
+        <span data-testid="portal-child">포털</span>
+      </Portal>
+    );
+
+    await waitFor(() => expect(document.querySelector(DEFAULT_PORTAL_SELECTOR)).not.toBeNull());
+    const container = document.querySelector(DEFAULT_PORTAL_SELECTOR)!;
+
+    expect(container).toHaveAttribute("data-ara-portal-container", "");
+    expect(container.className.split(" ")).toContain("ara-portal");
+    expect(container.querySelector("[data-testid='portal-child']")).toBeInTheDocument();
+  });
+
+  it("사용자 컨테이너와 className을 병합하고 언마운트 시 원복한다", async () => {
+    const customContainer = document.createElement("div");
+    customContainer.className = "existing";
+    document.body.appendChild(customContainer);
+
+    const { unmount } = render(
+      <Portal container={customContainer} className="custom">
+        <span>포털</span>
+      </Portal>
+    );
+
+    await waitFor(() => expect(customContainer.querySelector("span")).not.toBeNull());
+
+    expect(customContainer.className.split(" ")).toEqual(expect.arrayContaining(["existing", "custom", "ara-portal"]));
+
+    unmount();
+
+    expect(customContainer.className).toBe("existing");
+  });
+
+  it("disablePortal=true일 때 자식이 제자리에서 렌더링된다", () => {
+    const customContainer = document.createElement("div");
+    document.body.appendChild(customContainer);
+
+    const { getByTestId } = render(
+      <Portal container={customContainer} disablePortal>
+        <span data-testid="inline-child">인라인</span>
+      </Portal>
+    );
+
+    const child = getByTestId("inline-child");
+
+    expect(customContainer.contains(child)).toBe(false);
+    expect(child.parentElement).not.toBeNull();
+  });
+
+  it("StrictMode에서도 컨테이너를 중복 생성하지 않는다", async () => {
+    render(
+      <StrictMode>
+        <Portal>
+          <span>포털</span>
+        </Portal>
+      </StrictMode>
+    );
+
+    await waitFor(() => expect(document.querySelectorAll(DEFAULT_PORTAL_SELECTOR).length).toBe(1));
+  });
+});

--- a/packages/react/src/components/portal/index.tsx
+++ b/packages/react/src/components/portal/index.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef, type PropsWithChildren } from "react";
+import { createPortal } from "react-dom";
+import { usePortal } from "@ara/core";
+
+import { mergeClassNames } from "../layout/shared.js";
+
+export interface PortalProps extends PropsWithChildren {
+  readonly container?: HTMLElement | null;
+  readonly disablePortal?: boolean;
+  readonly className?: string;
+}
+
+const PORTAL_CLASSNAME = "ara-portal";
+
+export function Portal(props: PortalProps): JSX.Element {
+  const { children, container: containerProp, disablePortal = false, className } = props;
+
+  const { container } = usePortal({ container: containerProp, disabled: disablePortal });
+  const originalClassNameRef = useRef<string>("");
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!container || disablePortal) return undefined;
+
+    containerRef.current = container;
+    originalClassNameRef.current = container.className;
+
+    const mergedClassName = mergeClassNames(originalClassNameRef.current, PORTAL_CLASSNAME, className);
+    container.className = mergedClassName;
+
+    return () => {
+      if (!containerRef.current) return;
+      containerRef.current.className = originalClassNameRef.current;
+      containerRef.current = null;
+    };
+  }, [className, container, disablePortal]);
+
+  if (!container || disablePortal) {
+    return <>{children}</>;
+  }
+
+  return createPortal(children, container);
+}


### PR DESCRIPTION
## 요약
- Portal 컴포넌트를 추가하고 기본/사용자 컨테이너에 클래스 병합을 적용했습니다.
- disablePortal 시 인라인 렌더링, StrictMode 대응 등을 검증하는 테스트를 작성했습니다.
- 패키지 exports/typesVersions에 Portal 경로를 노출하고 README로 사용법을 정리했습니다.

## 테스트
- pnpm --filter @ara/react test -- --runInBand *(실패: 실행 환경에 pnpm/node 명령이 없어 수행하지 못했습니다)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321d02ae588322a0013d6896a5c679)