### PR TITLE
T-000120: Tooltip 컴포넌트 구현

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,6 +52,11 @@
       "import": "./dist/components/positioner/index.js",
       "default": "./dist/components/positioner/index.js"
     },
+    "./components/tooltip": {
+      "types": "./dist/components/tooltip/index.d.ts",
+      "import": "./dist/components/tooltip/index.js",
+      "default": "./dist/components/tooltip/index.js"
+    },
     "./components/portal": {
       "types": "./dist/components/portal/index.d.ts",
       "import": "./dist/components/portal/index.js",
@@ -121,6 +126,11 @@
       "types": "./dist/components/dismissable-layer/index.d.ts",
       "import": "./dist/components/dismissable-layer/index.js",
       "default": "./dist/components/dismissable-layer/index.js"
+    },
+    "./tooltip": {
+      "types": "./dist/components/tooltip/index.d.ts",
+      "import": "./dist/components/tooltip/index.js",
+      "default": "./dist/components/tooltip/index.js"
     },
     "./positioner": {
       "types": "./dist/components/positioner/index.d.ts",
@@ -208,6 +218,9 @@
       "components/positioner": [
         "dist/components/positioner/index.d.ts"
       ],
+      "components/tooltip": [
+        "dist/components/tooltip/index.d.ts"
+      ],
       "components/portal": [
         "dist/components/portal/index.d.ts"
       ],
@@ -255,6 +268,9 @@
       ],
       "positioner": [
         "dist/components/positioner/index.d.ts"
+      ],
+      "tooltip": [
+        "dist/components/tooltip/index.d.ts"
       ],
       "portal": [
         "dist/components/portal/index.d.ts"

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -9,5 +9,6 @@ export * from "./radio/index.js";
 export * from "./switch/index.js";
 export * from "./spacer/index.js";
 export * from "./positioner/index.js";
+export * from "./tooltip/index.js";
 export * from "./theme-provider/index.js";
 export * from "./text-field/index.js";

--- a/packages/react/src/components/tooltip/index.test.tsx
+++ b/packages/react/src/components/tooltip/index.test.tsx
@@ -1,0 +1,151 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "./index.js";
+
+describe("Tooltip", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("포인터 진입 지연 후 열리고 이탈 후 closeDelay 뒤 닫힌다", async () => {
+    const handleOpenChange = vi.fn();
+
+    render(
+      <Tooltip openDelay={0} closeDelay={0} onOpenChange={handleOpenChange}>
+        <TooltipTrigger asChild>
+          <button type="button">트리거</button>
+        </TooltipTrigger>
+        <TooltipContent>내용</TooltipContent>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "트리거" });
+
+    await act(async () => {
+      fireEvent.pointerEnter(trigger, { pointerType: "mouse" });
+      fireEvent.pointerMove(trigger, { pointerType: "mouse" });
+    });
+
+    await waitFor(() => expect(handleOpenChange).toHaveBeenCalledWith(true));
+    await waitFor(() => expect(trigger).toHaveAttribute("data-state", "open"));
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.pointerLeave(trigger, { pointerType: "mouse" });
+    });
+
+    fireEvent.pointerMove(document.body, { clientX: 0, clientY: 0, pointerType: "mouse" });
+
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+  });
+
+  it("포커스 시 즉시 열리고 blur 시 닫힌다", async () => {
+    render(
+      <Tooltip openDelay={0} closeDelay={0}>
+        <TooltipTrigger asChild>
+          <button type="button">트리거</button>
+        </TooltipTrigger>
+        <TooltipContent>내용</TooltipContent>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "트리거" });
+
+    await act(async () => {
+      trigger.focus();
+    });
+
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    await act(async () => {
+      trigger.blur();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("ESC 및 외부 클릭으로 닫힌다", async () => {
+    function Wrapper() {
+      const [open, setOpen] = useState(true);
+
+      return (
+        <Tooltip open={open} onOpenChange={setOpen} openDelay={0} closeDelay={0}>
+          <TooltipTrigger asChild>
+            <button type="button">트리거</button>
+          </TooltipTrigger>
+          <TooltipContent>내용</TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    render(<Wrapper />);
+
+    const trigger = screen.getByRole("button", { name: "트리거" });
+
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+
+    await act(async () => {
+      trigger.focus();
+    });
+
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.pointerDown(document.body, { pointerType: "mouse" });
+      fireEvent.pointerUp(document.body, { pointerType: "mouse" });
+    });
+
+    await waitFor(() => expect(screen.queryByRole("tooltip")).not.toBeInTheDocument());
+  });
+
+  it("트리거에 aria-describedby를 연결한다", () => {
+    render(
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button type="button">트리거</button>
+        </TooltipTrigger>
+        <TooltipContent id="tooltip-test">내용</TooltipContent>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByRole("button", { name: "트리거" });
+    expect(trigger).toHaveAttribute("aria-describedby", "tooltip-test");
+  });
+
+  it("withArrow 옵션일 때 화살표 데이터를 노출한다", async () => {
+    render(
+      <Tooltip withArrow>
+        <TooltipTrigger>트리거</TooltipTrigger>
+        <TooltipContent>내용</TooltipContent>
+      </Tooltip>
+    );
+
+    const trigger = screen.getByText("트리거");
+
+    await act(async () => {
+      fireEvent.pointerEnter(trigger, { pointerType: "mouse" });
+    });
+
+    const arrow = await screen.findByTestId("tooltip-arrow");
+    expect(arrow).toHaveAttribute("data-side");
+    expect(arrow).toHaveAttribute("data-align");
+  });
+});

--- a/packages/react/src/components/tooltip/index.tsx
+++ b/packages/react/src/components/tooltip/index.tsx
@@ -250,13 +250,13 @@ export function Tooltip(props: TooltipRootProps): JSX.Element {
   );
 }
 
-type TooltipTriggerProps = PropsWithChildren<{
+type TooltipTriggerComponentProps = PropsWithChildren<{
   readonly asChild?: boolean;
   readonly disabled?: boolean;
 }> &
   Omit<HTMLAttributes<HTMLElement>, "children">;
 
-export const TooltipTrigger = forwardRef<HTMLElement, TooltipTriggerProps>(function TooltipTrigger(
+export const TooltipTrigger = forwardRef<HTMLElement, TooltipTriggerComponentProps>(function TooltipTrigger(
   props,
   forwardedRef
 ) {
@@ -324,13 +324,13 @@ export const TooltipTrigger = forwardRef<HTMLElement, TooltipTriggerProps>(funct
   );
 });
 
-type TooltipContentProps = PropsWithChildren<{
+type TooltipContentComponentProps = PropsWithChildren<{
   readonly asChild?: boolean;
   readonly id?: string;
 }> &
   Omit<HTMLAttributes<HTMLElement>, "children">;
 
-export const TooltipContent = forwardRef<HTMLElement, TooltipContentProps>(function TooltipContent(
+export const TooltipContent = forwardRef<HTMLElement, TooltipContentComponentProps>(function TooltipContent(
   props,
   forwardedRef
 ) {

--- a/packages/react/src/components/tooltip/index.tsx
+++ b/packages/react/src/components/tooltip/index.tsx
@@ -1,0 +1,433 @@
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+  type HTMLAttributes,
+  type MutableRefObject,
+  type PropsWithChildren
+} from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { composeRefs } from "@radix-ui/react-compose-refs";
+import {
+  useHoverIntent,
+  type HoverIntentTargetProps,
+  type Placement,
+  type PositionStrategy
+} from "@ara/core";
+
+import { mergeClassNames } from "../layout/shared.js";
+import { Portal } from "../portal/index.js";
+import { usePositioner, type PositionerArrowProps } from "../positioner/index.js";
+
+type TooltipContextValue = {
+  readonly open: boolean;
+  readonly disabled: boolean;
+  readonly placement: Placement;
+  readonly offset: number;
+  readonly strategy: PositionStrategy;
+  readonly withArrow: boolean;
+  readonly portalContainer?: HTMLElement | null;
+  readonly contentId: string;
+  readonly setContentId: (id: string) => void;
+  readonly setOpen: (next: boolean) => void;
+  readonly anchorRef: MutableRefObject<HTMLElement | null>;
+  readonly floatingRef: MutableRefObject<HTMLElement | null>;
+  readonly setAnchor: (node: HTMLElement | null) => void;
+  readonly setFloating: (node: HTMLElement | null) => void;
+  readonly anchorHoverProps: HoverIntentTargetProps;
+  readonly floatingHoverProps: HoverIntentTargetProps;
+};
+
+type TooltipArrowContextValue = {
+  readonly arrowProps?: PositionerArrowProps;
+  readonly withArrow: boolean;
+};
+
+const TooltipContext = createContext<TooltipContextValue | null>(null);
+const TooltipArrowContext = createContext<TooltipArrowContextValue | null>(null);
+
+function useTooltipContext(): TooltipContextValue {
+  const context = useContext(TooltipContext);
+  if (!context) {
+    throw new Error("Tooltip 하위 컴포넌트는 Tooltip 안에서만 사용할 수 있습니다.");
+  }
+  return context;
+}
+
+function useTooltipArrowContext(): TooltipArrowContextValue {
+  const context = useContext(TooltipArrowContext);
+  if (!context) {
+    throw new Error("TooltipArrow는 TooltipContent 내부에서만 사용할 수 있습니다.");
+  }
+  return context;
+}
+
+function composeEventHandlers<Event>(
+  ours: ((event: Event) => void) | undefined,
+  theirs: ((event: Event) => void) | undefined
+): (event: Event) => void {
+  if (!ours && !theirs) return () => {};
+  return (event: Event) => {
+    ours?.(event);
+    theirs?.(event);
+  };
+}
+
+type Side = "top" | "bottom" | "left" | "right";
+type Align = "start" | "center" | "end";
+
+function parsePlacement(placement: Placement): { side: Side; align: Align } {
+  const [side, align] = placement.split("-") as [Side, Align];
+  return { side, align };
+}
+
+type TooltipRootProps = PropsWithChildren<{
+  readonly open?: boolean;
+  readonly defaultOpen?: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+  readonly placement?: Placement;
+  readonly offset?: number;
+  readonly strategy?: PositionStrategy;
+  readonly withArrow?: boolean;
+  readonly openDelay?: number;
+  readonly closeDelay?: number;
+  readonly disabled?: boolean;
+  readonly portalContainer?: HTMLElement | null;
+}> &
+  Pick<HTMLAttributes<HTMLDivElement>, "className" | "style">;
+
+const DEFAULT_PLACEMENT: Placement = "top-start";
+const DEFAULT_OFFSET = 8;
+const DEFAULT_STRATEGY: PositionStrategy = "absolute";
+const DEFAULT_OPEN_DELAY = 300;
+const DEFAULT_CLOSE_DELAY = 150;
+
+export function Tooltip(props: TooltipRootProps): JSX.Element {
+  const {
+    children,
+    open: openProp,
+    defaultOpen = false,
+    onOpenChange,
+    placement = DEFAULT_PLACEMENT,
+    offset = DEFAULT_OFFSET,
+    strategy = DEFAULT_STRATEGY,
+    withArrow = false,
+    openDelay = DEFAULT_OPEN_DELAY,
+    closeDelay = DEFAULT_CLOSE_DELAY,
+    disabled = false,
+    portalContainer,
+    className,
+    style
+  } = props;
+
+  const reactId = useId();
+  const generatedId = useMemo(() => `ara-tooltip-${reactId.replace(/:/g, "-")}`, [reactId]);
+  const [contentId, setContentId] = useState(generatedId);
+
+  const isControlled = openProp !== undefined;
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const open = disabled ? false : isControlled ? Boolean(openProp) : uncontrolledOpen;
+
+  const anchorRef = useRef<HTMLElement | null>(null);
+  const floatingRef = useRef<HTMLElement | null>(null);
+  const [anchorNode, setAnchorNode] = useState<HTMLElement | null>(null);
+  const [floatingNode, setFloatingNode] = useState<HTMLElement | null>(null);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      const resolved = disabled ? false : next;
+      if (!isControlled) {
+        setUncontrolledOpen(resolved);
+      }
+      onOpenChange?.(resolved);
+    },
+    [disabled, isControlled, onOpenChange]
+  );
+
+  useEffect(() => {
+    if (!disabled) return;
+    setUncontrolledOpen(false);
+    onOpenChange?.(false);
+  }, [disabled, onOpenChange]);
+
+  const setAnchor = useCallback((node: HTMLElement | null) => {
+    anchorRef.current = node;
+    setAnchorNode(node);
+  }, []);
+
+  const setFloating = useCallback((node: HTMLElement | null) => {
+    floatingRef.current = node;
+    setFloatingNode(node);
+  }, []);
+
+  const { anchorProps: anchorHoverProps, floatingProps: floatingHoverProps } = useHoverIntent({
+    isOpen: open,
+    openDelay,
+    closeDelay,
+    enableSafePolygon: false,
+    anchor: anchorNode,
+    floating: floatingNode,
+    onOpenChange: handleOpenChange
+  });
+
+  useEffect(() => {
+    if (!open || disabled) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        handleOpenChange(false);
+      }
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (target && (anchorRef.current?.contains(target) || floatingRef.current?.contains(target))) {
+        return;
+      }
+      handleOpenChange(false);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("pointerdown", handlePointerDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, [anchorRef, disabled, floatingRef, handleOpenChange, open]);
+
+  const contextValue = useMemo<TooltipContextValue>(
+    () => ({
+      open,
+      disabled,
+      placement,
+      offset,
+      strategy,
+      withArrow,
+      portalContainer,
+      contentId,
+      setContentId,
+      setOpen: handleOpenChange,
+      anchorRef,
+      floatingRef,
+      setAnchor,
+      setFloating,
+      anchorHoverProps,
+      floatingHoverProps
+    }),
+    [
+      anchorHoverProps,
+      anchorRef,
+      contentId,
+      disabled,
+      floatingHoverProps,
+      floatingRef,
+      handleOpenChange,
+      open,
+      offset,
+      placement,
+      portalContainer,
+      setAnchor,
+      setFloating,
+      strategy,
+      withArrow
+    ]
+  );
+
+  return (
+    <TooltipContext.Provider value={contextValue}>
+      <div className={mergeClassNames("ara-tooltip__root", className)} style={style}>
+        {children}
+      </div>
+    </TooltipContext.Provider>
+  );
+}
+
+type TooltipTriggerProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+  readonly disabled?: boolean;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+export const TooltipTrigger = forwardRef<HTMLElement, TooltipTriggerProps>(function TooltipTrigger(
+  props,
+  forwardedRef
+) {
+  const { children, asChild = false, disabled: disabledProp, className, onPointerEnter, onPointerMove, onPointerLeave, onFocus, onBlur, ...restProps } = props;
+
+  const {
+    open,
+    disabled: contextDisabled,
+    contentId,
+    setOpen,
+    setAnchor,
+    anchorHoverProps
+  } = useTooltipContext();
+  const disabled = contextDisabled || disabledProp;
+
+  const Component = asChild ? Slot : "span";
+  const resolvedClassName = mergeClassNames("ara-tooltip__trigger", className);
+
+  const composedRef = composeRefs<HTMLElement>(forwardedRef, anchorHoverProps.ref, setAnchor);
+
+  const handleFocus = useCallback<NonNullable<HTMLAttributes<HTMLElement>["onFocus"]>>(
+    (event) => {
+      if (disabled) return;
+      setOpen(true);
+      onFocus?.(event);
+    },
+    [disabled, onFocus, setOpen]
+  );
+
+  const handleBlur = useCallback<NonNullable<HTMLAttributes<HTMLElement>["onBlur"]>>(
+    (event) => {
+      if (disabled) return;
+      setOpen(false);
+      onBlur?.(event);
+    },
+    [disabled, onBlur, setOpen]
+  );
+
+  const pointerEnterHandler = disabled
+    ? undefined
+    : composeEventHandlers(anchorHoverProps.onPointerEnter, onPointerEnter);
+  const pointerMoveHandler = disabled
+    ? undefined
+    : composeEventHandlers(anchorHoverProps.onPointerMove, onPointerMove);
+  const pointerLeaveHandler = disabled
+    ? undefined
+    : composeEventHandlers(anchorHoverProps.onPointerLeave, onPointerLeave);
+
+  return (
+    <Component
+      ref={composedRef}
+      className={resolvedClassName}
+      aria-describedby={!disabled ? contentId : undefined}
+      aria-disabled={disabled || undefined}
+      data-state={open ? "open" : "closed"}
+      onPointerEnter={pointerEnterHandler}
+      onPointerMove={pointerMoveHandler}
+      onPointerLeave={pointerLeaveHandler}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      {...restProps}
+    >
+      {children}
+    </Component>
+  );
+});
+
+type TooltipContentProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+  readonly id?: string;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+export const TooltipContent = forwardRef<HTMLElement, TooltipContentProps>(function TooltipContent(
+  props,
+  forwardedRef
+) {
+  const { children, asChild = false, id, className, style, onPointerEnter, onPointerMove, onPointerLeave, ...restProps } = props;
+
+  const {
+    open,
+    disabled,
+    placement,
+    offset,
+    strategy,
+    withArrow,
+    portalContainer,
+    contentId,
+    setContentId,
+    floatingHoverProps,
+    floatingRef,
+    anchorRef,
+    setFloating
+  } = useTooltipContext();
+
+  const resolvedId = id ?? contentId;
+
+  useEffect(() => {
+    setContentId(resolvedId);
+  }, [resolvedId, setContentId]);
+
+  const { floatingProps, arrowProps, placement: resolvedPlacement } = usePositioner({
+    anchorRef,
+    floatingRef,
+    placement,
+    offset,
+    strategy,
+    withArrow
+  });
+
+  const { side, align } = parsePlacement(resolvedPlacement);
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-tooltip", className);
+
+  const composedRef = composeRefs<HTMLElement>(forwardedRef, floatingProps.ref, floatingHoverProps.ref, setFloating);
+
+  const pointerEnterHandler = disabled
+    ? undefined
+    : composeEventHandlers(floatingHoverProps.onPointerEnter, onPointerEnter);
+  const pointerMoveHandler = disabled
+    ? undefined
+    : composeEventHandlers(floatingHoverProps.onPointerMove, onPointerMove);
+  const pointerLeaveHandler = disabled
+    ? undefined
+    : composeEventHandlers(floatingHoverProps.onPointerLeave, onPointerLeave);
+
+  const arrowContext = useMemo<TooltipArrowContextValue>(() => ({ arrowProps, withArrow }), [arrowProps, withArrow]);
+
+  if (!open || disabled) return null;
+
+  return (
+    <TooltipArrowContext.Provider value={arrowContext}>
+      <Portal container={portalContainer} className="ara-tooltip__portal">
+        <Component
+          ref={composedRef}
+          id={resolvedId}
+          role="tooltip"
+          className={resolvedClassName}
+          data-state={open ? "open" : "closed"}
+          data-placement={resolvedPlacement}
+          data-side={side}
+          data-align={align}
+          style={{ ...floatingProps.style, ...(style ?? {}) }}
+          onPointerEnter={pointerEnterHandler}
+          onPointerMove={pointerMoveHandler}
+          onPointerLeave={pointerLeaveHandler}
+          {...restProps}
+        >
+          {children}
+          {withArrow ? <TooltipArrow /> : null}
+        </Component>
+      </Portal>
+    </TooltipArrowContext.Provider>
+  );
+});
+
+export function TooltipArrow(): JSX.Element | null {
+  const { arrowProps, withArrow } = useTooltipArrowContext();
+  if (!withArrow || !arrowProps) return null;
+
+  return (
+    <span
+      {...arrowProps}
+      className={mergeClassNames("ara-tooltip__arrow")}
+      data-testid="tooltip-arrow"
+    ></span>
+  );
+}
+
+export type TooltipProps = TooltipRootProps;
+export type TooltipTriggerProps = ComponentPropsWithoutRef<typeof TooltipTrigger>;
+export type TooltipContentProps = ComponentPropsWithoutRef<typeof TooltipContent>;
+export type TooltipArrowProps = ComponentPropsWithoutRef<typeof TooltipArrow>;


### PR DESCRIPTION
## 요약
- Tooltip/TooltipTrigger/TooltipContent/TooltipArrow 컴포넌트와 포털/포지셔너 연동을 추가했습니다.
- Tooltip 동작(지연, 포커스, ESC/외부 클릭 해제)과 aria 연결을 검증하는 테스트를 작성했습니다.
- @ara/react 패키지의 exports/typesVersions에 tooltip 엔트리를 등록했습니다.

## 테스트
- pnpm --filter @ara/react exec vitest run src/components/tooltip/index.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69378ce7be048322a5cbfd2a3d39aa93)