### PR TITLE
Update planning records for T-000104

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -327,7 +327,7 @@ T-000102,W-000010,Overlay Primitives v0,코어(headless),usePositioner(앵커 �
 T-000103,W-000010,Overlay Primitives v0,React 바인딩,Portal 컴포넌트 구현,완료,High," ● 내용: <Portal container>·children·disablePortal 옵션; className 병합
  ● 산출물: packages/react/src/components/portal/index.tsx + README
  ● 점검: SSR/StrictMode 스모크",확인
-T-000104,W-000010,Overlay Primitives v0,React 바인딩,FocusTrap 컴포넌트 구현,계획,High," ● 내용: <FocusTrap active initialFocus restoreFocus>·포커스 센티널 자동 구성
+T-000104,W-000010,Overlay Primitives v0,React 바인딩,FocusTrap 컴포넌트 구현,완료,High," ● 내용: <FocusTrap active initialFocus restoreFocus>·포커스 센티널 자동 구성
  ● 산출물: packages/react/src/components/focus-trap/index.tsx
  ● 점검: 탭 루프·복귀 확인",확인
 T-000105,W-000010,Overlay Primitives v0,React 바인딩,DismissableLayer 컴포넌트 구현,계획,High," ● 내용: <DismissableLayer onDismiss disableOutsidePointerEvents>·중첩 스택 연동

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -68,7 +68,7 @@ W-000009,T1,Form Controls v0 Comp,완료,100,"Form Controls v0
  ● 폼: name/value 제출·reset 대응·controlled/uncontrolled
  ● Storybook/테스트/Exports 고정; canary 포함
  ● AC: CI·Tests·Storybook·ESM+types·폼 제출/키보드 시나리오 통과",--
-W-000010,T1,Overlay Primitives v0,진행,50,"Overlay Primitives v0
+W-000010,T1,Overlay Primitives v0,진행,70,"Overlay Primitives v0
  ● 설계문서 : root/packages/core/overlays/README.md · root/packages/react/src/components/overlays/README.md
  ● 범위: Portal · FocusTrap · Positioner · DismissableLayer(+ScrollLock/Stack)
  ● a11y: 포커스 트랩/복귀·배경 inert/aria-hidden·ESC/바깥 클릭·SSR-safe


### PR DESCRIPTION
## Summary
- mark T-000104 FocusTrap component as complete after verifying implementation
- raise W-000010 progress to reflect the completed FocusTrap work

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932284d43e88322a9b538c5c360addb)