### PR TITLE
README 검증/테스트 안내를 표로 재구성

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,19 @@ VS Code(Git Bash) · Windows · React+TypeScript · Node 22 LTS · pnpm(workspac
 - 새 패키지를 추가하거나 변경한 뒤에는 `pnpm run check:manifests` 로 자동 점검을 수행한다.
 
 ## 워크스페이스 검증 스크립트
-- 루트에서 `pnpm -w lint`, `pnpm -w test`, `pnpm -w build`, `pnpm -w storybook:smoke` 를 실행하면 워크스페이스 전체에 동일한 명령이 순차적으로 적용된다.
-- 위 명령을 한 번에 돌리고 싶다면 `pnpm -w workspace:check` 스크립트를 사용한다. 순서는 `lint → test → build → storybook:smoke` 이며 Storybook 단계는 개발 서버 대신 스모크 테스트 플래그를 사용해 빠르게 종료된다.
-- Changesets 기반 배포 흐름(`pnpm release`)과는 별개의 사전 점검 라인이다. 배포가 필요한 경우에는 변경 사항을 Changeset으로 기록한 뒤 `pnpm release` 를 사용한다.
-- canary 프리릴리스 드라이런 순서는 [Changesets Canary 가이드](docs/releases/canary.md)를 따른다.
+| 명령 | 설명 |
+| --- | --- |
+| `pnpm -w lint`<br>`pnpm -w test`<br>`pnpm -w build`<br>`pnpm -w storybook:smoke` | 루트에서 실행하면 워크스페이스 전체에 동일한 명령을 순차 적용한다. |
+| `pnpm -w workspace:check` | 위 네 가지 명령을 한 번에 실행한다. 순서는 `lint → test → build → storybook:smoke`이며 Storybook 단계는 개발 서버 대신 스모크 테스트 플래그를 사용해 빠르게 종료한다. |
+| `pnpm release` | Changesets 기반 배포 흐름과 별도로, 배포가 필요할 때 Changeset을 기록한 뒤 실행한다. |
+| [Changesets Canary 가이드](docs/releases/canary.md) | canary 프리릴리스 드라이런 절차를 확인한다. |
 
 ### 패키지별 테스트 실행 팁
-- **패키지 전체 테스트:** `pnpm --filter @ara/react test`
-- **단일 테스트 파일 실행:** `pnpm --filter @ara/react test -- src/components/button/Button.test.tsx`
-  - `--` 뒤에 전달하는 경로는 **패키지 루트(`packages/react`) 기준**이어야 한다. 워크스페이스 루트 경로(예: `packages/react/...`)를 전달하면 Vitest가 테스트 파일을 찾지 못한다.
-
+| 목적 | 명령 예시 | 비고 |
+| --- | --- | --- |
+| 패키지 전체 테스트 | `pnpm --filter @ara/react test` | 패키지 단위로 모든 테스트를 실행한다. |
+| 단일 테스트 파일 실행 | `pnpm --filter @ara/react test -- src/components/button/Button.test.tsx` | `--` 뒤 경로는 **패키지 루트(`packages/react`) 기준**이다. 워크스페이스 루트 경로를 전달하면 Vitest가 파일을 찾지 못한다. |
+ 
 ## 일정 (WBS/Tasks)
  **경로** : root/planning
  **WBS** : WBS.CSV

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -42,6 +42,11 @@
       "import": "./dist/components/focus-trap/index.js",
       "default": "./dist/components/focus-trap/index.js"
     },
