### PR TITLE
[T-000121] Popover 컴포넌트 구현

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,6 +52,11 @@
       "import": "./dist/components/positioner/index.js",
       "default": "./dist/components/positioner/index.js"
     },
+    "./components/popover": {
+      "types": "./dist/components/popover/index.d.ts",
+      "import": "./dist/components/popover/index.js",
+      "default": "./dist/components/popover/index.js"
+    },
     "./components/tooltip": {
       "types": "./dist/components/tooltip/index.d.ts",
       "import": "./dist/components/tooltip/index.js",
@@ -137,6 +142,11 @@
       "import": "./dist/components/positioner/index.js",
       "default": "./dist/components/positioner/index.js"
     },
+    "./popover": {
+      "types": "./dist/components/popover/index.d.ts",
+      "import": "./dist/components/popover/index.js",
+      "default": "./dist/components/popover/index.js"
+    },
     "./portal": {
       "types": "./dist/components/portal/index.d.ts",
       "import": "./dist/components/portal/index.js",
@@ -218,6 +228,9 @@
       "components/positioner": [
         "dist/components/positioner/index.d.ts"
       ],
+      "components/popover": [
+        "dist/components/popover/index.d.ts"
+      ],
       "components/tooltip": [
         "dist/components/tooltip/index.d.ts"
       ],
@@ -268,6 +281,9 @@
       ],
       "positioner": [
         "dist/components/positioner/index.d.ts"
+      ],
+      "popover": [
+        "dist/components/popover/index.d.ts"
       ],
       "tooltip": [
         "dist/components/tooltip/index.d.ts"

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -9,6 +9,7 @@ export * from "./radio/index.js";
 export * from "./switch/index.js";
 export * from "./spacer/index.js";
 export * from "./positioner/index.js";
+export * from "./popover/index.js";
 export * from "./tooltip/index.js";
 export * from "./theme-provider/index.js";
 export * from "./text-field/index.js";

--- a/packages/react/src/components/popover/index.test.tsx
+++ b/packages/react/src/components/popover/index.test.tsx
@@ -1,0 +1,190 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  Popover,
+  PopoverBody,
+  PopoverClose,
+  PopoverContent,
+  PopoverFooter,
+  PopoverHeader,
+  PopoverTrigger
+} from "./index.js";
+
+describe("Popover", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("트리거 클릭/키보드로 열고 닫는다", async () => {
+    render(
+      <Popover>
+        <PopoverTrigger>열기</PopoverTrigger>
+        <PopoverContent>내용</PopoverContent>
+      </Popover>
+    );
+
+    const trigger = screen.getByRole("button", { name: "열기" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(trigger);
+    });
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveAttribute("data-state", "open");
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+    await act(async () => {
+      await user.click(trigger);
+    });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+    await act(async () => {
+      trigger.focus();
+      await user.keyboard("{Enter}");
+    });
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("ESC 또는 외부 포인터로 닫힌다", async () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>열기</PopoverTrigger>
+        <PopoverContent>내용</PopoverContent>
+      </Popover>
+    );
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    await act(async () => {
+      await user.keyboard("{Escape}");
+    });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "열기" }));
+    });
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      fireEvent.pointerDown(document.body);
+      fireEvent.pointerUp(document.body);
+    });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("closeOnInteractOutside=false이면 포인터 이벤트를 막고 닫지 않는다", async () => {
+    const outsidePointerDown = vi.fn();
+
+    render(
+      <>
+        <Popover defaultOpen closeOnInteractOutside={false}>
+          <PopoverTrigger>열기</PopoverTrigger>
+          <PopoverContent>내용</PopoverContent>
+        </Popover>
+        <button type="button" onPointerDown={(event) => outsidePointerDown(event.defaultPrevented)}>
+          바깥
+        </button>
+      </>
+    );
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      fireEvent.pointerDown(screen.getByRole("button", { name: "바깥" }));
+    });
+
+    expect(outsidePointerDown).toHaveBeenCalledWith(true);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("modal 모드에서 포커스를 가두고 닫힐 때 트리거로 포커스를 돌려준다", async () => {
+    render(
+      <>
+        <Popover defaultOpen modal>
+          <PopoverTrigger>열기</PopoverTrigger>
+          <PopoverContent>
+            <button type="button">확인</button>
+            <button type="button">취소</button>
+            <PopoverClose>닫기</PopoverClose>
+          </PopoverContent>
+        </Popover>
+        <button type="button">외부</button>
+      </>
+    );
+
+    const trigger = document.querySelector<HTMLButtonElement>(".ara-popover__trigger");
+    expect(trigger).not.toBeNull();
+    if (!trigger) {
+      throw new Error("trigger not found");
+    }
+
+    const dialog = await screen.findByRole("dialog");
+    await waitFor(() => expect(document.activeElement).toBe(dialog.querySelector("button")));
+
+    await act(async () => {
+      await user.tab();
+      await user.tab();
+    });
+
+    const activeText = document.activeElement?.textContent;
+    expect(activeText === "확인" || activeText === "취소" || activeText === "닫기").toBe(true);
+    expect(screen.queryByRole("button", { name: "외부" })).toBeNull();
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "닫기" }));
+    });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("Header/Body로 aria-labelledby/aria-describedby를 연결한다", async () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>열기</PopoverTrigger>
+        <PopoverContent>
+          <PopoverHeader>제목</PopoverHeader>
+          <PopoverBody>본문</PopoverBody>
+          <PopoverFooter>푸터</PopoverFooter>
+        </PopoverContent>
+      </Popover>
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    const header = screen.getByText("제목");
+    const body = screen.getByText("본문");
+
+    expect(dialog).toHaveAttribute("aria-labelledby", header.id);
+    expect(dialog).toHaveAttribute("aria-describedby", body.id);
+  });
+
+  it("withArrow 옵션일 때 화살표 데이터를 노출한다", async () => {
+    render(
+      <Popover defaultOpen withArrow>
+        <PopoverTrigger>열기</PopoverTrigger>
+        <PopoverContent>내용</PopoverContent>
+      </Popover>
+    );
+
+    const arrow = await screen.findByTestId("popover-arrow");
+    expect(arrow).toHaveAttribute("data-side");
+    expect(arrow).toHaveAttribute("data-align");
+  });
+});

