### PR TITLE
feat: Positioner 훅과 컴포넌트 추가

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -64,7 +64,14 @@ export type { UsePortalOptions, UsePortalResult } from "./overlays/use-portal.js
 export { usePortal } from "./overlays/use-portal.js";
 export type { UseDismissableLayerOptions, UseDismissableLayerResult, DismissableLayerContainerProps, DismissableLayerEvent } from "./overlays/use-dismissable-layer.js";
 export { useDismissableLayer } from "./overlays/use-dismissable-layer.js";
-export type { Placement, PositionerAnchorProps, PositionerFloatingProps, UsePositionerOptions, UsePositionerResult } from "./overlays/use-positioner.js";
+export type {
+  Placement,
+  PositionerAnchorProps,
+  PositionerFloatingProps,
+  PositionStrategy,
+  UsePositionerOptions,
+  UsePositionerResult
+} from "./overlays/use-positioner.js";
 export { usePositioner } from "./overlays/use-positioner.js";
 export type {
   FocusGuardProps,

--- a/packages/core/src/overlays/use-positioner.test.tsx
+++ b/packages/core/src/overlays/use-positioner.test.tsx
@@ -99,6 +99,31 @@ describe("usePositioner", () => {
     });
   });
 
+  it("strategy가 fixed이면 스크롤 보정 없이 뷰포트 기준 좌표를 사용한다", async () => {
+    Object.defineProperty(window, "scrollX", { value: 120, configurable: true });
+    Object.defineProperty(window, "scrollY", { value: 200, configurable: true });
+
+    const anchorRect = createRect({ x: 20, y: 30, width: 40, height: 20 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 10, height: 10 });
+    const { anchor, floating } = setupElements(anchorRect, floatingRect);
+
+    const { result } = renderHook(() => usePositioner({ strategy: "fixed" }));
+
+    act(() => {
+      result.current.anchorProps.ref(anchor);
+      result.current.floatingProps.ref(floating);
+    });
+
+    await waitFor(() => {
+      expect(result.current.floatingProps.style.left).toBeCloseTo(20);
+      expect(result.current.floatingProps.style.top).toBeCloseTo(50);
+      expect(result.current.floatingProps.style.position).toBe("fixed");
+    });
+
+    Object.defineProperty(window, "scrollX", { value: 0, configurable: true });
+    Object.defineProperty(window, "scrollY", { value: 0, configurable: true });
+  });
+
   it("뷰포트 밖으로 나갈 경우 반대편으로 뒤집는다", async () => {
     const anchorRect = createRect({ x: 300, y: 700, width: 60, height: 50 });
     const floatingRect = createRect({ x: 0, y: 0, width: 80, height: 40 });

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -8,5 +8,6 @@ export * from "./portal/index.js";
 export * from "./radio/index.js";
 export * from "./switch/index.js";
 export * from "./spacer/index.js";
+export * from "./positioner/index.js";
 export * from "./theme-provider/index.js";
 export * from "./text-field/index.js";

--- a/packages/react/src/components/positioner/index.test.tsx
+++ b/packages/react/src/components/positioner/index.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, render, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useLayoutEffect, useRef } from "react";
 
 import { Positioner, usePositioner } from "./index.js";
@@ -22,6 +22,11 @@ function createRect({ x, y, width, height }: RectInit): DOMRect {
 }
 
 describe("usePositioner (React)", () => {
+  beforeEach(() => {
+    Object.defineProperty(document.documentElement, "clientWidth", { value: 1024, configurable: true });
+    Object.defineProperty(document.documentElement, "clientHeight", { value: 768, configurable: true });
+  });
+
   afterEach(() => {
     cleanup();
     document.body.innerHTML = "";
@@ -87,6 +92,11 @@ describe("usePositioner (React)", () => {
 });
 
 describe("Positioner 컴포넌트", () => {
+  beforeEach(() => {
+    Object.defineProperty(document.documentElement, "clientWidth", { value: 1024, configurable: true });
+    Object.defineProperty(document.documentElement, "clientHeight", { value: 768, configurable: true });
+  });
+
   afterEach(() => {
     cleanup();
     document.body.innerHTML = "";

--- a/packages/react/src/components/positioner/index.test.tsx
+++ b/packages/react/src/components/positioner/index.test.tsx
@@ -1,0 +1,145 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useLayoutEffect, useRef } from "react";
+
+import { Positioner, usePositioner } from "./index.js";
+
+type RectInit = { x: number; y: number; width: number; height: number };
+
+function createRect({ x, y, width, height }: RectInit): DOMRect {
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+    toJSON: () => ({ x, y, width, height })
+  } as DOMRect;
+}
+
+describe("usePositioner (React)", () => {
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  it("anchorRef와 floatingRef를 사용해 위치를 계산하고 data-placement를 노출한다", async () => {
+    const anchorRect = createRect({ x: 100, y: 100, width: 50, height: 40 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 80, height: 30 });
+
+    const anchor = document.createElement("div");
+    anchor.getBoundingClientRect = () => anchorRect;
+    const floating = document.createElement("div");
+    floating.getBoundingClientRect = () => floatingRect;
+
+    const anchorRef = { current: anchor } satisfies { current: HTMLDivElement | null };
+    const floatingRef = { current: floating } satisfies { current: HTMLDivElement | null };
+
+    const { result } = renderHook(() => usePositioner({ anchorRef, floatingRef, placement: "top-end" }));
+
+    act(() => {
+      result.current.anchorProps.ref(anchor);
+      result.current.floatingProps.ref(floating);
+    });
+
+    await waitFor(() => {
+      expect(result.current.floatingProps.style.left).toBeCloseTo(70);
+      expect(result.current.floatingProps.style.top).toBeCloseTo(70);
+      expect(result.current.floatingProps["data-placement"]).toBe("top-end");
+    });
+  });
+
+  it("withArrow 옵션 사용 시 화살표 좌표와 방향 속성을 제공한다", async () => {
+    const anchorRect = createRect({ x: 100, y: 100, width: 50, height: 40 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 80, height: 30 });
+
+    const anchor = document.createElement("div");
+    anchor.getBoundingClientRect = () => anchorRect;
+    const floating = document.createElement("div");
+    floating.getBoundingClientRect = () => floatingRect;
+
+    const anchorRef = { current: anchor } satisfies { current: HTMLDivElement | null };
+    const floatingRef = { current: floating } satisfies { current: HTMLDivElement | null };
+
+    const { result } = renderHook(() => usePositioner({ anchorRef, floatingRef, withArrow: true }));
+
+    const arrow = document.createElement("div");
+    Object.defineProperty(arrow, "offsetWidth", { value: 10 });
+    Object.defineProperty(arrow, "offsetHeight", { value: 10 });
+
+    act(() => {
+      result.current.anchorProps.ref(anchor);
+      result.current.floatingProps.ref(floating);
+      result.current.arrowProps?.ref(arrow);
+    });
+
+    await waitFor(() => {
+      expect(result.current.arrowProps?.style.left).toBeCloseTo(20);
+      expect(result.current.arrowProps?.style.top).toBeUndefined();
+      expect(result.current.arrowProps?.["data-side"]).toBe("bottom");
+      expect(result.current.arrowProps?.["data-align"]).toBe("start");
+    });
+  });
+});
+
+describe("Positioner 컴포넌트", () => {
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+  });
+
+  it("컨테이너에 ref, 클래스, data-placement를 적용한다", async () => {
+    const anchorRect = createRect({ x: 40, y: 50, width: 60, height: 30 });
+    const floatingRect = createRect({ x: 0, y: 0, width: 70, height: 20 });
+
+    function Example() {
+      const anchorRef = useRef<HTMLDivElement | null>(null);
+      const floatingRef = useRef<HTMLElement | null>(null);
+
+      useLayoutEffect(() => {
+        if (anchorRef.current) {
+          anchorRef.current.getBoundingClientRect = () => anchorRect;
+        }
+
+        if (floatingRef.current) {
+          floatingRef.current.getBoundingClientRect = () => floatingRect;
+        }
+      });
+
+      return (
+        <>
+          <div ref={anchorRef} data-testid="anchor">
+            anchor
+          </div>
+          <Positioner
+            anchorRef={anchorRef}
+            className="custom"
+            ref={(node) => {
+              floatingRef.current = node;
+              if (node) {
+                node.getBoundingClientRect = () => floatingRect;
+              }
+            }}
+          >
+            <span data-testid="content">콘텐츠</span>
+          </Positioner>
+        </>
+      );
+    }
+
+    const { getByTestId } = render(<Example />);
+
+    await waitFor(() => {
+      const container = getByTestId("content").parentElement as HTMLElement;
+
+      expect(container).toHaveAttribute("data-placement", "bottom-start");
+      expect(container).toHaveClass("ara-positioner", "custom");
+      expect(Number.parseFloat(container.style.left)).toBeCloseTo(40);
+      expect(Number.parseFloat(container.style.top)).toBeCloseTo(80);
+    });
+  });
+});

--- a/packages/react/src/components/positioner/index.tsx
+++ b/packages/react/src/components/positioner/index.tsx
@@ -1,0 +1,68 @@
+import { forwardRef, type HTMLAttributes, type PropsWithChildren, type ReactNode, type RefObject } from "react";
+import { composeRefs } from "@radix-ui/react-compose-refs";
+import { Slot } from "@radix-ui/react-slot";
+
+import { mergeClassNames } from "../layout/shared.js";
+import {
+  usePositioner,
+  type Placement,
+  type PositionerArrowProps,
+  type PositionStrategy
+} from "./use-positioner.js";
+
+export type PositionerProps = PropsWithChildren<{
+  readonly anchorRef?: RefObject<HTMLElement | null>;
+  readonly placement?: Placement;
+  readonly offset?: number;
+  readonly strategy?: PositionStrategy;
+  readonly withArrow?: boolean;
+  readonly asChild?: boolean;
+  readonly renderArrow?: (props: PositionerArrowProps) => ReactNode;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children" | "className"> & { readonly className?: string };
+
+export const Positioner = forwardRef<HTMLElement, PositionerProps>(function Positioner(props, forwardedRef) {
+  const {
+    children,
+    anchorRef,
+    placement,
+    offset,
+    strategy,
+    withArrow = false,
+    renderArrow,
+    asChild = false,
+    className,
+    style: userStyle,
+    ...restProps
+  } = props;
+
+  const { floatingProps, arrowProps } = usePositioner({
+    anchorRef,
+    placement,
+    offset,
+    strategy,
+    withArrow: withArrow || Boolean(renderArrow)
+  });
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-positioner", className);
+  const { ref: floatingRef, style: floatingStyle, ...restFloatingProps } = floatingProps;
+  const composedRef = composeRefs<HTMLElement>(forwardedRef, floatingRef);
+
+  return (
+    <Component
+      ref={composedRef}
+      className={resolvedClassName}
+      {...restFloatingProps}
+      {...restProps}
+      style={{ ...floatingStyle, ...(userStyle ?? {}) }}
+    >
+      {children}
+      {arrowProps &&
+        (renderArrow ? renderArrow(arrowProps) : <span {...arrowProps} className="ara-positioner__arrow" />)}
+    </Component>
+  );
+});
+
+export { usePositioner } from "./use-positioner.js";
+export type { UsePositionerOptions, UsePositionerResult, PositionerArrowProps, PositionStrategy } from "./use-positioner.js";

--- a/packages/react/src/components/positioner/use-positioner.ts
+++ b/packages/react/src/components/positioner/use-positioner.ts
@@ -7,7 +7,7 @@ import {
   type PositionStrategy
 } from "@ara/core";
 
-export type { PositionStrategy };
+export type { Placement, PositionStrategy };
 
 type Side = "top" | "bottom" | "left" | "right";
 type Align = "start" | "center" | "end";

--- a/packages/react/src/components/positioner/use-positioner.ts
+++ b/packages/react/src/components/positioner/use-positioner.ts
@@ -71,8 +71,10 @@ export function usePositioner(options: UsePositionerOptions = {}): UsePositioner
     const anchorCenterX = anchorRect.left + anchorRect.width / 2 + (coreFloatingProps.style.position === "absolute" ? scrollX : 0);
     const anchorCenterY = anchorRect.top + anchorRect.height / 2 + (coreFloatingProps.style.position === "absolute" ? scrollY : 0);
 
-    const floatingLeft = floatingRect.left + (coreFloatingProps.style.position === "absolute" ? scrollX : 0);
-    const floatingTop = floatingRect.top + (coreFloatingProps.style.position === "absolute" ? scrollY : 0);
+    const floatingLeft = (typeof coreFloatingProps.style.left === "number" ? coreFloatingProps.style.left : floatingRect.left) +
+      (coreFloatingProps.style.position === "absolute" ? scrollX : 0);
+    const floatingTop = (typeof coreFloatingProps.style.top === "number" ? coreFloatingProps.style.top : floatingRect.top) +
+      (coreFloatingProps.style.position === "absolute" ? scrollY : 0);
     const arrowHalfWidth = (arrowNode.offsetWidth ?? 0) / 2;
     const arrowHalfHeight = (arrowNode.offsetHeight ?? 0) / 2;
 

--- a/packages/react/src/components/positioner/use-positioner.ts
+++ b/packages/react/src/components/positioner/use-positioner.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useState, type CSSProperties, type RefObject } from "react";
+import {
+  usePositioner as useCorePositioner,
+  type Placement,
+  type PositionerAnchorProps,
+  type PositionerFloatingProps,
+  type PositionStrategy
+} from "@ara/core";
+
+export type { PositionStrategy };
+
+type Side = "top" | "bottom" | "left" | "right";
+type Align = "start" | "center" | "end";
+
+export interface PositionerArrowProps {
+  readonly ref: (node: HTMLElement | null) => void;
+  readonly style: CSSProperties;
+  readonly "data-side": Side;
+  readonly "data-align": Align;
+}
+
+export interface UsePositionerOptions {
+  readonly anchorRef?: RefObject<HTMLElement | null>;
+  readonly floatingRef?: RefObject<HTMLElement | null>;
+  readonly placement?: Placement;
+  readonly offset?: number;
+  readonly strategy?: PositionStrategy;
+  readonly withArrow?: boolean;
+}
+
+export interface UsePositionerResult {
+  readonly anchorProps: PositionerAnchorProps;
+  readonly floatingProps: PositionerFloatingProps & { readonly "data-placement": Placement };
+  readonly arrowProps?: PositionerArrowProps;
+  readonly placement: Placement;
+}
+
+function parsePlacement(placement: Placement): { side: Side; align: Align } {
+  const [side, align] = placement.split("-") as [Side, Align];
+  return { side, align };
+}
+
+export function usePositioner(options: UsePositionerOptions = {}): UsePositionerResult {
+  const { anchorRef, floatingRef, placement, offset, strategy, withArrow = false } = options;
+
+  const [localAnchor, setLocalAnchor] = useState<HTMLElement | null>(null);
+  const [localFloating, setLocalFloating] = useState<HTMLElement | null>(null);
+  const [arrowNode, setArrowNode] = useState<HTMLElement | null>(null);
+  const [arrowStyle, setArrowStyle] = useState<CSSProperties>({ position: "absolute" });
+
+  const resolvedAnchor = anchorRef?.current ?? localAnchor;
+  const resolvedFloating = floatingRef?.current ?? localFloating;
+
+  const { anchorProps: coreAnchorProps, floatingProps: coreFloatingProps, placement: resolvedPlacement } = useCorePositioner({
+    anchor: resolvedAnchor,
+    floating: resolvedFloating,
+    placement,
+    offset,
+    strategy
+  });
+
+  const updateArrowPosition = useCallback(() => {
+    if (!withArrow || !arrowNode || !resolvedAnchor || !resolvedFloating) return;
+
+    const anchorRect = resolvedAnchor.getBoundingClientRect();
+    const floatingRect = resolvedFloating.getBoundingClientRect();
+    const { side, align } = parsePlacement(resolvedPlacement);
+
+    const scrollX = window.scrollX ?? window.pageXOffset ?? 0;
+    const scrollY = window.scrollY ?? window.pageYOffset ?? 0;
+    const anchorCenterX = anchorRect.left + anchorRect.width / 2 + (coreFloatingProps.style.position === "absolute" ? scrollX : 0);
+    const anchorCenterY = anchorRect.top + anchorRect.height / 2 + (coreFloatingProps.style.position === "absolute" ? scrollY : 0);
+
+    const floatingLeft = floatingRect.left + (coreFloatingProps.style.position === "absolute" ? scrollX : 0);
+    const floatingTop = floatingRect.top + (coreFloatingProps.style.position === "absolute" ? scrollY : 0);
+    const arrowHalfWidth = (arrowNode.offsetWidth ?? 0) / 2;
+    const arrowHalfHeight = (arrowNode.offsetHeight ?? 0) / 2;
+
+    const position: CSSProperties = { position: "absolute" };
+
+    if (side === "top" || side === "bottom") {
+      position.left = anchorCenterX - floatingLeft - arrowHalfWidth;
+    }
+
+    if (side === "left" || side === "right") {
+      position.top = anchorCenterY - floatingTop - arrowHalfHeight;
+    }
+
+    setArrowStyle(position);
+  }, [arrowNode, coreFloatingProps.style.position, resolvedAnchor, resolvedFloating, resolvedPlacement, withArrow]);
+
+  useEffect(() => {
+    updateArrowPosition();
+  }, [updateArrowPosition, coreFloatingProps.style.left, coreFloatingProps.style.top]);
+
+  const anchorProps = useMemo<PositionerAnchorProps>(
+    () => ({
+      ref: (node: HTMLElement | null) => {
+        setLocalAnchor(node);
+        coreAnchorProps.ref(node);
+      }
+    }),
+    [coreAnchorProps]
+  );
+
+  const floatingProps = useMemo<UsePositionerResult["floatingProps"]>(
+    () => ({
+      ref: (node: HTMLElement | null) => {
+        setLocalFloating(node);
+        coreFloatingProps.ref(node);
+      },
+      style: coreFloatingProps.style,
+      "data-placement": resolvedPlacement
+    }),
+    [coreFloatingProps, resolvedPlacement]
+  );
+
+  const arrowProps = useMemo<PositionerArrowProps | undefined>(() => {
+    if (!withArrow) return undefined;
+
+    const { side, align } = parsePlacement(resolvedPlacement);
+
+    return {
+      ref: setArrowNode,
+      style: arrowStyle,
+      "data-side": side,
+      "data-align": align
+    };
+  }, [arrowStyle, resolvedPlacement, withArrow]);
+
+  return { anchorProps, floatingProps, arrowProps, placement: resolvedPlacement };
+}


### PR DESCRIPTION
## Summary
- 코어 usePositioner에 strategy 옵션을 추가해 absolute/fixed 배치를 모두 지원합니다.
- React usePositioner/Positioner와 화살표 데이터 속성을 제공해 오버레이 배치 기능을 구현했습니다.
- Positioner 훅·컴포넌트에 대한 단위 테스트를 추가했습니다.

## Testing
- pnpm --filter @ara/core test -- src/overlays/use-positioner.test.tsx (jsdom의 parse5 ESM require 오류로 실패)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693230a6304883228f2d9ed98221d8f2)