### PR TITLE
Anchored overlay Tooltip/Popover/Menu 계약 문서 추가

### DIFF
--- a/packages/react/src/components/menu/README.md
+++ b/packages/react/src/components/menu/README.md
@@ -1,0 +1,114 @@
+# Menu
+
+> 파일: `packages/react/src/components/menu/README.md`
+> 범위: 단일 레벨+1-depth 서브메뉴를 지원하는 컨텍스트/버튼 드롭다운 메뉴. Command palette/Select는 별도 컴포넌트.
+
+## 1) 목적 / 범위
+- **목적:** Anchored overlay 중 키보드 내비게이션/선택 중심 메뉴의 계약을 정의한다.
+- **성공 기준:** Trigger/List/Item/Group/Separator/Submenu 계약과 roving focus/typeahead/닫힘 규칙이 합의되고, 이후 구현·테스트·스토리가 이를 따른다.
+
+---
+
+## 2) Public API (Props 계약)
+
+### Menu (루트 상태/컨텍스트)
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **open** | boolean | — | 제어 모드 열림 상태. |
+| **defaultOpen** | boolean | false | 비제어 초기값. |
+| **onOpenChange** | `(open: boolean) => void` | — | 열림/닫힘 전환 시 호출. |
+| **placement** | `Placement` (`top|bottom|left|right` + `-start|center|end`) | `bottom-start` | 리스트가 트리거 대비 놓일 위치. |
+| **offset** | number | 6 | 앵커와 리스트 간격(px). |
+| **strategy** | `"absolute" \| "fixed"` | "absolute" | 포지셔닝 전략. |
+| **openOnHover** | boolean | false | true이면 hover로도 오픈(서브메뉴 포함). 기본은 click/press 전용. |
+| **closeOnSelect** | boolean | true | 항목 선택 시 메뉴 닫기. checkbox/radio는 상태 토글 후에도 닫을지 여부. |
+| **loopFocus** | boolean | true | roving focus가 끝에서 다시 처음으로 순환할지 여부. |
+| **typeaheadTimeout** | number(ms) | 700 | 연속 타이핑으로 검색할 때 리셋까지의 시간. |
+| **portalContainer** | `HTMLElement \| null` | 기본 Portal 컨테이너 | 리스트 렌더 위치. |
+
+### MenuTrigger (MenuButton)
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **asChild** | boolean | false | 자식 요소로 치환. 이벤트/ARIA/refs 병합. |
+| **children** | ReactNode | — | 메뉴를 여는 버튼 또는 커스텀 앵커. |
+| **disabled** | boolean | — | true이면 press 무시. |
+| **aria-label** | 문자열 | — | 레이블 없는 아이콘 트리거 시 필수. |
+
+### MenuContent (MenuList)
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **children** | ReactNode | — | `MenuItem`/`MenuGroup`/`MenuSeparator` 등을 포함. |
+| **id** | string | 자동 생성 | `aria-controls`/`aria-labelledby` 연결용. |
+| **aria-label** | 문자열 | — | 시각적 제목 없을 때 필수. |
+| **className / style** | 문자열 / 스타일 | — | 리스트 래퍼 병합. |
+| **asChild** | boolean | false | 사용자 정의 래퍼 사용. |
+
+### MenuItem / MenuCheckboxItem / MenuRadioGroup / MenuRadioItem
+
+| 컴포넌트 | 주요 Props | 설명 |
+| --- | --- | --- |
+| **MenuItem** | `onSelect: () => void`, `disabled?: boolean`, `shortcut?: string`, `inset?: boolean` | 기본 항목. press/Enter/Space/Click로 선택, `closeOnSelect`에 따라 닫힘. `shortcut`은 보조 텍스트 슬롯. |
+| **MenuCheckboxItem** | `checked: boolean`, `onCheckedChange: (checked: boolean) => void`, `disabled?`, `shortcut?` | 토글 가능 항목. Space/Click로 체크 전환 후 `closeOnSelect`에 따라 닫힘. 체크 상태는 `role="menuitemcheckbox"`. |
+| **MenuRadioGroup** | `value: string`, `onValueChange: (value: string) => void`, `name?: string` | 동일 그룹 내 `MenuRadioItem`을 관리. `aria-labelledby`로 외부/Label과 연결. |
+| **MenuRadioItem** | `value: string`, `disabled?: boolean`, `shortcut?` | `role="menuitemradio"`. 선택 시 그룹 value를 변경하고 필요 시 닫힘. |
+
+### MenuGroup / MenuLabel / MenuSeparator / MenuArrow
+- **MenuGroup:** 관련 항목 묶음. `aria-labelledby`로 Label id와 연결.
+- **MenuLabel:** 그룹 제목. 자동 id를 생성해 그룹에 전달.
+- **MenuSeparator:** 구분선(`role="separator"`).
+- **MenuArrow:** Positioner arrow props 사용. 필요한 경우만 렌더.
+
+### MenuSub / MenuSubTrigger / MenuSubContent (1-depth 서브메뉴)
+- **MenuSub:** 서브메뉴 상태 컨텍스트. 별도 Props 없음, 부모 Menu의 placement/offset을 기본 상속하되 `placement="right-start"`를 기본으로 사용.
+- **MenuSubTrigger:** 부모 MenuItem 역할 + `aria-haspopup="menu"`, `aria-expanded` 관리. hover 또는 방향키 Right로 열림, Left/ESC로 닫힘.
+- **MenuSubContent:** 서브 리스트. `closeDelay`(기본 150ms) 동안 pointer-safe polygon 지원을 염두에 둔다. 포지셔닝은 `usePositioner`를 재사용.
+
+---
+
+## 3) 동작 계약 (Behavior)
+- **열림:** Trigger press(Click/Enter/Space) 기본. `openOnHover` true이면 hover/포인터 진입 시 `openDelay`(기본 150ms) 후 열림.
+- **닫힘:**
+  - ESC 또는 `closeOnInteractOutside`(기본 true)로 외부 클릭 시 닫힘.
+  - 포커스가 Menu 컨텍스트 밖으로 이동하면 닫음. Trigger 포커스 복귀.
+  - 항목 선택 시 `closeOnSelect` true면 닫고 `onOpenChange(false)` 호출.
+- **포커스/내비게이션:**
+  - Roving tabIndex로 한 번에 하나의 항목만 tabIndex=0. ArrowUp/Down, Home/End 이동. `loopFocus`에 따라 첫↔끝 순환.
+  - Typeahead: 연속 입력을 `typeaheadTimeout` 윈도우 내 버퍼링해 첫 매칭 항목으로 포커스 이동. 한글 초성 등은 제외(문서화).
+  - 서브메뉴: Right Arrow 또는 hover 지연 후 열림, Left/ESC로 부모로 복귀. 부모 메뉴는 열린 서브메뉴가 닫힐 때까지 focus/selection을 유지.
+- **포지셔닝:** `usePositioner` 활용. 서브메뉴는 기본 `right-start` + 동일 offset. Arrow 사용 시 `data-side/align` 제공.
+
+---
+
+## 4) 접근성 계약 (A11y)
+- **역할:** Trigger `aria-haspopup="menu"` + `aria-expanded`. Content `role="menu"`, Item `role="menuitem"`/`menuitemcheckbox`/`menuitemradio`.
+- **레이블링:** Trigger는 레이블 필요. MenuContent는 `aria-labelledby`(Label/외부 id) 또는 `aria-label`로 이름을 가져야 한다. Group/Label을 통한 서브 레이블 연결.
+- **포커스 관리:** 메뉴가 열릴 때 첫 활성 항목에 포커스, 닫힐 때 Trigger로 복귀. 포커스 트랩은 사용하지 않지만 Tab키는 메뉴를 닫고 다음 포커스로 이동하도록 한다.
+- **키보드 상호작용:**
+  - Enter/Space → 선택. Arrow 키는 포커스 이동, Right/Left로 서브 열림/닫힘.
+  - ESC → 현재 메뉴 계층 닫기. 상위 메뉴 존재 시 상위로 포커스 이동.
+- **마우스/포인터:** 서브메뉴는 pointer-safe polygon(향후 `useHoverIntent` 연동)으로 포인터 지름길 이동 시 닫힘을 지연시켜 사용성을 보장.
+
+---
+
+## 5) 컴포지션 / 슬롯
+- 구조: `Menu` → `MenuTrigger` → `MenuContent` → (`MenuItem` | `MenuCheckboxItem` | `MenuRadioGroup`→`MenuRadioItem` | `MenuGroup`→`MenuLabel`/`MenuItem` | `MenuSeparator` | `MenuSub`→`MenuSubTrigger`+`MenuSubContent`).
+- 데이터 속성: `data-state`, `data-disabled`, `data-highlighted`(focus된 항목), `data-checked`, `data-submenu-open`, `data-side`/`data-align`.
+- Portal/Positioner/DismissableLayer와 조합 가능, `asChild`로 애니메이션 래퍼에 위임.
+
+---
+
+## 6) Exports 계약
+- **@ara/react**
+  - `@ara/react/menu` → `Menu`, `MenuTrigger`, `MenuContent`, `MenuItem`, `MenuCheckboxItem`, `MenuRadioGroup`, `MenuRadioItem`, `MenuGroup`, `MenuLabel`, `MenuSeparator`, `MenuArrow`, `MenuSub`, `MenuSubTrigger`, `MenuSubContent` 및 Props 타입
+- **package.json (react 패키지)**
+  - `exports`: `./menu`(ESM) + `types`, `sideEffects:false`
+  - Node ≥ 22, ESM 우선, d.ts 포함
+
+---
+
+## 7) 테스트/스토리 요구
+- 키보드 내비게이션(Arrow/Home/End/Enter/Space/ESC)과 typeahead 버퍼링 시나리오 검증.
+- `closeOnSelect`/`openOnHover`/서브메뉴 지연 등의 상호작용 스냅, RTL/Portal 환경에서 포지셔닝/aria 연결 확인.

