### PR TITLE
[T-000104] FocusTrap 컴포넌트 추가

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -298,6 +298,7 @@
     "@ara/tsconfig": "workspace:*",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.23",
     "@vitejs/plugin-react": "^4.3.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -37,6 +37,11 @@
       "import": "./dist/components/spacer/index.js",
       "default": "./dist/components/spacer/index.js"
     },
+    "./components/focus-trap": {
+      "types": "./dist/components/focus-trap/index.d.ts",
+      "import": "./dist/components/focus-trap/index.js",
+      "default": "./dist/components/focus-trap/index.js"
+    },
     "./components/portal": {
       "types": "./dist/components/portal/index.d.ts",
       "import": "./dist/components/portal/index.js",
@@ -96,6 +101,11 @@
       "types": "./dist/components/text-field/index.d.ts",
       "import": "./dist/components/text-field/index.js",
       "default": "./dist/components/text-field/index.js"
+    },
+    "./focus-trap": {
+      "types": "./dist/components/focus-trap/index.d.ts",
+      "import": "./dist/components/focus-trap/index.js",
+      "default": "./dist/components/focus-trap/index.js"
     },
     "./portal": {
       "types": "./dist/components/portal/index.d.ts",
@@ -169,6 +179,9 @@
       "components/spacer": [
         "dist/components/spacer/index.d.ts"
       ],
+      "components/focus-trap": [
+        "dist/components/focus-trap/index.d.ts"
+      ],
       "components/portal": [
         "dist/components/portal/index.d.ts"
       ],
@@ -207,6 +220,9 @@
       ],
       "spacer": [
         "dist/components/spacer/index.d.ts"
+      ],
+      "focus-trap": [
+        "dist/components/focus-trap/index.d.ts"
       ],
       "portal": [
         "dist/components/portal/index.d.ts"

--- a/packages/react/src/components/focus-trap/README.md
+++ b/packages/react/src/components/focus-trap/README.md
@@ -1,0 +1,36 @@
+# FocusTrap
+
+키보드 탭 포커스를 지정한 컨테이너 내부에 가두고, 언마운트 시 이전 포커스로 복구하는 컴포넌트입니다. 모달/다이얼로그 콘텐츠가 화면 전체에서 포커스를 독점해야 할 때 사용합니다.
+
+## 사용 방법
+
+```tsx
+import { FocusTrap } from "@ara/react";
+
+function DialogContent() {
+  return (
+    <FocusTrap>
+      <h2>제목</h2>
+      <p>설명</p>
+      <button>확인</button>
+    </FocusTrap>
+  );
+}
+```
+
+## Props
+
+| 이름 | 타입 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **active** | `boolean` | `true` | `false`이면 포커스 트랩을 비활성화하고 아무 동작도 하지 않습니다. |
+| **initialFocus** | `HTMLElement \| (() => HTMLElement \| null) \| null` | 첫 번째 포커스 가능한 요소 | 최초 마운트 시 포커스를 줄 요소. 반환값이나 요소가 컨테이너 내부에 있을 때만 적용됩니다. |
+| **restoreFocus** | `boolean` | `true` | 언마운트 시 트랩 활성화 이전에 포커스를 갖고 있던 요소로 되돌립니다. |
+| **asChild** | `boolean` | `false` | `true`이면 자식 요소를 그대로 컨테이너로 사용해 추가 래퍼를 만들지 않습니다. |
+| **children** | `ReactNode` | — | 포커스를 가둘 콘텐츠. |
+
+## 동작/고려 사항
+
+- 컴포넌트가 렌더링되면 앞뒤에 포커스 가드(`tabIndex=0`)가 자동으로 삽입되어 탭 순환이 컨테이너 안에서만 이루어집니다.
+- `initialFocus`가 유효하지 않으면 컨테이너 내부의 첫 번째 포커스 가능한 요소나 컨테이너 자체로 포커스를 이동합니다.
+- `restoreFocus`가 활성화된 상태에서 트랩이 언마운트되면, 트랩이 처음 활성화되기 직전에 포커스를 가졌던 요소로 복구합니다.
+- `asChild`를 사용하면 외부에서 전달한 엘리먼트가 컨테이너가 되며, `className` 등 속성은 그대로 병합됩니다.

--- a/packages/react/src/components/focus-trap/index.test.tsx
+++ b/packages/react/src/components/focus-trap/index.test.tsx
@@ -1,0 +1,105 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, afterEach } from "vitest";
+
+import { FocusTrap } from "./index.js";
+
+describe("FocusTrap", () => {
+  const user = userEvent.setup();
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("컨테이너 내부에서 탭 포커스를 순환시킨다", async () => {
+    const { getByTestId } = render(
+      <FocusTrap>
+        <button data-testid="first">첫 번째</button>
+        <button data-testid="last">마지막</button>
+      </FocusTrap>
+    );
+
+    const first = getByTestId("first");
+    const last = getByTestId("last");
+
+    await act(async () => {});
+
+    expect(first).toHaveFocus();
+
+    await act(async () => {
+      await user.tab();
+    });
+
+    expect(last).toHaveFocus();
+
+    await act(async () => {
+      await user.tab();
+    });
+
+    expect(first).toHaveFocus();
+  });
+
+  it("initialFocus가 주어지면 해당 요소에 우선 포커스한다", async () => {
+    let preferred: HTMLButtonElement | null = null;
+
+    const { getByTestId } = render(
+      <FocusTrap initialFocus={() => preferred}>
+        <button data-testid="first">첫 번째</button>
+        <button
+          data-testid="preferred"
+          ref={(node) => {
+            preferred = node;
+          }}
+        >
+          선호 포커스
+        </button>
+      </FocusTrap>
+    );
+
+    await act(async () => {});
+
+    expect(getByTestId("preferred")).toHaveFocus();
+  });
+
+  it("언마운트 시 이전 포커스를 복원한다", async () => {
+    const outsideButton = document.createElement("button");
+    document.body.appendChild(outsideButton);
+    outsideButton.focus();
+
+    const { unmount, getByTestId } = render(
+      <FocusTrap>
+        <button data-testid="inside">안쪽</button>
+      </FocusTrap>
+    );
+
+    await act(async () => {});
+
+    expect(getByTestId("inside")).toHaveFocus();
+
+    unmount();
+
+    expect(outsideButton).toHaveFocus();
+    outsideButton.remove();
+  });
+
+  it("asChild로 전달한 요소에 ref와 클래스명을 적용한다", async () => {
+    let container: HTMLElement | null = null;
+
+    const { getByTestId } = render(
+      <FocusTrap asChild className="custom" ref={(node) => (container = node)}>
+        <section data-testid="container">
+          <button>안쪽</button>
+        </section>
+      </FocusTrap>
+    );
+
+    await act(async () => {});
+
+    const element = getByTestId("container");
+
+    expect(element).toHaveAttribute("data-ara-focus-trap", "");
+    expect(element).toHaveClass("ara-focus-trap", "custom");
+    expect(container).toBe(element);
+  });
+});

