### PR TITLE
[W-000010][T-000107] inert 타입 선언 추가

### DIFF
--- a/docs/overlay-contract.md
+++ b/docs/overlay-contract.md
@@ -54,6 +54,7 @@
   - 캡처 단계 포인터 감시로 내부→외부로 이동하는 드래그(press inside, release outside)를 dismiss 대상으로 취급하지 않는다.
   - 스택 최상단만 ESC/외부 상호작용을 처리한다. 하위 레이어는 이벤트에 반응하지 않는다.
   - 포커스가 바깥으로 이동하려 할 때 `onFocusOutside` 후 `preventDefault()` 여부에 따라 유지 또는 dismiss를 결정한다.
+  - 모달 시 오버레이 이외의 형제 DOM을 `inert` + `aria-hidden="true"`로 전환해 스크린 리더·포커스 유출을 차단하고, 언마운트 시 이전 상태로 복원한다.
 
 ## Positioner
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/overlays/use-portal.js",
       "default": "./dist/overlays/use-portal.js"
     },
+    "./overlays/use-aria-hidden": {
+      "types": "./dist/overlays/use-aria-hidden.d.ts",
+      "import": "./dist/overlays/use-aria-hidden.js",
+      "default": "./dist/overlays/use-aria-hidden.js"
+    },
     "./overlays/use-dismissable-layer": {
       "types": "./dist/overlays/use-dismissable-layer.d.ts",
       "import": "./dist/overlays/use-dismissable-layer.js",
@@ -66,6 +71,9 @@
       ],
       "overlays/use-portal": [
         "dist/overlays/use-portal.d.ts"
+      ],
+      "overlays/use-aria-hidden": [
+        "dist/overlays/use-aria-hidden.d.ts"
       ],
       "overlays/use-dismissable-layer": [
         "dist/overlays/use-dismissable-layer.d.ts"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -60,6 +60,12 @@ export type {
   UseRadioGroupResult
 } from "./use-radio-group.js";
 export { useRadioGroup } from "./use-radio-group.js";
+export type {
+  AriaHiddenContainerProps,
+  UseAriaHiddenOptions,
+  UseAriaHiddenResult
+} from "./overlays/use-aria-hidden.js";
+export { useAriaHidden } from "./overlays/use-aria-hidden.js";
 export type { UsePortalOptions, UsePortalResult } from "./overlays/use-portal.js";
 export { usePortal } from "./overlays/use-portal.js";
 export type { UseDismissableLayerOptions, UseDismissableLayerResult, DismissableLayerContainerProps, DismissableLayerEvent } from "./overlays/use-dismissable-layer.js";

--- a/packages/core/src/overlays/use-aria-hidden.test.tsx
+++ b/packages/core/src/overlays/use-aria-hidden.test.tsx
@@ -1,0 +1,132 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+
+import { useAriaHidden } from "./use-aria-hidden.js";
+
+describe("useAriaHidden", () => {
+  const user = userEvent.setup();
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("hides siblings with aria-hidden and inert by default", async () => {
+    function Modal() {
+      const { containerProps } = useAriaHidden();
+
+      return (
+        <div>
+          <div data-testid="background">background</div>
+          <div data-testid="overlay" {...containerProps}>
+            overlay
+          </div>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<Modal />);
+
+    await act(async () => {
+      await user.tab();
+    });
+
+    const background = getByTestId("background");
+    const overlay = getByTestId("overlay");
+
+    expect(background).toHaveAttribute("aria-hidden", "true");
+    expect(background).toHaveAttribute("inert", "");
+    expect(overlay).not.toHaveAttribute("aria-hidden");
+  });
+
+  it("restores previous attributes when deactivated", async () => {
+    function Modal() {
+      const [open, setOpen] = useState(true);
+      const { containerProps } = useAriaHidden({ active: open });
+
+      return (
+        <div>
+          <div data-testid="background" aria-hidden="false" inert="">
+            background
+          </div>
+          {open ? (
+            <div data-testid="overlay" {...containerProps}>
+              overlay
+              <button onClick={() => setOpen(false)}>close</button>
+            </div>
+          ) : null}
+        </div>
+      );
+    }
+
+    const { getByText, getByTestId } = render(<Modal />);
+
+    expect(getByTestId("background")).toHaveAttribute("aria-hidden", "true");
+
+    await act(async () => {
+      await user.click(getByText("close"));
+    });
+
+    expect(getByTestId("background")).toHaveAttribute("aria-hidden", "false");
+    expect(getByTestId("background")).toHaveAttribute("inert", "");
+  });
+
+  it("keeps background hidden until the last overlay is removed", async () => {
+    function Modal({ label }: { label: string }) {
+      const { containerProps } = useAriaHidden();
+
+      return (
+        <div data-testid={`overlay-${label}`} {...containerProps}>
+          overlay-{label}
+        </div>
+      );
+    }
+
+    function Scene() {
+      const [showSecond, setShowSecond] = useState(true);
+
+      return (
+        <div>
+          <div data-testid="background">background</div>
+          <Modal label="one" />
+          {showSecond ? <Modal label="two" /> : null}
+          <button onClick={() => setShowSecond(false)}>remove</button>
+        </div>
+      );
+    }
+
+    const { getByTestId, getByText } = render(<Scene />);
+
+    const background = getByTestId("background");
+    expect(background).toHaveAttribute("aria-hidden", "true");
+
+    await act(async () => {
+      await user.click(getByText("remove"));
+    });
+
+    expect(background).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("can disable inert while keeping aria-hidden", () => {
+    function Modal() {
+      const { containerProps } = useAriaHidden({ inert: false });
+
+      return (
+        <div>
+          <div data-testid="background">background</div>
+          <div data-testid="overlay" {...containerProps}>
+            overlay
+          </div>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<Modal />);
+    const background = getByTestId("background");
+
+    expect(background).toHaveAttribute("aria-hidden", "true");
+    expect(background).not.toHaveAttribute("inert");
+  });
+});

--- a/packages/core/src/overlays/use-aria-hidden.ts
+++ b/packages/core/src/overlays/use-aria-hidden.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export interface UseAriaHiddenOptions {
+  readonly active?: boolean;
+  readonly container?: HTMLElement | null;
+  readonly inert?: boolean;
+}
+
+export interface UseAriaHiddenResult {
+  readonly containerProps: AriaHiddenContainerProps;
+}
+
+export interface AriaHiddenContainerProps {
+  readonly ref: (node: HTMLElement | null) => void;
+}
+
+type InertableElement = HTMLElement & { inert?: boolean };
+
+interface HiddenElementState {
+  readonly ariaHidden: string | null;
+  readonly inertAttribute: boolean;
+  readonly inertValue: boolean | undefined;
+}
+
+const hiddenCounts = new WeakMap<HTMLElement, number>();
+const hiddenStates = new WeakMap<HTMLElement, HiddenElementState>();
+
+function isHTMLElement(node: unknown): node is HTMLElement {
+  return node instanceof HTMLElement;
+}
+
+function setElementHidden(element: HTMLElement, enableInert: boolean) {
+  const count = hiddenCounts.get(element) ?? 0;
+
+  if (count === 0) {
+    hiddenStates.set(element, {
+      ariaHidden: element.getAttribute("aria-hidden"),
+      inertAttribute: element.hasAttribute("inert"),
+      inertValue: (element as InertableElement).inert
+    });
+  }
+
+  hiddenCounts.set(element, count + 1);
+  element.setAttribute("aria-hidden", "true");
+
+  if (enableInert) {
+    const inertable = element as InertableElement;
+    inertable.inert = true;
+    element.setAttribute("inert", "");
+  }
+}
+
+function restoreElementHidden(element: HTMLElement, enableInert: boolean) {
+  const count = hiddenCounts.get(element) ?? 0;
+  if (count <= 0) return;
+
+  if (count > 1) {
+    hiddenCounts.set(element, count - 1);
+    return;
+  }
+
+  hiddenCounts.delete(element);
+  const previousState = hiddenStates.get(element);
+  if (!previousState) return;
+
+  if (previousState.ariaHidden === null) {
+    element.removeAttribute("aria-hidden");
+  } else {
+    element.setAttribute("aria-hidden", previousState.ariaHidden);
+  }
+
+  if (enableInert) {
+    const inertable = element as InertableElement;
+    inertable.inert = previousState.inertValue ?? false;
+
+    if (previousState.inertAttribute) {
+      element.setAttribute("inert", "");
+    } else {
+      element.removeAttribute("inert");
+    }
+  }
+}
+
+function collectElementsToHide(node: HTMLElement): HTMLElement[] {
+  const elements = new Set<HTMLElement>();
+  let current: HTMLElement | null = node;
+
+  while (current) {
+    const parent: HTMLElement | null = current.parentElement;
+    if (!parent) break;
+
+    Array.from(parent.children).forEach((sibling) => {
+      if (sibling === current) return;
+      if (isHTMLElement(sibling)) {
+        elements.add(sibling);
+      }
+    });
+
+    if (parent === document.body || parent === document.documentElement) {
+      break;
+    }
+
+    current = parent;
+  }
+
+  return Array.from(elements);
+}
+
+export function useAriaHidden(options: UseAriaHiddenOptions = {}): UseAriaHiddenResult {
+  const { active = true, container, inert = true } = options;
+  const [containerNode, setContainerNode] = useState<HTMLElement | null>(null);
+  const resolvedContainer = container ?? containerNode;
+
+  const setContainer = useCallback((node: HTMLElement | null) => {
+    setContainerNode(node);
+  }, []);
+
+  useEffect(() => {
+    if (!active || !resolvedContainer) return undefined;
+
+    const elementsToHide = collectElementsToHide(resolvedContainer);
+    elementsToHide.forEach((element) => setElementHidden(element, inert));
+
+    return () => {
+      elementsToHide.forEach((element) => restoreElementHidden(element, inert));
+    };
+  }, [active, inert, resolvedContainer]);
+
+  const containerProps = useMemo<AriaHiddenContainerProps>(() => ({ ref: setContainer }), [setContainer]);
+
+  return { containerProps };
+}

--- a/packages/core/src/react-inert.d.ts
+++ b/packages/core/src/react-inert.d.ts
@@ -1,0 +1,11 @@
+import "react";
+
+declare module "react" {
+  interface HTMLAttributes<T> {
+    /**
+     * Global `inert` attribute support for browsers that implement it.
+     * Accepts boolean or string forms used by React (e.g., "", "true").
+     */
+    inert?: boolean | "" | "true";
+  }
+}


### PR DESCRIPTION
## Summary
- React `HTMLAttributes`에 `inert` 속성을 허용하는 타입 선언을 추가해 테스트의 타입 오류를 해소했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [ ] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [ ] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [ ] pnpm -r run test (환경에 pnpm이 설치되어 있지 않아 실행하지 못했습니다)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932477de3a0832295b94c0ffdf66b07)