--- a/packages/react/src/components/popover/README.md
+++ b/packages/react/src/components/popover/README.md
@@ -1,0 +1,101 @@
+# Popover
+
+> 파일: `packages/react/src/components/popover/README.md`
+> 범위: 앵커에 붙는 작은 대화상자. 간단한 폼/버튼 등 **인터랙티브 콘텐츠**를 포함하지만 전체 모달/드로어는 제외.
+
+## 1) 목적 / 범위
+- **목적:** Anchored overlay 제품군 중 상호작용형 팝오버의 Props/동작/A11y/Exports를 정의한다.
+- **성공 기준:** Trigger/Content/Arrow/Close 슬롯과 상태(open)·포지셔닝(placement/offset)·해제 규칙(ESC/바깥클릭)이 합의되고, 이후 구현/스토리/테스트가 이를 준수한다.
+
+---
+
+## 2) Public API (Props 계약)
+
+### Popover (루트 상태/컨텍스트)
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **open** | boolean | — | 제어 모드. 상위가 열림/닫힘을 직접 관리. |
+| **defaultOpen** | boolean | false | 비제어 초기 열림 여부. |
+| **onOpenChange** | `(open: boolean) => void` | — | 상태가 변할 때 호출. 제어/비제어 공통. |
+| **placement** | `Placement` (`top|bottom|left|right` + `-start|center|end`) | `bottom-start` | 앵커 대비 배치 위치. `@ara/core/use-positioner`와 동일. |
+| **offset** | number | 8 | 앵커와 콘텐츠 사이 간격(px). |
+| **strategy** | `"absolute" \| "fixed"` | "absolute" | 포지셔닝 전략. 스크롤 고정 시 `fixed`. |
+| **withArrow** | boolean | false | true일 때 `PopoverArrow` 렌더. |
+| **modal** | boolean | false | true이면 `use-focus-trap`을 사용해 Tab 순환을 가두고, 오버레이 뒤 영역을 inert/aria-hidden 처리한다. |
+| **closeOnEscape** | boolean | true | ESC 키로 닫기 허용 여부. |
+| **closeOnInteractOutside** | boolean | true | 콘텐츠 외부 클릭/포인터다운 시 닫기 여부. |
+| **closeOnFocusOutside** | boolean | true | 포커스가 외부로 이동하면 닫기 여부. 폼 입력 유지 시 false로 설정. |
+| **returnFocusOnClose** | boolean | true | 닫힐 때 Trigger로 포커스를 돌려준다(모달=true일 때 필수). |
+| **portalContainer** | `HTMLElement \| null` | 기본 Portal 컨테이너 | 콘텐츠 렌더링 위치. |
+| **className / style** | 문자열 / 스타일 | — | 루트 래퍼에 병합. |
+
+### PopoverTrigger
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **asChild** | boolean | false | 자식 요소를 그대로 렌더하고 이벤트/ARIA/refs를 병합. |
+| **children** | ReactNode | — | 팝오버를 여닫는 앵커. 기본 동작은 press(Enter/Space/Click) 토글. |
+| **disabled** | boolean | — | true이면 해당 트리거만 비활성(press 무시). |
+| **aria-label** | 문자열 | — | 아이콘 전용 트리거 시 필수. |
+
+### PopoverContent
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **children** | ReactNode | — | 인터랙티브 콘텐츠(버튼, 폼 등). |
+| **id** | string | 자동 생성 | `aria-controls`/`aria-describedby` 연결용 id. |
+| **aria-label** | 문자열 | — | 시각적 제목이 없을 때 필수. |
+| **aria-labelledby / aria-describedby** | 문자열 | — | 외부 제목/설명 노드 id 연결. 내부 Header/Body와 병합. |
+| **className / style** | 문자열 / 스타일 | — | 콘텐츠 래퍼 병합. |
+| **asChild** | boolean | false | 사용자 정의 래퍼 사용 시. |
+
+### PopoverArrow / PopoverClose / PopoverHeader / PopoverBody / PopoverFooter
+- **PopoverArrow:** Props 없음. `withArrow` true일 때 사용하며 Positioner `data-side/align`/`style` 적용.
+- **PopoverClose:** `asChild` 지원, 클릭/press 시 닫기. 기본 role=button/`aria-label="Close"` 권장.
+- **PopoverHeader/Body/Footer:** 시맨틱 래퍼. Header id를 자동으로 생성해 Content의 `aria-labelledby`에 병합한다.
+
+---
+
+## 3) 동작 계약 (Behavior)
+- **토글:** Trigger press(Click/Enter/Space) 시 `open` ↔ `closed`. 제어 모드에서는 `onOpenChange`만 호출하고 실제 상태는 상위가 유지.
+- **닫힘:**
+  - `closeOnEscape`가 true이면 ESC keyup으로 닫고, `onOpenChange(false)` 호출.
+  - `closeOnInteractOutside` true → 콘텐츠 밖 포인터 다운/클릭 시 닫음. `preventDefault()`로 사용자 쪽에서 차단 가능.
+  - `closeOnFocusOutside` true → 포커스가 컨텍스트 밖으로 이동하면 닫음(모달 모드에서 기본). 폼 제출 등으로 포커스 이동이 필요한 경우 false로 설정.
+- **포커스 관리:**
+  - `modal=true` → `use-focus-trap`으로 Tab 순환, 초기 포커스는 첫 포커스 가능 요소 또는 콘텐츠에 `autoFocus` 지정된 요소.
+  - 닫힐 때 `returnFocusOnClose` true라면 마지막 Trigger로 포커스 복귀.
+- **포지셔닝:** `usePositioner`로 anchor/floating/arrow props 제공. flip/shift 기본 true, `placement`/`offset`/`strategy` 옵션을 그대로 전달.
+- **상태 동기화:** 내부 상태 변화 시 Context를 통해 Trigger/Content에 `data-state="open|closed"` 전달해 스타일/애니메이션 훅으로 사용.
+
+---
+
+## 4) 접근성 계약 (A11y)
+- **역할:** 콘텐츠는 기본적으로 `role="dialog"`(modal=true 시 `aria-modal="true"`). 비모달 시에도 `aria-modal`은 false로 유지하되 dismiss 규칙을 동일하게 적용.
+- **연결:** Trigger에는 `aria-haspopup="dialog"`와 `aria-controls={contentId}`를 설정하고, 열림 상태에 따라 `aria-expanded`를 업데이트한다.
+- **레이블링:** Header가 있으면 그 id를 `aria-labelledby`에 병합. Header가 없을 때는 `aria-label` 제공 필수. Body 텍스트는 `aria-describedby`에 포함 가능.
+- **키보드:** ESC 닫힘, Tab 순환(모달), Shift+Tab 역방향, Trigger 포커스 복귀. 외부 영역은 modal=true일 때 inert/aria-hidden 처리로 스크린 리더 격리.
+- **포털:** Portal 렌더링으로 문서 순서가 달라져도 `aria-controls`로 연결된다.
+
+---
+
+## 5) 컴포지션 / 슬롯
+- 구조: `Popover` → `PopoverTrigger` → `PopoverContent` (+ `PopoverHeader`/`Body`/`Footer`/`PopoverClose`/`PopoverArrow`).
+- 스타일 훅: `data-state`, `data-side`, `data-align`, `data-placement`, `data-modal` 등을 콘텐츠/화살표에 노출.
+- DismissableLayer/Portal/FocusTrap/Positioner를 내부에서 조합하되, `asChild`를 통해 애니메이션 래퍼와 병합 가능.
+
+---
+
+## 6) Exports 계약
+- **@ara/react**
+  - `@ara/react/popover` → `Popover`, `PopoverTrigger`, `PopoverContent`, `PopoverArrow`, `PopoverClose`, `PopoverHeader`, `PopoverBody`, `PopoverFooter` 및 Props 타입
+- **package.json (react 패키지)**
+  - `exports`: `./popover`(ESM) + `types`, `sideEffects:false`
+  - Node ≥ 22, ESM 우선, d.ts 포함
+
+---
+
+## 7) 테스트/스토리 요구
+- Trigger press 토글, ESC/외부 클릭/포커스 아웃 닫힘, `modal` 포커스 트랩 시나리오에 대한 RTL/Vitest 스냅.
+- `placement`/`offset`/`withArrow` 조합 시각 회귀, `aria-expanded`/`aria-controls` 연결 검증.

