### PR TITLE
[T-000119] 게시판 글 상세 조회 쿼리 검증 추가

### DIFF
--- a/apps/api/src/board/board.service.test.ts
+++ b/apps/api/src/board/board.service.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { BoardPost, getBoardPostDetail } from "./board.service";
+
+const makeTimestamp = (seconds: number) => ({ seconds });
+
+const samplePosts: BoardPost[] = [
+  {
+    id: 1,
+    title: "첫 번째 글",
+    content: "본문",
+    createdAt: makeTimestamp(1_700_000_000),
+  },
+  {
+    id: "latest",
+    title: "최신 글",
+    content: "내용",
+    createdAt: makeTimestamp(1_800_000_000),
+  },
+];
+
+describe("getBoardPostDetail", () => {
+  it("start_time 없이 호출하면 에러를 던진다", () => {
+    expect(() =>
+      getBoardPostDetail(samplePosts, {
+        postId: 1,
+        end_time: makeTimestamp(1_900_000_000),
+      }),
+    ).toThrow(/start_time/);
+  });
+
+  it("end_time 없이 호출하면 에러를 던진다", () => {
+    expect(() =>
+      getBoardPostDetail(samplePosts, {
+        postId: 1,
+        start_time: makeTimestamp(1_600_000_000),
+      }),
+    ).toThrow(/end_time/);
+  });
+
+  it("지정한 기간 내의 게시글을 찾아 반환한다", () => {
+    const result = getBoardPostDetail(samplePosts, {
+      postId: "latest",
+      start_time: makeTimestamp(1_700_000_000),
+      end_time: makeTimestamp(1_900_000_000),
+    });
+
+    expect(result?.title).toBe("최신 글");
+  });
+
+  it("기간을 벗어나면 null을 반환한다", () => {
+    const result = getBoardPostDetail(samplePosts, {
+      postId: 1,
+      start_time: makeTimestamp(1_800_000_001),
+      end_time: makeTimestamp(1_900_000_000),
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/board/board.service.ts
+++ b/apps/api/src/board/board.service.ts
@@ -1,0 +1,60 @@
+export interface Timestamp {
+  seconds: number;
+  nanos?: number;
+}
+
+export interface BoardPost {
+  id: string | number;
+  title: string;
+  content: string;
+  createdAt: Timestamp;
+}
+
+export interface BoardDetailQueryParams {
+  postId: string | number;
+  start_time?: Timestamp;
+  end_time?: Timestamp;
+}
+
+const toMilliseconds = ({ seconds, nanos = 0 }: Timestamp): number => {
+  if (!Number.isFinite(seconds) || !Number.isFinite(nanos)) {
+    throw new Error("Timestamp 값이 올바른 숫자가 아닙니다.");
+  }
+
+  return seconds * 1000 + Math.floor(nanos / 1_000_000);
+};
+
+const requireTimestamp = (
+  value: Timestamp | undefined,
+  field: "start_time" | "end_time",
+): Timestamp => {
+  if (!value) throw new Error(`${field} 값이 누락되었습니다.`);
+  return value;
+};
+
+/**
+ * 게시판 글 상세 조회.
+ *
+ * start_time/end_time 쿼리 파라미터를 필수로 요구하며 Timestamp 스키마로 검증한다.
+ * 요청 구간(start_time~end_time) 안에 생성된 게시글만 반환하며, 범위를 벗어나면 null을 돌려준다.
+ */
+export const getBoardPostDetail = (
+  posts: BoardPost[],
+  query: BoardDetailQueryParams,
+): BoardPost | null => {
+  const startTime = requireTimestamp(query.start_time, "start_time");
+  const endTime = requireTimestamp(query.end_time, "end_time");
+
+  const startMs = toMilliseconds(startTime);
+  const endMs = toMilliseconds(endTime);
+
+  if (startMs > endMs) {
+    throw new Error("start_time 은 end_time 보다 이후일 수 없습니다.");
+  }
+
+  const target = posts.find(({ id }) => String(id) === String(query.postId));
+  if (!target) return null;
+
+  const createdMs = toMilliseconds(target.createdAt);
+  return createdMs >= startMs && createdMs <= endMs ? target : null;
+};


### PR DESCRIPTION
## Summary
- 게시판 글 상세 조회 시 start_time/end_time Timestamp를 필수 파라미터로 요구하고 검증합니다.
- 요청 기간 안에서만 게시글을 반환하도록 상세 조회 로직을 추가했습니다.
- vitest 단위 테스트로 필수 쿼리와 기간 필터링을 점검했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다. (W-000011 / T-000119)
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다. (해당 없음)
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.** (없음)

## Testing
- [x] pnpm --filter @ara/core exec vitest run ../../apps/api/src/board/board.service.test.ts --root ../..


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937836c4f7c8322a082b1ac60c2459e)