+    "./components/dismissable-layer": {
+      "types": "./dist/components/dismissable-layer/index.d.ts",
+      "import": "./dist/components/dismissable-layer/index.js",
+      "default": "./dist/components/dismissable-layer/index.js"
+    },
     "./components/portal": {
       "types": "./dist/components/portal/index.d.ts",
       "import": "./dist/components/portal/index.js",
@@ -106,6 +111,11 @@
       "types": "./dist/components/focus-trap/index.d.ts",
       "import": "./dist/components/focus-trap/index.js",
       "default": "./dist/components/focus-trap/index.js"
+    },
+    "./dismissable-layer": {
+      "types": "./dist/components/dismissable-layer/index.d.ts",
+      "import": "./dist/components/dismissable-layer/index.js",
+      "default": "./dist/components/dismissable-layer/index.js"
     },
     "./portal": {
       "types": "./dist/components/portal/index.d.ts",
@@ -182,6 +192,9 @@
       "components/focus-trap": [
         "dist/components/focus-trap/index.d.ts"
       ],
+      "components/dismissable-layer": [
+        "dist/components/dismissable-layer/index.d.ts"
+      ],
       "components/portal": [
         "dist/components/portal/index.d.ts"
       ],
@@ -223,6 +236,9 @@
       ],
       "focus-trap": [
         "dist/components/focus-trap/index.d.ts"
+      ],
+      "dismissable-layer": [
+        "dist/components/dismissable-layer/index.d.ts"
       ],
       "portal": [
         "dist/components/portal/index.d.ts"

--- a/packages/react/src/components/dismissable-layer/index.test.tsx
+++ b/packages/react/src/components/dismissable-layer/index.test.tsx
@@ -16,10 +16,15 @@ describe("DismissableLayer", () => {
     const onDismiss = vi.fn();
 
     const { getByTestId } = render(
-      <DismissableLayer onDismiss={onDismiss}>
-        <button data-testid="inside">안쪽</button>
+      <>
+        <DismissableLayer onDismiss={onDismiss}>
+          <button data-testid="inside" autoFocus>
+            안쪽
+          </button>
+        </DismissableLayer>
+
         <button data-testid="outside">바깥</button>
-      </DismissableLayer>
+      </>
     );
 
     await act(async () => {
@@ -51,10 +56,15 @@ describe("DismissableLayer", () => {
     const onDismiss = vi.fn();
 
     const { getByTestId } = render(
-      <DismissableLayer onDismiss={onDismiss}>
-        <button data-testid="inside">안쪽</button>
+      <>
+        <DismissableLayer onDismiss={onDismiss}>
+          <button data-testid="inside" autoFocus>
+            안쪽
+          </button>
+        </DismissableLayer>
+
         <button data-testid="outside">바깥</button>
-      </DismissableLayer>
+      </>
     );
 
     await act(async () => {
@@ -70,12 +80,17 @@ describe("DismissableLayer", () => {
     const outsidePointerDown = vi.fn();
 
     const { getByTestId } = render(
-      <DismissableLayer disableOutsidePointerEvents onDismiss={onDismiss}>
-        <button data-testid="inside">안쪽</button>
+      <>
+        <DismissableLayer disableOutsidePointerEvents onDismiss={onDismiss}>
+          <button data-testid="inside" autoFocus>
+            안쪽
+          </button>
+        </DismissableLayer>
+
         <button data-testid="outside" onPointerDown={(event) => outsidePointerDown(event.defaultPrevented)}>
           바깥
         </button>
-      </DismissableLayer>
+      </>
     );
 
     await act(async () => {

--- a/packages/react/src/components/dismissable-layer/index.test.tsx
+++ b/packages/react/src/components/dismissable-layer/index.test.tsx
@@ -1,0 +1,88 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DismissableLayer } from "./index.js";
+
+describe("DismissableLayer", () => {
+  const user = userEvent.setup();
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("외부 포인터 다운 시 dismiss를 발생시킨다", async () => {
+    const onDismiss = vi.fn();
+
+    const { getByTestId } = render(
+      <DismissableLayer onDismiss={onDismiss}>
+        <button data-testid="inside">안쪽</button>
+        <button data-testid="outside">바깥</button>
+      </DismissableLayer>
+    );
+
+    await act(async () => {
+      await user.pointer({ keys: "[MouseLeft]", target: getByTestId("outside") });
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledWith("pointer");
+  });
+
+  it("Escape 키로 dismiss를 발생시킨다", async () => {
+    const onDismiss = vi.fn();
+
+    render(
+      <DismissableLayer onDismiss={onDismiss}>
+        <button>안쪽</button>
+      </DismissableLayer>
+    );
+
+    await act(async () => {
+      await user.keyboard("{Escape}");
+    });
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledWith("escape");
+  });
+
+  it("포커스가 바깥으로 이동하면 dismiss를 발생시킨다", async () => {
+    const onDismiss = vi.fn();
+
+    const { getByTestId } = render(
+      <DismissableLayer onDismiss={onDismiss}>
+        <button data-testid="inside">안쪽</button>
+        <button data-testid="outside">바깥</button>
+      </DismissableLayer>
+    );
+
+    await act(async () => {
+      await user.pointer({ keys: "[MouseLeft]", target: getByTestId("inside") });
+      await user.tab();
+    });
+
+    expect(onDismiss).toHaveBeenCalledWith("focus");
+  });
+
+  it("disableOutsidePointerEvents가 true면 바깥 포인터 이벤트를 막고 dismiss를 중단한다", async () => {
+    const onDismiss = vi.fn();
+    const outsidePointerDown = vi.fn();
+
+    const { getByTestId } = render(
+      <DismissableLayer disableOutsidePointerEvents onDismiss={onDismiss}>
+        <button data-testid="inside">안쪽</button>
+        <button data-testid="outside" onPointerDown={(event) => outsidePointerDown(event.defaultPrevented)}>
+          바깥
+        </button>
+      </DismissableLayer>
+    );
+
+    await act(async () => {
+      await user.pointer({ keys: "[MouseLeft]", target: getByTestId("outside") });
+    });
+
+    expect(outsidePointerDown).toHaveBeenCalledWith(true);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/components/dismissable-layer/index.tsx
+++ b/packages/react/src/components/dismissable-layer/index.tsx
@@ -1,0 +1,87 @@
+import { forwardRef, type HTMLAttributes, type PropsWithChildren, useCallback } from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { composeRefs } from "@radix-ui/react-compose-refs";
+import { useDismissableLayer, type DismissableLayerEvent } from "@ara/core";
+
+import { mergeClassNames } from "../layout/shared.js";
+
+type DismissReason = "escape" | "pointer" | "focus";
+
+type DismissableLayerOptions = {
+  readonly disableOutsidePointerEvents?: boolean;
+  readonly active?: boolean;
+  readonly onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  readonly onPointerDownOutside?: (event: PointerEvent) => void;
+  readonly onFocusOutside?: (event: FocusEvent) => void;
+  readonly onDismiss?: (reason: DismissReason) => void;
+  readonly asChild?: boolean;
+};
+
+export type DismissableLayerProps = PropsWithChildren<DismissableLayerOptions> &
+  Omit<HTMLAttributes<HTMLElement>, keyof DismissableLayerOptions | "children">;
+
+function mapDismissReason(event: DismissableLayerEvent): DismissReason {
+  switch (event.type) {
+    case "escape-key":
+      return "escape";
+    case "focus-outside":
+      return "focus";
+    case "pointer-down-outside":
+    default:
+      return "pointer";
+  }
+}
+
+export const DismissableLayer = forwardRef<HTMLElement, DismissableLayerProps>(function DismissableLayer(
+  props,
+  forwardedRef
+) {
+  const {
+    children,
+    asChild = false,
+    disableOutsidePointerEvents = false,
+    active,
+    onEscapeKeyDown,
+    onPointerDownOutside,
+    onFocusOutside,
+    onDismiss,
+    className,
+    ...restProps
+  } = props;
+
+  const handleDismiss = useCallback(
+    (event: DismissableLayerEvent) => {
+      onDismiss?.(mapDismissReason(event));
+    },
+    [onDismiss]
+  );
+
+  const handlePointerDownOutside = useCallback(
+    (event: PointerEvent) => {
+      if (disableOutsidePointerEvents && !event.defaultPrevented) {
+        event.preventDefault();
+      }
+
+      onPointerDownOutside?.(event);
+    },
+    [disableOutsidePointerEvents, onPointerDownOutside]
+  );
+
+  const { containerProps } = useDismissableLayer({
+    active,
+    onDismiss: handleDismiss,
+    onEscapeKeyDown,
+    onPointerDownOutside: handlePointerDownOutside,
+    onFocusOutside
+  });
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-dismissable-layer", className);
+  const composedRef = composeRefs<HTMLElement>(forwardedRef, containerProps.ref);
+
+  return (
+    <Component ref={composedRef} className={resolvedClassName} data-ara-dismissable-layer="" {...restProps}>
+      {children}
+    </Component>
+  );
+});

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -3,6 +3,7 @@ export * from "./checkbox/index.js";
 export * from "./icon/index.js";
 export * from "./layout/index.js";
 export * from "./focus-trap/index.js";
+export * from "./dismissable-layer/index.js";
 export * from "./portal/index.js";
 export * from "./radio/index.js";
 export * from "./switch/index.js";

--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -330,7 +330,7 @@ T-000103,W-000010,Overlay Primitives v0,React 바인딩,Portal 컴포넌트 구�
 T-000104,W-000010,Overlay Primitives v0,React 바인딩,FocusTrap 컴포넌트 구현,완료,High," ● 내용: <FocusTrap active initialFocus restoreFocus>·포커스 센티널 자동 구성
  ● 산출물: packages/react/src/components/focus-trap/index.tsx
  ● 점검: 탭 루프·복귀 확인",확인
-T-000105,W-000010,Overlay Primitives v0,React 바인딩,DismissableLayer 컴포넌트 구현,계획,High," ● 내용: <DismissableLayer onDismiss disableOutsidePointerEvents>·중첩 스택 연동
+T-000105,W-000010,Overlay Primitives v0,React 바인딩,DismissableLayer 컴포넌트 구현,완료,High," ● 내용: <DismissableLayer onDismiss disableOutsidePointerEvents>·중첩 스택 연동
  ● 산출물: packages/react/src/components/dismissable-layer/index.tsx
  ● 점검: ESC/외부클릭·내부 드래그 예외",확인
 T-000106,W-000010,Overlay Primitives v0,React 바인딩,Positioner 컴포넌트/훅 구현,계획,High," ● 내용: <Positioner anchorRef placement offset strategy(absolute|fixed) withArrow>·스타일 훅(data-placement)

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -68,7 +68,7 @@ W-000009,T1,Form Controls v0 Comp,완료,100,"Form Controls v0
  ● 폼: name/value 제출·reset 대응·controlled/uncontrolled
  ● Storybook/테스트/Exports 고정; canary 포함
  ● AC: CI·Tests·Storybook·ESM+types·폼 제출/키보드 시나리오 통과",--
-W-000010,T1,Overlay Primitives v0,진행,70,"Overlay Primitives v0
+W-000010,T1,Overlay Primitives v0,진행,75,"Overlay Primitives v0
  ● 설계문서 : root/packages/core/overlays/README.md · root/packages/react/src/components/overlays/README.md
  ● 범위: Portal · FocusTrap · Positioner · DismissableLayer(+ScrollLock/Stack)
  ● a11y: 포커스 트랩/복귀·배경 inert/aria-hidden·ESC/바깥 클릭·SSR-safe


### PR DESCRIPTION
## 요약
- 워크스페이스 검증 스크립트 안내를 표 형태로 정리해 명령과 설명을 한눈에 제공했습니다.
- 패키지별 테스트 실행 팁을 목적/명령/비고로 구분한 표로 변경해 경로 기준 주의 사항을 강조했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932291f75ac8322bf566d96c75c42aa)