### PR TITLE
T-000117: 메뉴 typeahead 훅 추가

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,6 +26,10 @@ const theme = createTheme({
 
 테마 객체는 `@ara/tokens`이 제공하는 기본 토큰을 기반으로 하며, React 등의 바인딩 레이어에서 그대로 사용할 수 있습니다.
 
+### 유틸리티 훅
+
+- `useTypeahead`: 키보드로 빠르게 입력된 문자열을 버퍼링해 일치하는 항목을 찾아주는 훅입니다. 기본 타임아웃은 700ms이며, 영문 기준 접두 검색만 지원하고 한글 초성 매칭은 제공하지 않습니다.
+
 ## Testing
 
 - ✅ pnpm --filter @ara/core build

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,11 @@
       "import": "./dist/use-switch.js",
       "default": "./dist/use-switch.js"
     },
+    "./use-typeahead": {
+      "types": "./dist/use-typeahead.d.ts",
+      "import": "./dist/use-typeahead.js",
+      "default": "./dist/use-typeahead.js"
+    },
     "./use-text-field": {
       "types": "./dist/use-text-field.d.ts",
       "import": "./dist/use-text-field.js",
@@ -116,6 +121,9 @@
       ],
       "use-switch": [
         "dist/use-switch.d.ts"
+      ],
+      "use-typeahead": [
+        "dist/use-typeahead.d.ts"
       ],
       "use-text-field": [
         "dist/use-text-field.d.ts"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,3 +96,9 @@ export type {
   UseFocusTrapResult
 } from "./overlays/use-focus-trap.js";
 export { useFocusTrap } from "./overlays/use-focus-trap.js";
+export type {
+  TypeaheadItem,
+  UseTypeaheadOptions,
+  UseTypeaheadResult
+} from "./use-typeahead.js";
+export { useTypeahead } from "./use-typeahead.js";

--- a/packages/core/src/use-typeahead.test.tsx
+++ b/packages/core/src/use-typeahead.test.tsx
@@ -1,0 +1,138 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { useTypeahead, type TypeaheadItem } from "./use-typeahead.js";
+
+const baseItems: TypeaheadItem[] = [
+  { id: "apple", textValue: "Apple" },
+  { id: "banana", textValue: "Banana" },
+  { id: "cherry", textValue: "Cherry" },
+  { id: "date", textValue: "Date" }
+];
+
+describe("useTypeahead", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("매칭된 항목을 반환하고 콜백을 호출한다", () => {
+    const onMatch = vi.fn();
+    const { result } = renderHook(() =>
+      useTypeahead({
+        items: baseItems,
+        onMatch
+      })
+    );
+
+    const match = result.current.handleTypeahead({ key: "b", altKey: false, ctrlKey: false, metaKey: false });
+
+    expect(match?.id).toBe("banana");
+    expect(onMatch).toHaveBeenCalledWith(baseItems[1]);
+  });
+
+  it("연속 타이핑을 버퍼링하여 접두 매칭한다", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() =>
+      useTypeahead({
+        items: baseItems,
+        activeId: "apple"
+      })
+    );
+
+    act(() => {
+      const first = result.current.handleTypeahead({ key: "c", altKey: false, ctrlKey: false, metaKey: false });
+      expect(first?.id).toBe("cherry");
+    });
+
+    act(() => {
+      const buffered = result.current.handleTypeahead({ key: "h", altKey: false, ctrlKey: false, metaKey: false });
+      expect(buffered?.id).toBe("cherry");
+    });
+  });
+
+  it("타임아웃 이후에는 버퍼를 초기화한다", () => {
+    vi.useFakeTimers();
+    const items: TypeaheadItem[] = [
+      { id: "citrus", textValue: "Citrus" },
+      { id: "honey", textValue: "Honey" },
+      { id: "mint", textValue: "Mint" }
+    ];
+
+    const { result } = renderHook(() => useTypeahead({ items, timeout: 700 }));
+
+    act(() => {
+      const first = result.current.handleTypeahead({ key: "c", altKey: false, ctrlKey: false, metaKey: false });
+      expect(first?.id).toBe("citrus");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(750);
+      const afterTimeout = result.current.handleTypeahead({ key: "h", altKey: false, ctrlKey: false, metaKey: false });
+      expect(afterTimeout?.id).toBe("honey");
+    });
+  });
+
+  it("활성 항목 이후부터 순회하며 동일 키 입력으로 다음 항목을 찾는다", () => {
+    vi.useFakeTimers();
+    const items: TypeaheadItem[] = [
+      { id: "alpha", textValue: "Alpha" },
+      { id: "amber", textValue: "Amber" },
+      { id: "amaranth", textValue: "Amaranth" }
+    ];
+
+    const { result, rerender } = renderHook(
+      (props: Parameters<typeof useTypeahead>[0]) => useTypeahead(props),
+      {
+        initialProps: {
+          items,
+          activeId: "alpha",
+          loop: true
+        }
+      }
+    );
+
+    act(() => {
+      const first = result.current.handleTypeahead({ key: "a", altKey: false, ctrlKey: false, metaKey: false });
+      expect(first?.id).toBe("amber");
+    });
+
+    rerender({ items, activeId: "amber", loop: true });
+
+    act(() => {
+      const second = result.current.handleTypeahead({ key: "a", altKey: false, ctrlKey: false, metaKey: false });
+      expect(second?.id).toBe("amaranth");
+    });
+
+    rerender({ items, activeId: "amaranth", loop: true });
+
+    act(() => {
+      const looped = result.current.handleTypeahead({ key: "a", altKey: false, ctrlKey: false, metaKey: false });
+      expect(looped?.id).toBe("alpha");
+    });
+  });
+
+  it("비활성 항목은 건너뛰고 매칭한다", () => {
+    const items: TypeaheadItem[] = [
+      { id: "apple", textValue: "Apple", disabled: true },
+      { id: "apricot", textValue: "Apricot" },
+      { id: "banana", textValue: "Banana" }
+    ];
+
+    const { result } = renderHook(() => useTypeahead({ items }));
+
+    const match = result.current.handleTypeahead({ key: "a", altKey: false, ctrlKey: false, metaKey: false });
+    expect(match?.id).toBe("apricot");
+  });
+
+  it("modifier 키나 공백 입력은 무시한다", () => {
+    const onMatch = vi.fn();
+    const { result } = renderHook(() => useTypeahead({ items: baseItems, onMatch }));
+
+    const ignored = result.current.handleTypeahead({ key: " ", altKey: false, ctrlKey: false, metaKey: false });
+    const withCtrl = result.current.handleTypeahead({ key: "a", altKey: false, ctrlKey: true, metaKey: false });
+
+    expect(ignored).toBeNull();
+    expect(withCtrl).toBeNull();
+    expect(onMatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/use-typeahead.ts
+++ b/packages/core/src/use-typeahead.ts
@@ -1,0 +1,129 @@
+import { useCallback, useRef } from "react";
+
+export interface TypeaheadItem {
+  readonly id: string;
+  readonly textValue: string;
+  readonly disabled?: boolean;
+}
+
+export interface UseTypeaheadOptions {
+  /** 매칭 대상 항목 목록 */
+  readonly items: readonly TypeaheadItem[];
+  /** 현재 포커스된 항목 id. 매칭 시작 지점을 결정한다. */
+  readonly activeId?: string | null;
+  /** true이면 목록 끝에서 다시 처음으로 순회 검색한다. */
+  readonly loop?: boolean;
+  /** 연속 타이핑 버퍼 리셋까지의 시간(ms). 기본 700ms. */
+  readonly timeout?: number;
+  /** 매칭 성공 시 호출된다. */
+  readonly onMatch?: (item: TypeaheadItem) => void;
+}
+
+export interface UseTypeaheadResult {
+  /** typeahead 키 입력을 처리하고 매칭된 항목을 반환한다. */
+  readonly handleTypeahead: (event: Pick<KeyboardEvent, "key" | "altKey" | "ctrlKey" | "metaKey">) => TypeaheadItem | null;
+  /** 내부 버퍼와 타이머를 초기화한다. */
+  readonly resetTypeahead: () => void;
+}
+
+function isValidTypeaheadKey(event: Pick<KeyboardEvent, "key" | "altKey" | "ctrlKey" | "metaKey">): boolean {
+  if (event.altKey || event.ctrlKey || event.metaKey) return false;
+  if (event.key.length !== 1) return false;
+  // Space/제어 문자는 선택/스크롤 등 다른 핸들러와 충돌할 수 있어 제외한다.
+  return event.key.trim().length > 0;
+}
+
+function normalizeText(text: string): string {
+  // 영문 기준 접두 검색만 지원하며, 한글 초성 대응은 제공하지 않는다.
+  return text.trim().toLocaleLowerCase();
+}
+
+function findMatch(
+  items: readonly TypeaheadItem[],
+  search: string,
+  startIndex: number,
+  loop: boolean
+): TypeaheadItem | null {
+  if (!search) return null;
+
+  const total = items.length;
+  const normalizedSearch = normalizeText(search);
+
+  for (let offset = 1; offset <= total; offset += 1) {
+    const nextIndex = loop ? (startIndex + offset) % total : startIndex + offset;
+    if (!loop && nextIndex >= total) break;
+
+    const candidate = items[nextIndex];
+    if (!candidate || candidate.disabled) continue;
+
+    const candidateLabel = normalizeText(candidate.textValue);
+    if (candidateLabel.startsWith(normalizedSearch)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function useTypeahead(options: UseTypeaheadOptions): UseTypeaheadResult {
+  const { items, activeId = null, loop = true, timeout = 700, onMatch } = options;
+
+  const bufferRef = useRef("");
+  const lastTypeTimeRef = useRef(0);
+  const timeoutIdRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const resetTypeahead = useCallback(() => {
+    bufferRef.current = "";
+    lastTypeTimeRef.current = 0;
+    if (timeoutIdRef.current !== null) {
+      clearTimeout(timeoutIdRef.current);
+      timeoutIdRef.current = null;
+    }
+  }, []);
+
+  const scheduleReset = useCallback(() => {
+    if (timeoutIdRef.current !== null) {
+      clearTimeout(timeoutIdRef.current);
+    }
+    timeoutIdRef.current = setTimeout(() => {
+      resetTypeahead();
+    }, timeout);
+  }, [resetTypeahead, timeout]);
+
+  const handleTypeahead = useCallback(
+    (event: Pick<KeyboardEvent, "key" | "altKey" | "ctrlKey" | "metaKey">) => {
+      if (!isValidTypeaheadKey(event)) return null;
+
+      const now = Date.now();
+      const isWithinWindow = lastTypeTimeRef.current && now - lastTypeTimeRef.current <= timeout;
+
+      if (!isWithinWindow) {
+        bufferRef.current = "";
+      }
+
+      bufferRef.current += event.key;
+      lastTypeTimeRef.current = now;
+      scheduleReset();
+
+      const activeIndex = items.findIndex((item) => item.id === activeId);
+      const startIndex = activeIndex < 0 ? -1 : activeIndex;
+
+      let match = findMatch(items, bufferRef.current, startIndex, loop);
+
+      // 버퍼 전체로 매칭되지 않으면 마지막 입력만으로 재탐색한다(예: "aaa" 순회).
+      if (!match && bufferRef.current.length > 1) {
+        bufferRef.current = event.key;
+        match = findMatch(items, bufferRef.current, startIndex, loop);
+      }
+
+      if (match) {
+        onMatch?.(match);
+      }
+
+      return match;
+    },
+    [activeId, items, loop, onMatch, scheduleReset, timeout]
+  );
+
+  return { handleTypeahead, resetTypeahead };
+}


### PR DESCRIPTION
## Summary
- `useTypeahead` 훅을 추가해 메뉴 등 앵커드 오버레이에서 타이핑 기반 포커스 이동을 지원했습니다.
- 패키지 엔트리포인트와 README에 신규 훅과 한글 초성 미지원 범위를 문서화했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (W-000011 / T-000117)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- [x] `pnpm --filter @ara/core test`

## Screenshots
- N/A


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69377b993210832283c480dd75fbb446)