--- a/packages/react/src/components/focus-trap/index.tsx
+++ b/packages/react/src/components/focus-trap/index.tsx
@@ -1,0 +1,48 @@
+import { forwardRef, type HTMLAttributes, type PropsWithChildren } from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { composeRefs } from "@radix-ui/react-compose-refs";
+import { useFocusTrap, type UseFocusTrapOptions } from "@ara/core";
+
+import { mergeClassNames } from "../layout/shared.js";
+
+type FocusTrapOptions = Pick<UseFocusTrapOptions, "active" | "initialFocus" | "restoreFocus">;
+
+export type FocusTrapProps = PropsWithChildren<FocusTrapOptions & {
+  readonly asChild?: boolean;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, keyof FocusTrapOptions | "children">;
+
+export const FocusTrap = forwardRef<HTMLElement, FocusTrapProps>(function FocusTrap(
+  props,
+  forwardedRef
+) {
+  const {
+    children,
+    asChild = false,
+    active,
+    initialFocus,
+    restoreFocus,
+    className,
+    ...restProps
+  } = props;
+
+  const { containerProps, beforeFocusGuardProps, afterFocusGuardProps } = useFocusTrap({
+    active,
+    initialFocus,
+    restoreFocus
+  });
+
+  const Component = asChild ? Slot : "div";
+  const composedRef = composeRefs<HTMLElement>(forwardedRef, containerProps.ref);
+  const resolvedClassName = mergeClassNames("ara-focus-trap", className);
+
+  return (
+    <>
+      <span {...beforeFocusGuardProps} />
+      <Component ref={composedRef} className={resolvedClassName} data-ara-focus-trap="" {...restProps}>
+        {children}
+      </Component>
+      <span {...afterFocusGuardProps} />
+    </>
+  );
+});

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -2,6 +2,7 @@ export * from "./button/index.js";
 export * from "./checkbox/index.js";
 export * from "./icon/index.js";
 export * from "./layout/index.js";
+export * from "./focus-trap/index.js";
 export * from "./portal/index.js";
 export * from "./radio/index.js";
 export * from "./switch/index.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.0.1
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.5.2(@testing-library/dom@10.4.1)
       '@types/react':
         specifier: ^18.2.64
         version: 18.3.26


### PR DESCRIPTION
## Summary
- FocusTrap 컴포넌트를 추가해 자동 포커스 가드/초기 포커스/포커스 복원 옵션을 제공했습니다.
- 테스트와 README, 패키지 exports/typesVersions를 갱신해 React 진입점을 노출했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [ ] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [ ] pnpm --filter @ara/react test -- --runInBand (Node 18 환경에서 webidl-conversions 의존성 오류로 실패)

## Screenshots
- UI 변경 없음

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932222aa3508322a2be9e39374d3a10)