--- a/packages/react/src/components/popover/index.tsx
+++ b/packages/react/src/components/popover/index.tsx
@@ -1,0 +1,597 @@
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+  type HTMLAttributes,
+  type MutableRefObject,
+  type PropsWithChildren
+} from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { composeRefs } from "@radix-ui/react-compose-refs";
+import {
+  useAriaHidden,
+  useDismissableLayer,
+  useFocusTrap,
+  type DismissableLayerEvent,
+  type Placement,
+  type PositionStrategy
+} from "@ara/core";
+
+import { mergeClassNames } from "../layout/shared.js";
+import { Portal } from "../portal/index.js";
+import { usePositioner, type PositionerArrowProps } from "../positioner/index.js";
+
+type PopoverContextValue = {
+  readonly open: boolean;
+  readonly placement: Placement;
+  readonly offset: number;
+  readonly strategy: PositionStrategy;
+  readonly withArrow: boolean;
+  readonly modal: boolean;
+  readonly closeOnEscape: boolean;
+  readonly closeOnInteractOutside: boolean;
+  readonly closeOnFocusOutside: boolean;
+  readonly returnFocusOnClose: boolean;
+  readonly portalContainer?: HTMLElement | null;
+  readonly contentId: string;
+  readonly headerId: string | null;
+  readonly bodyId: string | null;
+  readonly setContentId: (id: string) => void;
+  readonly registerHeaderId: (id: string | null) => void;
+  readonly registerBodyId: (id: string | null) => void;
+  readonly setOpen: (next: boolean) => void;
+  readonly anchorRef: MutableRefObject<HTMLElement | null>;
+  readonly floatingRef: MutableRefObject<HTMLElement | null>;
+  readonly setAnchor: (node: HTMLElement | null) => void;
+  readonly setFloating: (node: HTMLElement | null) => void;
+};
+
+type PopoverArrowContextValue = {
+  readonly arrowProps?: PositionerArrowProps;
+  readonly withArrow: boolean;
+};
+
+const PopoverContext = createContext<PopoverContextValue | null>(null);
+const PopoverArrowContext = createContext<PopoverArrowContextValue | null>(null);
+
+function usePopoverContext(): PopoverContextValue {
+  const context = useContext(PopoverContext);
+  if (!context) {
+    throw new Error("Popover 하위 컴포넌트는 Popover 안에서만 사용할 수 있습니다.");
+  }
+  return context;
+}
+
+function usePopoverArrowContext(): PopoverArrowContextValue {
+  const context = useContext(PopoverArrowContext);
+  if (!context) {
+    throw new Error("PopoverArrow는 PopoverContent 내부에서만 사용할 수 있습니다.");
+  }
+  return context;
+}
+
+function composeEventHandlers<Event>(
+  first: ((event: Event) => void) | undefined,
+  second: ((event: Event) => void) | undefined
+): (event: Event) => void {
+  if (!first && !second) return () => {};
+  return (event: Event) => {
+    first?.(event);
+    second?.(event);
+  };
+}
+
+type Side = "top" | "bottom" | "left" | "right";
+type Align = "start" | "center" | "end";
+
+function parsePlacement(placement: Placement): { side: Side; align: Align } {
+  const [side, align] = placement.split("-") as [Side, Align];
+  return { side, align };
+}
+
+type PopoverRootProps = PropsWithChildren<{
+  readonly open?: boolean;
+  readonly defaultOpen?: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+  readonly placement?: Placement;
+  readonly offset?: number;
+  readonly strategy?: PositionStrategy;
+  readonly withArrow?: boolean;
+  readonly modal?: boolean;
+  readonly closeOnEscape?: boolean;
+  readonly closeOnInteractOutside?: boolean;
+  readonly closeOnFocusOutside?: boolean;
+  readonly returnFocusOnClose?: boolean;
+  readonly portalContainer?: HTMLElement | null;
+}> &
+  Pick<HTMLAttributes<HTMLDivElement>, "className" | "style">;
+
+const DEFAULT_PLACEMENT: Placement = "bottom-start";
+const DEFAULT_OFFSET = 8;
+const DEFAULT_STRATEGY: PositionStrategy = "absolute";
+
+export function Popover(props: PopoverRootProps): JSX.Element {
+  const {
+    children,
+    open: openProp,
+    defaultOpen = false,
+    onOpenChange,
+    placement = DEFAULT_PLACEMENT,
+    offset = DEFAULT_OFFSET,
+    strategy = DEFAULT_STRATEGY,
+    withArrow = false,
+    modal = false,
+    closeOnEscape = true,
+    closeOnInteractOutside = true,
+    closeOnFocusOutside = true,
+    returnFocusOnClose = true,
+    portalContainer,
+    className,
+    style
+  } = props;
+
+  const reactId = useId();
+  const generatedId = useMemo(() => `ara-popover-${reactId.replace(/:/g, "-")}`, [reactId]);
+  const [contentId, setContentId] = useState(generatedId);
+  const [headerId, setHeaderId] = useState<string | null>(null);
+  const [bodyId, setBodyId] = useState<string | null>(null);
+
+  const isControlled = openProp !== undefined;
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const open = isControlled ? Boolean(openProp) : uncontrolledOpen;
+
+  const anchorRef = useRef<HTMLElement | null>(null);
+  const floatingRef = useRef<HTMLElement | null>(null);
+
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(next);
+      }
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const previousOpenRef = useRef(open);
+  useEffect(() => {
+    if (previousOpenRef.current && !open && returnFocusOnClose) {
+      anchorRef.current?.focus({ preventScroll: true });
+    }
+    previousOpenRef.current = open;
+  }, [open, returnFocusOnClose]);
+
+  const setAnchor = useCallback((node: HTMLElement | null) => {
+    anchorRef.current = node;
+  }, []);
+
+  const setFloating = useCallback((node: HTMLElement | null) => {
+    floatingRef.current = node;
+  }, []);
+
+  const registerHeaderId = useCallback((id: string | null) => setHeaderId(id), []);
+  const registerBodyId = useCallback((id: string | null) => setBodyId(id), []);
+
+  const contextValue = useMemo<PopoverContextValue>(
+    () => ({
+      open,
+      placement,
+      offset,
+      strategy,
+      withArrow,
+      modal,
+      closeOnEscape,
+      closeOnInteractOutside,
+      closeOnFocusOutside,
+      returnFocusOnClose,
+      portalContainer,
+      contentId,
+      headerId,
+      bodyId,
+      setContentId,
+      registerHeaderId,
+      registerBodyId,
+      setOpen: handleOpenChange,
+      anchorRef,
+      floatingRef,
+      setAnchor,
+      setFloating
+    }),
+    [
+      bodyId,
+      closeOnEscape,
+      closeOnFocusOutside,
+      closeOnInteractOutside,
+      contentId,
+      handleOpenChange,
+      headerId,
+      modal,
+      offset,
+      open,
+      placement,
+      portalContainer,
+      registerBodyId,
+      registerHeaderId,
+      returnFocusOnClose,
+      strategy,
+      withArrow
+    ]
+  );
+
+  return (
+    <PopoverContext.Provider value={contextValue}>
+      <div className={mergeClassNames("ara-popover__root", className)} style={style}>
+        {children}
+      </div>
+    </PopoverContext.Provider>
+  );
+}
+
+type PopoverTriggerProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+  readonly disabled?: boolean;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+export const PopoverTrigger = forwardRef<HTMLElement, PopoverTriggerProps>(function PopoverTrigger(
+  props,
+  forwardedRef
+) {
+  const {
+    children,
+    asChild = false,
+    disabled = false,
+    className,
+    onClick,
+    onKeyDown,
+    ...restProps
+  } = props;
+
+  const { open, contentId, setOpen, setAnchor } = usePopoverContext();
+
+  const Component = asChild ? Slot : "button";
+  const resolvedClassName = mergeClassNames("ara-popover__trigger", className);
+
+  const composedRef = composeRefs<HTMLElement>(forwardedRef, setAnchor);
+
+  const toggleOpen = useCallback(() => {
+    if (disabled) return;
+    setOpen(!open);
+  }, [disabled, open, setOpen]);
+
+  const handleClick = useCallback<NonNullable<HTMLAttributes<HTMLElement>["onClick"]>>(
+    (event) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      toggleOpen();
+    },
+    [onClick, toggleOpen]
+  );
+
+  const handleKeyDown = useCallback<NonNullable<HTMLAttributes<HTMLElement>["onKeyDown"]>>(
+    (event) => {
+      onKeyDown?.(event);
+      if (event.defaultPrevented) return;
+
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        toggleOpen();
+      }
+    },
+    [onKeyDown, toggleOpen]
+  );
+
+  return (
+    <Component
+      ref={composedRef}
+      type={!asChild ? "button" : undefined}
+      className={resolvedClassName}
+      aria-haspopup="dialog"
+      aria-expanded={open}
+      aria-controls={contentId}
+      aria-disabled={disabled || undefined}
+      data-state={open ? "open" : "closed"}
+      disabled={!asChild ? disabled : undefined}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      {...restProps}
+    >
+      {children}
+    </Component>
+  );
+});
+
+type PopoverContentProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+  readonly id?: string;
+}> &
+  Omit<
+    HTMLAttributes<HTMLElement>,
+    "children" | "id" | "role" | "aria-label" | "aria-labelledby" | "aria-describedby"
+  > & {
+    readonly "aria-label"?: string;
+    readonly "aria-labelledby"?: string;
+    readonly "aria-describedby"?: string;
+  };
+
+export const PopoverContent = forwardRef<HTMLElement, PopoverContentProps>(function PopoverContent(
+  props,
+  forwardedRef
+) {
+  const {
+    children,
+    asChild = false,
+    id,
+    className,
+    style,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledby,
+    "aria-describedby": ariaDescribedby,
+    onPointerDown,
+    onFocus,
+    ...restProps
+  } = props;
+
+  const {
+    open,
+    placement,
+    offset,
+    strategy,
+    withArrow,
+    modal,
+    closeOnEscape,
+    closeOnInteractOutside,
+    closeOnFocusOutside,
+    returnFocusOnClose,
+    portalContainer,
+    contentId,
+    headerId,
+    bodyId,
+    setContentId,
+    setOpen,
+    anchorRef,
+    floatingRef,
+    setFloating
+  } = usePopoverContext();
+
+  const resolvedId = id ?? contentId;
+
+  useEffect(() => {
+    setContentId(resolvedId);
+  }, [resolvedId, setContentId]);
+
+  const { floatingProps, arrowProps, placement: resolvedPlacement } = usePositioner({
+    anchorRef,
+    floatingRef,
+    placement,
+    offset,
+    strategy,
+    withArrow
+  });
+
+  const { side, align } = parsePlacement(resolvedPlacement);
+
+  const {
+    containerProps: focusTrapContainerProps,
+    beforeFocusGuardProps,
+    afterFocusGuardProps
+  } = useFocusTrap({
+    active: open && modal,
+    restoreFocus: returnFocusOnClose
+  });
+
+  const { containerProps: ariaHiddenContainerProps } = useAriaHidden({
+    active: open && modal,
+    inert: true
+  });
+
+  const { containerProps: dismissableContainerProps } = useDismissableLayer({
+    active: open,
+    onDismiss: (event: DismissableLayerEvent) => {
+      if (event.type === "escape-key" && !closeOnEscape) return;
+      if (event.type === "pointer-down-outside" && !closeOnInteractOutside) return;
+      if (event.type === "focus-outside" && !closeOnFocusOutside) return;
+      setOpen(false);
+    },
+    onPointerDownOutside: (event) => {
+      if (!closeOnInteractOutside) {
+        event.preventDefault();
+      }
+    },
+    onFocusOutside: (event) => {
+      if (!closeOnFocusOutside) {
+        event.preventDefault();
+      }
+    }
+  });
+
+  const { ref: positionerFloatingRef, style: floatingStyle, ...restFloatingProps } = floatingProps;
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-popover", className);
+
+  const wrapperRef = composeRefs<HTMLElement>(
+    positionerFloatingRef,
+    setFloating,
+    focusTrapContainerProps.ref,
+    ariaHiddenContainerProps.ref,
+    dismissableContainerProps.ref
+  );
+
+  const contentRef = composeRefs<HTMLElement>(forwardedRef);
+
+  const labelledBy = useMemo(() => {
+    const ids = [ariaLabelledby, headerId].filter(Boolean).join(" ");
+    return ids.length > 0 ? ids : undefined;
+  }, [ariaLabelledby, headerId]);
+
+  const describedBy = useMemo(() => {
+    const ids = [ariaDescribedby, bodyId].filter(Boolean).join(" ");
+    return ids.length > 0 ? ids : undefined;
+  }, [ariaDescribedby, bodyId]);
+
+  const focusGuardStyle = useMemo(
+    () => ({ position: "fixed", width: 0, height: 0, padding: 0, margin: 0, outline: "none", opacity: 0 }),
+    []
+  );
+
+  const arrowContext = useMemo<PopoverArrowContextValue>(() => ({ arrowProps, withArrow }), [arrowProps, withArrow]);
+
+  if (!open) return null;
+
+  return (
+    <PopoverArrowContext.Provider value={arrowContext}>
+      <Portal container={portalContainer} className="ara-popover__portal">
+        <div ref={wrapperRef} style={floatingStyle} {...restFloatingProps}>
+          {modal ? <span {...beforeFocusGuardProps} style={focusGuardStyle} /> : null}
+          <Component
+            ref={contentRef}
+            id={resolvedId}
+            role="dialog"
+            aria-modal={modal || undefined}
+            aria-label={ariaLabel}
+            aria-labelledby={labelledBy}
+            aria-describedby={describedBy}
+            className={resolvedClassName}
+            data-state={open ? "open" : "closed"}
+            data-placement={resolvedPlacement}
+            data-side={side}
+            data-align={align}
+            data-modal={modal ? "true" : undefined}
+            style={style}
+            onPointerDown={composeEventHandlers(onPointerDown, restProps.onPointerDown)}
+            onFocus={composeEventHandlers(onFocus, restProps.onFocus)}
+            {...restProps}
+          >
+            {children}
+            {withArrow ? <PopoverArrow /> : null}
+          </Component>
+          {modal ? <span {...afterFocusGuardProps} style={focusGuardStyle} /> : null}
+        </div>
+      </Portal>
+    </PopoverArrowContext.Provider>
+  );
+});
+
+export function PopoverArrow(): JSX.Element | null {
+  const { arrowProps, withArrow } = usePopoverArrowContext();
+  if (!withArrow || !arrowProps) return null;
+
+  return <span {...arrowProps} className={mergeClassNames("ara-popover__arrow")} data-testid="popover-arrow" />;
+}
+
+type PopoverCloseProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+export const PopoverClose = forwardRef<HTMLElement, PopoverCloseProps>(function PopoverClose(props, forwardedRef) {
+  const { children, asChild = false, className, onClick, ...restProps } = props;
+  const { setOpen } = usePopoverContext();
+
+  const Component = asChild ? Slot : "button";
+  const resolvedClassName = mergeClassNames("ara-popover__close", className);
+
+  const handleClick = useCallback<NonNullable<HTMLAttributes<HTMLElement>["onClick"]>>(
+    (event) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      setOpen(false);
+    },
+    [onClick, setOpen]
+  );
+
+  return (
+    <Component
+      ref={forwardedRef}
+      type={!asChild ? "button" : undefined}
+      className={resolvedClassName}
+      onClick={handleClick}
+      {...restProps}
+    >
+      {children}
+    </Component>
+  );
+});
+
+type PopoverSectionProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+  readonly id?: string;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+export const PopoverHeader = forwardRef<HTMLElement, PopoverSectionProps>(function PopoverHeader(
+  props,
+  forwardedRef
+) {
+  const { children, asChild = false, id, className, ...restProps } = props;
+  const { registerHeaderId } = usePopoverContext();
+  const reactId = useId();
+  const resolvedId = id ?? `ara-popover-header-${reactId.replace(/:/g, "-")}`;
+
+  useEffect(() => {
+    registerHeaderId(resolvedId);
+    return () => registerHeaderId(null);
+  }, [registerHeaderId, resolvedId]);
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-popover__header", className);
+
+  return (
+    <Component ref={forwardedRef} id={resolvedId} className={resolvedClassName} {...restProps}>
+      {children}
+    </Component>
+  );
+});
+
+export const PopoverBody = forwardRef<HTMLElement, PopoverSectionProps>(function PopoverBody(props, forwardedRef) {
+  const { children, asChild = false, id, className, ...restProps } = props;
+  const { registerBodyId } = usePopoverContext();
+  const reactId = useId();
+  const resolvedId = id ?? `ara-popover-body-${reactId.replace(/:/g, "-")}`;
+
+  useEffect(() => {
+    registerBodyId(resolvedId);
+    return () => registerBodyId(null);
+  }, [registerBodyId, resolvedId]);
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-popover__body", className);
+
+  return (
+    <Component ref={forwardedRef} id={resolvedId} className={resolvedClassName} {...restProps}>
+      {children}
+    </Component>
+  );
+});
+
+export const PopoverFooter = forwardRef<HTMLElement, PropsWithChildren<Omit<PopoverSectionProps, "id">>>(
+  function PopoverFooter(props, forwardedRef) {
+    const { children, asChild = false, className, ...restProps } = props;
+
+    const Component = asChild ? Slot : "div";
+    const resolvedClassName = mergeClassNames("ara-popover__footer", className);
+
+    return (
+      <Component ref={forwardedRef} className={resolvedClassName} {...restProps}>
+        {children}
+      </Component>
+    );
+  }
+);
+
+export type PopoverProps = PopoverRootProps;
+export type PopoverTriggerProps = ComponentPropsWithoutRef<typeof PopoverTrigger>;
+export type PopoverContentProps = ComponentPropsWithoutRef<typeof PopoverContent>;
+export type PopoverArrowProps = ComponentPropsWithoutRef<typeof PopoverArrow>;
+export type PopoverCloseProps = ComponentPropsWithoutRef<typeof PopoverClose>;
+export type PopoverHeaderProps = ComponentPropsWithoutRef<typeof PopoverHeader>;
+export type PopoverBodyProps = ComponentPropsWithoutRef<typeof PopoverBody>;
+export type PopoverFooterProps = ComponentPropsWithoutRef<typeof PopoverFooter>;

