### PR TITLE
feat: useHoverIntent 훅 추가 (T-000116)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,11 @@
       "import": "./dist/overlays/use-positioner.js",
       "default": "./dist/overlays/use-positioner.js"
     },
+    "./overlays/use-hover-intent": {
+      "types": "./dist/overlays/use-hover-intent.d.ts",
+      "import": "./dist/overlays/use-hover-intent.js",
+      "default": "./dist/overlays/use-hover-intent.js"
+    },
     "./overlays/use-scroll-lock": {
       "types": "./dist/overlays/use-scroll-lock.d.ts",
       "import": "./dist/overlays/use-scroll-lock.js",
@@ -96,6 +101,9 @@
       ],
       "overlays/use-positioner": [
         "dist/overlays/use-positioner.d.ts"
+      ],
+      "overlays/use-hover-intent": [
+        "dist/overlays/use-hover-intent.d.ts"
       ],
       "overlays/use-scroll-lock": [
         "dist/overlays/use-scroll-lock.d.ts"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,12 @@ export type {
 } from "./overlays/use-positioner.js";
 export { usePositioner } from "./overlays/use-positioner.js";
 export type {
+  HoverIntentTargetProps,
+  UseHoverIntentOptions,
+  UseHoverIntentResult
+} from "./overlays/use-hover-intent.js";
+export { useHoverIntent } from "./overlays/use-hover-intent.js";
+export type {
   FocusGuardProps,
   FocusTrapContainerProps,
   UseFocusTrapOptions,

--- a/packages/core/src/overlays/use-hover-intent.test.tsx
+++ b/packages/core/src/overlays/use-hover-intent.test.tsx
@@ -1,0 +1,143 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+
+import { useHoverIntent } from "./use-hover-intent.js";
+
+describe("useHoverIntent", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("열림 지연과 포인터 안정 구간을 존중한다", async () => {
+    vi.useFakeTimers();
+
+    function Target() {
+      const { anchorProps, isOpen } = useHoverIntent({ openDelay: 120, restMs: 50 });
+      return (
+        <button data-testid="anchor" {...anchorProps}>
+          {isOpen ? "open" : "closed"}
+        </button>
+      );
+    }
+
+    const { getByTestId } = render(<Target />);
+    const anchor = getByTestId("anchor");
+
+    await act(async () => {
+      fireEvent.pointerEnter(anchor, { clientX: 10, clientY: 10 });
+    });
+
+    expect(anchor).toHaveTextContent("closed");
+
+    await act(async () => {
+      vi.advanceTimersByTime(120);
+    });
+
+    expect(anchor).toHaveTextContent("open");
+  });
+
+  it("포인터 이동이 계속되면 안정 구간까지 열지 않는다", async () => {
+    vi.useFakeTimers();
+
+    function Target() {
+      const { anchorProps, isOpen } = useHoverIntent({ openDelay: 30, restMs: 80 });
+      return (
+        <button data-testid="anchor" {...anchorProps}>
+          {isOpen ? "open" : "closed"}
+        </button>
+      );
+    }
+
+    const { getByTestId } = render(<Target />);
+    const anchor = getByTestId("anchor");
+
+    await act(async () => {
+      fireEvent.pointerEnter(anchor, { clientX: 0, clientY: 0 });
+      vi.advanceTimersByTime(30);
+      fireEvent.pointerMove(anchor, { clientX: 5, clientY: 5 });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+
+    expect(anchor).toHaveTextContent("closed");
+
+    await act(async () => {
+      vi.advanceTimersByTime(80);
+    });
+
+    expect(anchor).toHaveTextContent("open");
+  });
+
+  it("세이프 폴리곤을 사용할 때 포인터가 경유 영역에 있으면 닫힘을 지연한다", async () => {
+    vi.useFakeTimers();
+
+    function Overlay() {
+      const { anchorProps, floatingProps, isOpen } = useHoverIntent({
+        defaultOpen: true,
+        closeDelay: 150
+      });
+
+      return (
+        <div>
+          <button data-testid="anchor" {...anchorProps}>
+            anchor
+          </button>
+          <div data-testid="floating" {...floatingProps}>
+            {isOpen ? "open" : "closed"}
+          </div>
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(<Overlay />);
+    const anchor = getByTestId("anchor");
+    const floating = getByTestId("floating");
+
+    vi.spyOn(anchor, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 20,
+      top: 0,
+      right: 100,
+      bottom: 20,
+      left: 0,
+      toJSON: () => ({})
+    });
+
+    vi.spyOn(floating, "getBoundingClientRect").mockReturnValue({
+      x: 150,
+      y: 0,
+      width: 80,
+      height: 40,
+      top: 0,
+      right: 230,
+      bottom: 40,
+      left: 150,
+      toJSON: () => ({})
+    });
+
+    expect(floating).toHaveTextContent("open");
+
+    await act(async () => {
+      fireEvent.pointerLeave(anchor, { clientX: 120, clientY: 10 });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(floating).toHaveTextContent("open");
+
+    await act(async () => {
+      fireEvent.pointerMove(document.body, { clientX: 400, clientY: 10 });
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(floating).toHaveTextContent("closed");
+  });
+});

--- a/packages/core/src/overlays/use-hover-intent.ts
+++ b/packages/core/src/overlays/use-hover-intent.ts
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEventHandler } from "react";
+
+export interface UseHoverIntentOptions {
+  readonly isOpen?: boolean;
+  readonly defaultOpen?: boolean;
+  readonly openDelay?: number;
+  readonly closeDelay?: number;
+  readonly restMs?: number;
+  readonly enableSafePolygon?: boolean;
+  readonly anchor?: HTMLElement | null;
+  readonly floating?: HTMLElement | null;
+  readonly onOpenChange?: (open: boolean) => void;
+}
+
+export interface HoverIntentTargetProps {
+  readonly ref: (node: HTMLElement | null) => void;
+  readonly onPointerEnter: PointerEventHandler<HTMLElement>;
+  readonly onPointerMove: PointerEventHandler<HTMLElement>;
+  readonly onPointerLeave: PointerEventHandler<HTMLElement>;
+}
+
+export interface UseHoverIntentResult {
+  readonly isOpen: boolean;
+  readonly anchorProps: HoverIntentTargetProps;
+  readonly floatingProps: HoverIntentTargetProps;
+  readonly open: () => void;
+  readonly close: () => void;
+}
+
+const DEFAULT_OPEN_DELAY = 150;
+const DEFAULT_CLOSE_DELAY = 100;
+const DEFAULT_REST_MS = 50;
+
+interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+function isPointInSafeArea(point: Point, anchorRect: DOMRect, floatingRect: DOMRect): boolean {
+  const left = Math.min(anchorRect.left, floatingRect.left);
+  const right = Math.max(anchorRect.right, floatingRect.right);
+  const top = Math.min(anchorRect.top, floatingRect.top);
+  const bottom = Math.max(anchorRect.bottom, floatingRect.bottom);
+
+  return point.x >= left && point.x <= right && point.y >= top && point.y <= bottom;
+}
+
+export function useHoverIntent(options: UseHoverIntentOptions = {}): UseHoverIntentResult {
+  const {
+    isOpen: controlledOpen,
+    defaultOpen = false,
+    openDelay = DEFAULT_OPEN_DELAY,
+    closeDelay = DEFAULT_CLOSE_DELAY,
+    restMs = DEFAULT_REST_MS,
+    enableSafePolygon = true,
+    anchor,
+    floating,
+    onOpenChange
+  } = options;
+
+  const isControlled = controlledOpen !== undefined;
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const open = isControlled ? Boolean(controlledOpen) : uncontrolledOpen;
+
+  const [anchorNode, setAnchorNode] = useState<HTMLElement | null>(null);
+  const [floatingNode, setFloatingNode] = useState<HTMLElement | null>(null);
+
+  const resolvedAnchor = anchor ?? anchorNode;
+  const resolvedFloating = floating ?? floatingNode;
+
+  const lastPointerTimeRef = useRef<number>(0);
+  const openTimerRef = useRef<number>();
+  const closeTimerRef = useRef<number>();
+  const safeMonitorCleanupRef = useRef<(() => void) | null>(null);
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(next);
+      }
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const clearOpenTimer = useCallback(() => {
+    if (openTimerRef.current) {
+      window.clearTimeout(openTimerRef.current);
+      openTimerRef.current = undefined;
+    }
+  }, []);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = undefined;
+    }
+  }, []);
+
+  const stopSafeMonitor = useCallback(() => {
+    safeMonitorCleanupRef.current?.();
+    safeMonitorCleanupRef.current = null;
+  }, []);
+
+  useEffect(() => () => {
+    clearOpenTimer();
+    clearCloseTimer();
+    stopSafeMonitor();
+  }, [clearCloseTimer, clearOpenTimer, stopSafeMonitor]);
+
+  const scheduleOpen = useCallback(() => {
+    clearOpenTimer();
+    const attemptOpen = () => {
+      const elapsed = Date.now() - lastPointerTimeRef.current;
+      if (elapsed >= restMs) {
+        setOpen(true);
+      } else {
+        openTimerRef.current = window.setTimeout(attemptOpen, restMs - elapsed);
+      }
+    };
+
+    openTimerRef.current = window.setTimeout(attemptOpen, openDelay);
+  }, [clearOpenTimer, openDelay, restMs, setOpen]);
+
+  const scheduleClose = useCallback(() => {
+    clearCloseTimer();
+    closeTimerRef.current = window.setTimeout(() => setOpen(false), closeDelay);
+  }, [clearCloseTimer, closeDelay, setOpen]);
+
+  const handlePointerEnter = useCallback<PointerEventHandler<HTMLElement>>(
+    (event) => {
+      lastPointerTimeRef.current = Date.now();
+      stopSafeMonitor();
+      clearCloseTimer();
+      scheduleOpen();
+      if (event.pointerType === "touch") {
+        clearOpenTimer();
+      }
+    },
+    [clearCloseTimer, clearOpenTimer, scheduleOpen, stopSafeMonitor]
+  );
+
+  const handlePointerMove = useCallback<PointerEventHandler<HTMLElement>>((event) => {
+    lastPointerTimeRef.current = Date.now();
+    if (event.pointerType === "touch") {
+      clearOpenTimer();
+    }
+  }, [clearOpenTimer]);
+
+  const handlePointerLeave = useCallback<PointerEventHandler<HTMLElement>>(
+    (event) => {
+      const nextTarget = event.relatedTarget as HTMLElement | null;
+      if (
+        nextTarget instanceof Node &&
+        (resolvedAnchor?.contains(nextTarget) || resolvedFloating?.contains(nextTarget))
+      ) {
+        return;
+      }
+
+      clearOpenTimer();
+
+      if (enableSafePolygon && resolvedAnchor && resolvedFloating) {
+        const anchorRect = resolvedAnchor.getBoundingClientRect();
+        const floatingRect = resolvedFloating.getBoundingClientRect();
+        const point: Point = { x: event.clientX, y: event.clientY };
+
+        if (isPointInSafeArea(point, anchorRect, floatingRect)) {
+          stopSafeMonitor();
+          const handlePointerMoveOutside = (moveEvent: PointerEvent) => {
+            const nextPoint: Point = { x: moveEvent.clientX, y: moveEvent.clientY };
+            if (!isPointInSafeArea(nextPoint, anchorRect, floatingRect)) {
+              stopSafeMonitor();
+              scheduleClose();
+            }
+          };
+          document.addEventListener("pointermove", handlePointerMoveOutside);
+          safeMonitorCleanupRef.current = () => document.removeEventListener("pointermove", handlePointerMoveOutside);
+          return;
+        }
+      }
+
+      scheduleClose();
+    },
+    [clearOpenTimer, enableSafePolygon, resolvedAnchor, resolvedFloating, scheduleClose, stopSafeMonitor]
+  );
+
+  const openManually = useCallback(() => {
+    clearCloseTimer();
+    clearOpenTimer();
+    stopSafeMonitor();
+    setOpen(true);
+  }, [clearCloseTimer, clearOpenTimer, setOpen, stopSafeMonitor]);
+
+  const closeManually = useCallback(() => {
+    clearCloseTimer();
+    clearOpenTimer();
+    stopSafeMonitor();
+    setOpen(false);
+  }, [clearCloseTimer, clearOpenTimer, setOpen, stopSafeMonitor]);
+
+  const setAnchor = useCallback((node: HTMLElement | null) => setAnchorNode(node), []);
+  const setFloating = useCallback((node: HTMLElement | null) => setFloatingNode(node), []);
+
+  const anchorProps = useMemo<HoverIntentTargetProps>(
+    () => ({
+      ref: setAnchor,
+      onPointerEnter: handlePointerEnter,
+      onPointerMove: handlePointerMove,
+      onPointerLeave: handlePointerLeave
+    }),
+    [handlePointerEnter, handlePointerLeave, handlePointerMove, setAnchor]
+  );
+
+  const floatingProps = useMemo<HoverIntentTargetProps>(
+    () => ({
+      ref: setFloating,
+      onPointerEnter: handlePointerEnter,
+      onPointerMove: handlePointerMove,
+      onPointerLeave: handlePointerLeave
+    }),
+    [handlePointerEnter, handlePointerLeave, handlePointerMove, setFloating]
+  );
+
+  return {
+    isOpen: open,
+    anchorProps,
+    floatingProps,
+    open: openManually,
+    close: closeManually
+  };
+}


### PR DESCRIPTION
## Summary
- [x] useHoverIntent 훅으로 hover 열림/닫힘 지연과 세이프 폴리곤을 처리합니다. (WBS: W-000011, Task: T-000116)
- [x] 패키지 exports/types를 갱신하고 단위 테스트를 추가해 계약을 검증했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/core test -- --runTestsByPath packages/core/src/overlays/use-hover-intent.test.tsx`

## Screenshots
(없음)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69377463df088322bf07cb8ce6ec40e0)