### PR TITLE
Update overlay integration planning status

### DIFF
--- a/planning/Tasks.csv
+++ b/planning/Tasks.csv
@@ -348,7 +348,7 @@ T-000109,W-000010,Overlay Primitives v0,테스트,Vitest+RTL 상호작용 테스
 T-000110,W-000010,Overlay Primitives v0,문서/스토리북,Stories/MDX(각 프리미티브),완료,Medium," ● 내용: Portal/FocusTrap/Positioner/DismissableLayer 데모; 중첩/스크롤/배치 컨트롤
  ● 산출물: stories 및 MDX
  ● 점검: build-storybook 스모크",확인
-T-000111,W-000010,Overlay Primitives v0,통합,메뉴/다이얼로그 예비 스모크,계획,Medium," ● 내용: Button 토글로 메뉴/모달 모의 구성(오버레이 프리미티브 조합)·회귀 체크
+T-000111,W-000010,Overlay Primitives v0,통합,메뉴/다이얼로그 예비 스모크,완료,Medium," ● 내용: Button 토글로 메뉴/모달 모의 구성(오버레이 프리미티브 조합)·회귀 체크
  ● 산출물: showcase 또는 stories
  ● 점검: 스택/포커스/스크롤 정상",확인
 T-000112,W-000010,Overlay Primitives v0,빌드/출하,Exports/Types 계약 점검,계획,High," ● 내용: @ara/react/{portal,focus-trap,positioner,dismissable-layer} 서브패스, sideEffects:false, types/exports 해상도

--- a/planning/WBS.csv
+++ b/planning/WBS.csv
@@ -68,7 +68,7 @@ W-000009,T1,Form Controls v0 Comp,완료,100,"Form Controls v0
  ● 폼: name/value 제출·reset 대응·controlled/uncontrolled
  ● Storybook/테스트/Exports 고정; canary 포함
  ● AC: CI·Tests·Storybook·ESM+types·폼 제출/키보드 시나리오 통과",--
-W-000010,T1,Overlay Primitives v0,진행,75,"Overlay Primitives v0
+W-000010,T1,Overlay Primitives v0,진행,82,"Overlay Primitives v0
  ● 설계문서 : root/packages/core/overlays/README.md · root/packages/react/src/components/overlays/README.md
  ● 범위: Portal · FocusTrap · Positioner · DismissableLayer(+ScrollLock/Stack)
  ● a11y: 포커스 트랩/복귀·배경 inert/aria-hidden·ESC/바깥 클릭·SSR-safe


### PR DESCRIPTION
## Summary
- mark T-000111 overlay menu/dialog smoke test as complete in the planning tracker
- update W-000010 progress percentage to reflect the completed integration work

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693624c2c07883228b7b6a9fddfeb13f)