--- a/packages/react/src/components/popover/index.tsx
+++ b/packages/react/src/components/popover/index.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
   type ComponentPropsWithoutRef,
+  type CSSProperties,
   type HTMLAttributes,
   type MutableRefObject,
   type PropsWithChildren
@@ -234,13 +235,13 @@ export function Popover(props: PopoverRootProps): JSX.Element {
   );
 }
 
-type PopoverTriggerProps = PropsWithChildren<{
+type PopoverTriggerComponentProps = PropsWithChildren<{
   readonly asChild?: boolean;
   readonly disabled?: boolean;
 }> &
   Omit<HTMLAttributes<HTMLElement>, "children">;
 
-export const PopoverTrigger = forwardRef<HTMLElement, PopoverTriggerProps>(function PopoverTrigger(
+export const PopoverTrigger = forwardRef<HTMLButtonElement, PopoverTriggerComponentProps>(function PopoverTrigger(
   props,
   forwardedRef
 ) {
@@ -259,7 +260,7 @@ export const PopoverTrigger = forwardRef<HTMLElement, PopoverTriggerProps>(funct
   const Component = asChild ? Slot : "button";
   const resolvedClassName = mergeClassNames("ara-popover__trigger", className);
 
-  const composedRef = composeRefs<HTMLElement>(forwardedRef, setAnchor);
+  const composedRef = composeRefs<HTMLButtonElement>(forwardedRef, setAnchor);
 
   const toggleOpen = useCallback(() => {
     if (disabled) return;
@@ -308,20 +309,17 @@ export const PopoverTrigger = forwardRef<HTMLElement, PopoverTriggerProps>(funct
   );
 });
 
-type PopoverContentProps = PropsWithChildren<{
+type PopoverContentComponentProps = PropsWithChildren<{
   readonly asChild?: boolean;
   readonly id?: string;
 }> &
-  Omit<
-    HTMLAttributes<HTMLElement>,
-    "children" | "id" | "role" | "aria-label" | "aria-labelledby" | "aria-describedby"
-  > & {
+  Omit<HTMLAttributes<HTMLElement>, "children" | "id" | "role"> & {
     readonly "aria-label"?: string;
     readonly "aria-labelledby"?: string;
     readonly "aria-describedby"?: string;
   };
 
-export const PopoverContent = forwardRef<HTMLElement, PopoverContentProps>(function PopoverContent(
+export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentComponentProps>(function PopoverContent(
   props,
   forwardedRef
 ) {
@@ -334,8 +332,8 @@ export const PopoverContent = forwardRef<HTMLElement, PopoverContentProps>(funct
     "aria-label": ariaLabel,
     "aria-labelledby": ariaLabelledby,
     "aria-describedby": ariaDescribedby,
-    onPointerDown,
-    onFocus,
+    onPointerDown: userPointerDown,
+    onFocus: userFocus,
     ...restProps
   } = props;
 
@@ -417,7 +415,7 @@ export const PopoverContent = forwardRef<HTMLElement, PopoverContentProps>(funct
   const Component = asChild ? Slot : "div";
   const resolvedClassName = mergeClassNames("ara-popover", className);
 
-  const wrapperRef = composeRefs<HTMLElement>(
+  const wrapperRef = composeRefs<HTMLDivElement>(
     positionerFloatingRef,
     setFloating,
     focusTrapContainerProps.ref,
@@ -425,7 +423,7 @@ export const PopoverContent = forwardRef<HTMLElement, PopoverContentProps>(funct
     dismissableContainerProps.ref
   );
 
-  const contentRef = composeRefs<HTMLElement>(forwardedRef);
+  const contentRef = composeRefs<HTMLDivElement>(forwardedRef);
 
   const labelledBy = useMemo(() => {
     const ids = [ariaLabelledby, headerId].filter(Boolean).join(" ");
@@ -437,10 +435,15 @@ export const PopoverContent = forwardRef<HTMLElement, PopoverContentProps>(funct
     return ids.length > 0 ? ids : undefined;
   }, [ariaDescribedby, bodyId]);
 
-  const focusGuardStyle = useMemo(
-    () => ({ position: "fixed", width: 0, height: 0, padding: 0, margin: 0, outline: "none", opacity: 0 }),
-    []
-  );
+  const focusGuardStyle: CSSProperties = {
+    position: "fixed",
+    width: 0,
+    height: 0,
+    padding: 0,
+    margin: 0,
+    outline: "none",
+    opacity: 0
+  };
 
   const arrowContext = useMemo<PopoverArrowContextValue>(() => ({ arrowProps, withArrow }), [arrowProps, withArrow]);
 
@@ -466,8 +469,8 @@ export const PopoverContent = forwardRef<HTMLElement, PopoverContentProps>(funct
             data-align={align}
             data-modal={modal ? "true" : undefined}
             style={style}
-            onPointerDown={composeEventHandlers(onPointerDown, restProps.onPointerDown)}
-            onFocus={composeEventHandlers(onFocus, restProps.onFocus)}
+            onPointerDown={userPointerDown}
+            onFocus={userFocus}
             {...restProps}
           >
             {children}
@@ -487,12 +490,15 @@ export function PopoverArrow(): JSX.Element | null {
   return <span {...arrowProps} className={mergeClassNames("ara-popover__arrow")} data-testid="popover-arrow" />;
 }
 
-type PopoverCloseProps = PropsWithChildren<{
+type PopoverCloseComponentProps = PropsWithChildren<{
   readonly asChild?: boolean;
 }> &
   Omit<HTMLAttributes<HTMLElement>, "children">;
 
-export const PopoverClose = forwardRef<HTMLElement, PopoverCloseProps>(function PopoverClose(props, forwardedRef) {
+export const PopoverClose = forwardRef<HTMLButtonElement, PopoverCloseComponentProps>(function PopoverClose(
+  props,
+  forwardedRef
+) {
   const { children, asChild = false, className, onClick, ...restProps } = props;
   const { setOpen } = usePopoverContext();
 
@@ -527,7 +533,7 @@ type PopoverSectionProps = PropsWithChildren<{
 }> &
   Omit<HTMLAttributes<HTMLElement>, "children">;
 
-export const PopoverHeader = forwardRef<HTMLElement, PopoverSectionProps>(function PopoverHeader(
+export const PopoverHeader = forwardRef<HTMLDivElement, PopoverSectionProps>(function PopoverHeader(
   props,
   forwardedRef
 ) {
@@ -551,7 +557,10 @@ export const PopoverHeader = forwardRef<HTMLElement, PopoverSectionProps>(functi
   );
 });
 
-export const PopoverBody = forwardRef<HTMLElement, PopoverSectionProps>(function PopoverBody(props, forwardedRef) {
+export const PopoverBody = forwardRef<HTMLDivElement, PopoverSectionProps>(function PopoverBody(
+  props,
+  forwardedRef
+) {
   const { children, asChild = false, id, className, ...restProps } = props;
   const { registerBodyId } = usePopoverContext();
   const reactId = useId();
@@ -572,7 +581,7 @@ export const PopoverBody = forwardRef<HTMLElement, PopoverSectionProps>(function
   );
 });
 
-export const PopoverFooter = forwardRef<HTMLElement, PropsWithChildren<Omit<PopoverSectionProps, "id">>>(
+export const PopoverFooter = forwardRef<HTMLDivElement, PropsWithChildren<Omit<PopoverSectionProps, "id">>>(
   function PopoverFooter(props, forwardedRef) {
     const { children, asChild = false, className, ...restProps } = props;
 


### PR DESCRIPTION
## Summary
- [x] Popover 트리거/콘텐츠/헤더/바디/푸터/닫기/화살표 슬롯을 포함한 React 컴포넌트를 추가하고 모달/비모달 동작을 지원했습니다.
- [x] DismissableLayer, FocusTrap, AriaHidden, Positioner를 조합해 포커스 가두기·외부 inert 처리·포지셔닝/화살표 데이터를 연동했습니다.
- [x] Popover의 토글, 해제, 모달 포커스 트랩, aria 연결, 화살표 노출 시나리오를 Vitest로 검증했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.** (없음)

## Testing
- [x] `pnpm --filter @ara/react test -- src/components/popover/index.test.tsx` (Node 20 환경 경고 무시)

## Screenshots
해당 사항 없음.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69488e3bd7108322afb60e1dc161c86f)