--- a/packages/react/src/components/tooltip/README.md
+++ b/packages/react/src/components/tooltip/README.md
@@ -1,0 +1,98 @@
+# Tooltip
+
+> 파일: `packages/react/src/components/tooltip/README.md`
+> 범위: 간단한 정보성 풍선 도움말. 키보드/포인터 트리거만 허용, **상호작용형(popover) UI는 제외**.
+
+## 1) 목적 / 범위
+- **목적:** Anchored overlay 계열 컴포넌트의 계약(Props/동작/A11y/Exports)을 Tooltip에서 확정한다.
+- **성공 기준:** Trigger/Content/Arrow 계약과 타이밍(openDelay/closeDelay), 포지셔닝 옵션(placement/offset)이 본 문서와 일치하고 이후 구현·스토리·테스트가 이를 준수한다.
+
+---
+
+## 2) Public API (Props 계약)
+
+### Tooltip (루트 상태/컨텍스트)
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **open** | boolean | — | 제어 모드. 존재 시 모든 열림/닫힘은 상위에서 관리하며, 내부 상태를 사용하지 않는다. |
+| **defaultOpen** | boolean | false | 비제어 초기값. 이후 상태는 내부에서 관리된다. |
+| **onOpenChange** | `(open: boolean) => void` | — | 열림 상태가 바뀔 때 호출. 제어/비제어 모두에서 발화. |
+| **placement** | `Placement` (`top|bottom|left|right` + `-start|center|end`) | `top-start` | 콘텐츠가 기준(anchor) 대비 배치될 위치. `@ara/core/use-positioner` 타입 그대로 사용한다. |
+| **offset** | number | 8 | 기준 요소와 풍선 사이의 간격(px). |
+| **strategy** | `"absolute" \| "fixed"` | "absolute" | 포지셔닝 전략. 스크롤 컨테이너 내 고정이 필요하면 `fixed` 사용. |
+| **withArrow** | boolean | false | true이면 `TooltipArrow`를 렌더하고 Positioner에서 화살표 위치 계산을 요청한다. |
+| **openDelay** | number(ms) | 300 | 마우스/포인터 진입 후 실제 표시까지 지연 시간. A11y 가이드 최소 300ms 준수. |
+| **closeDelay** | number(ms) | 150 | 포인터 이탈/blur 후 닫히기까지 지연. 서브 콘텐츠 없이 짧게 유지. |
+| **disabled** | boolean | false | true이면 모든 트리거 이벤트를 무시하고 콘텐츠를 렌더하지 않는다. |
+| **portalContainer** | `HTMLElement \| null` | 기본 Portal 컨테이너 | 콘텐츠를 렌더링할 DOM 노드. 미지정 시 `Portal`의 기본 컨테이너를 사용. |
+| **className / style** | 문자열 / 스타일 | — | 최상위 래퍼에 병합될 사용자 정의 클래스/스타일. |
+
+> **제어 규칙:** `open`이 주어지면 내부 상태를 사용하지 않으며, `onOpenChange`는 트리거 이벤트가 발생했을 때 호출만 한다.
+> **포지셔닝 용어:** `placement`/`offset`/`strategy`는 `usePositioner`의 옵션과 1:1 대응한다.
+
+### TooltipTrigger (앵커/트리거)
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **asChild** | boolean | false | true이면 자식 하나를 그대로 렌더하고 이벤트/refs/ARIA를 병합한다. |
+| **children** | ReactNode | — | 툴팁을 여는 앵커 요소. 버튼/아이콘 등 자유롭게 사용. |
+| **disabled** | boolean | — | 명시 시 루트 `disabled`보다 우선해 해당 트리거만 비활성화한다. |
+| **aria-label** | 문자열 | — | 아이콘 전용 트리거 등 레이블이 없는 경우 **필수**. |
+
+### TooltipContent
+
+| 속성 | 값/형식 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| **children** | ReactNode | — | 표시할 텍스트/노드. 인터랙티브 컨트롤은 넣지 않는 것을 규칙으로 한다. |
+| **id** | string | 자동 생성 | 트리거와 `aria-describedby`로 연결되는 id. 미지정 시 내부에서 생성한다. |
+| **className / style** | 문자열 / 스타일 | — | 콘텐츠 래퍼에 최종 병합. |
+| **asChild** | boolean | false | 사용자 정의 래퍼로 치환할 때 사용(예: 애니메이션 컴포넌트). |
+
+### TooltipArrow (선택)
+- 별도 Props 없음. `withArrow`가 true일 때만 렌더하며, `usePositioner`에서 제공하는 `data-side`/`data-align`/`style`을 그대로 적용한다.
+
+---
+
+## 3) 동작 계약 (Behavior)
+- **열림 트리거:**
+  - 포인터 `mouseenter`/`pointerenter` → `openDelay` 후 열림. `disabled` 또는 `TooltipTrigger.disabled`면 무시.
+  - 키보드 `focusin` → 즉시 열림. 포커스가 유지되는 동안만 표시.
+- **닫힘 트리거:**
+  - 포인터가 트리거와 콘텐츠 모두에서 벗어나면 `closeDelay` 후 닫힘. `disabled` 또는 컨텐츠 존재하지 않으면 즉시 닫힘.
+  - `blur` 시 즉시 닫힘. ESC/외부 클릭 시에도 닫혀야 한다(포커스 트랩 없음).
+- **상태 관리:**
+  - 루트 `open`이 제어 모드이면 내부 타이머/상태는 콜백만 호출하고 실제 표시 여부는 상위가 결정한다.
+  - 동일 앵커에 대한 연속 진입 시 기존 타이머를 공유해 깜빡임을 방지한다.
+- **포지셔닝:** `usePositioner` 결과를 Anchor/Floating에 반영하고, `withArrow`일 때는 Arrow의 `data-side/align`과 `style`을 전달한다. 플립/시프트 기본 동작은 `usePositioner` 기본값(flip/shift true)을 따른다.
+
+---
+
+## 4) 접근성 계약 (A11y)
+- **역할/연결:** 콘텐츠는 `role="tooltip"`을 사용하고, 트리거에 `aria-describedby={contentId}`를 설정한다.
+- **키보드:** 포커스 진입 시 바로 노출하며, 포커스 아웃/ESC에서 닫힌다. 포커스 링은 트리거에만 노출되고 콘텐츠에는 포커스 가능 요소를 넣지 않는다.
+- **레이블:** 텍스트 없는 아이콘 트리거는 `aria-label` 또는 외부 `aria-labelledby`를 제공해야 한다.
+- **모션/타이밍:** `openDelay` 최소 300ms로 설정해 의도하지 않은 깜빡임을 방지하고, `closeDelay`는 짧게 유지해 포인터 이동 시 빠르게 숨겨 사용자를 방해하지 않도록 한다.
+- **Portal:** 기본 포털 렌더링을 사용해 DOM 계층에 상관없이 스크린 리더가 올바르게 탐색하도록 한다.
+
+---
+
+## 5) 컴포지션 / 슬롯
+- 구조: `Tooltip`(상태) → `TooltipTrigger`(anchor) → `TooltipContent`(+ `TooltipArrow` 선택).
+- 스타일 훅: `data-state="open|closed"`, `data-side`, `data-align`, `data-placement` 등을 콘텐츠/화살표에 노출해 CSS 제어를 돕는다.
+- Portal/Positioner/외부 Theme Provider와 병합 가능해야 한다.
+
+---
+
+## 6) Exports 계약
+- **@ara/react**
+  - `@ara/react/tooltip` → `Tooltip`, `TooltipTrigger`, `TooltipContent`, `TooltipArrow`, 관련 Props/Context 타입
+- **package.json (react 패키지)**
+  - `exports`: `./tooltip`(ESM) + `types`, `sideEffects:false`
+  - Node ≥ 22, ESM 우선, d.ts 포함
+
+---
+
+## 7) 테스트/스토리 요구
+- 트리거 hover/focus/ESC 닫힘 시나리오 스냅 및 RTL/포털 환경 검증.
+- `placement`/`offset`/`withArrow` 옵션별 시각 스냅샷과 키보드 접근성 검사(aria-describedby 연결) 준비.


### PR DESCRIPTION
## 요약
- Tooltip/Popover/Menu의 공개 API와 동작/접근성 계약을 README로 정리했습니다.
- 포지셔닝 옵션, 트리거/닫힘 규칙, exports 경로 등 공통 네이밍과 계약을 고정했습니다.
- 향후 구현을 위한 테스트/스토리 체크리스트를 함께 기록했습니다.

## 테스트
- 문서 변경으로 별도 실행한 테스트는 없습니다.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69376c5ea97c83229ecccb7f7db0ea04)