### PR TITLE
[T-000122] Menu 컴포넌트 구현

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,7 +115,7 @@ export type {
   UseMenuResult
 } from "./overlays/use-menu.js";
 export { useMenu } from "./overlays/use-menu.js";
-export type { UseMenuItemOptions, UseMenuItemResult } from "./overlays/use-menu-item.js";
+export type { MenuItemRole, UseMenuItemOptions, UseMenuItemResult } from "./overlays/use-menu-item.js";
 export { useMenuItem } from "./overlays/use-menu-item.js";
 export type { UseMenuTriggerOptions, UseMenuTriggerResult } from "./overlays/use-menu-trigger.js";
 export { useMenuTrigger } from "./overlays/use-menu-trigger.js";

--- a/packages/core/src/overlays/use-menu.ts
+++ b/packages/core/src/overlays/use-menu.ts
@@ -31,6 +31,8 @@ function createTypeaheadItem(item: InternalMenuItem): TypeaheadItem {
 }
 
 export interface UseMenuOptions {
+  /** 메뉴 id. 지정하지 않으면 자동 생성된다. */
+  readonly id?: string;
   /** 제어 모드: 메뉴 열림 여부. */
   readonly open?: boolean;
   /** 비제어 모드: 초기 열림 여부. */
@@ -39,6 +41,10 @@ export interface UseMenuOptions {
   readonly onOpenChange?: (open: boolean) => void;
   /** 선택 시 메뉴를 닫을지 여부. 기본 true. */
   readonly closeOnSelect?: boolean;
+  /** roving focus가 끝에서 다시 처음으로 순환할지 여부. 기본 true. */
+  readonly loopFocus?: boolean;
+  /** typeahead 버퍼 리셋까지의 시간(ms). 기본 700. */
+  readonly typeaheadTimeout?: number;
 }
 
 export interface MenuItemRegistration {
@@ -72,9 +78,17 @@ export interface UseMenuResult {
 }
 
 export function useMenu(options: UseMenuOptions = {}): UseMenuResult {
-  const { open, defaultOpen = false, onOpenChange, closeOnSelect = true } = options;
+  const {
+    id,
+    open,
+    defaultOpen = false,
+    onOpenChange,
+    closeOnSelect = true,
+    loopFocus = true,
+    typeaheadTimeout
+  } = options;
 
-  const menuId = useId();
+  const menuId = id ?? useId();
   const triggerRef = useRef<HTMLElement | null>(null);
   const [typeaheadItems, setTypeaheadItems] = useState<TypeaheadItem[]>([]);
   const itemsRef = useRef<InternalMenuItem[]>([]);
@@ -85,7 +99,7 @@ export function useMenu(options: UseMenuOptions = {}): UseMenuResult {
 
   const { activeId, registerItem, setActiveId, handleKeyDown, updateTabStops } = useRovingFocus({
     orientation: "vertical",
-    loop: true
+    loop: loopFocus
   });
 
   const focusItem = useCallback((id: string | null) => {
@@ -148,6 +162,7 @@ export function useMenu(options: UseMenuOptions = {}): UseMenuResult {
     items: typeaheadItems,
     activeId,
     loop: true,
+    timeout: typeaheadTimeout,
     onMatch: (match) => {
       setActiveId(match.id);
       focusItem(match.id);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,6 +57,11 @@
       "import": "./dist/components/popover/index.js",
       "default": "./dist/components/popover/index.js"
     },
+    "./components/menu": {
+      "types": "./dist/components/menu/index.d.ts",
+      "import": "./dist/components/menu/index.js",
+      "default": "./dist/components/menu/index.js"
+    },
     "./components/tooltip": {
       "types": "./dist/components/tooltip/index.d.ts",
       "import": "./dist/components/tooltip/index.js",
@@ -147,6 +152,11 @@
       "import": "./dist/components/popover/index.js",
       "default": "./dist/components/popover/index.js"
     },
+    "./menu": {
+      "types": "./dist/components/menu/index.d.ts",
+      "import": "./dist/components/menu/index.js",
+      "default": "./dist/components/menu/index.js"
+    },
     "./portal": {
       "types": "./dist/components/portal/index.d.ts",
       "import": "./dist/components/portal/index.js",
@@ -231,6 +241,9 @@
       "components/popover": [
         "dist/components/popover/index.d.ts"
       ],
+      "components/menu": [
+        "dist/components/menu/index.d.ts"
+      ],
       "components/tooltip": [
         "dist/components/tooltip/index.d.ts"
       ],
@@ -284,6 +297,9 @@
       ],
       "popover": [
         "dist/components/popover/index.d.ts"
+      ],
+      "menu": [
+        "dist/components/menu/index.d.ts"
       ],
       "tooltip": [
         "dist/components/tooltip/index.d.ts"

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -10,6 +10,7 @@ export * from "./switch/index.js";
 export * from "./spacer/index.js";
 export * from "./positioner/index.js";
 export * from "./popover/index.js";
+export * from "./menu/index.js";
 export * from "./tooltip/index.js";
 export * from "./theme-provider/index.js";
 export * from "./text-field/index.js";

--- a/packages/react/src/components/menu/index.test.tsx
+++ b/packages/react/src/components/menu/index.test.tsx
@@ -1,0 +1,214 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  Menu,
+  MenuCheckboxItem,
+  MenuContent,
+  MenuItem,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSub,
+  MenuSubContent,
+  MenuSubTrigger,
+  MenuTrigger
+} from "./index.js";
+
+describe("Menu", () => {
+  let user: ReturnType<typeof userEvent.setup>;
+
+  beforeEach(() => {
+    user = userEvent.setup();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("트리거를 클릭/키보드로 열고 ESC로 닫으며 포커스를 되돌린다", async () => {
+    render(
+      <Menu>
+        <MenuTrigger>열기</MenuTrigger>
+        <MenuContent aria-label="루트 메뉴">
+          <MenuItem>항목 1</MenuItem>
+          <MenuItem>항목 2</MenuItem>
+        </MenuContent>
+      </Menu>
+    );
+
+    const trigger = screen.getByRole("button", { name: "열기" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await act(async () => {
+      await user.click(trigger);
+    });
+
+    await screen.findByRole("menu", { name: "루트 메뉴" });
+    const firstItem = screen.getByText("항목 1").closest("[role=\"menuitem\"]");
+    expect(firstItem).not.toBeNull();
+    expect(firstItem).toHaveAttribute("data-highlighted", "true");
+
+    await act(async () => {
+      await user.keyboard("{Escape}");
+    });
+
+    await waitFor(() => expect(screen.queryByRole("menu")).not.toBeInTheDocument());
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("closeOnSelect=false일 때 선택해도 열림 상태를 유지한다", async () => {
+    render(
+      <Menu closeOnSelect={false}>
+        <MenuTrigger>열기</MenuTrigger>
+        <MenuContent aria-label="루트 메뉴">
+          <MenuItem>항목 1</MenuItem>
+          <MenuItem>항목 2</MenuItem>
+        </MenuContent>
+      </Menu>
+    );
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "열기" }));
+    });
+
+    const secondItem = screen.getByText("항목 2");
+    await act(async () => {
+      await user.click(secondItem);
+    });
+
+    expect(screen.getByRole("menu", { name: "루트 메뉴" })).toBeInTheDocument();
+  });
+
+  it("Arrow/Home/End/typeahead로 항목을 탐색한다", async () => {
+    render(
+      <Menu>
+        <MenuTrigger>열기</MenuTrigger>
+        <MenuContent aria-label="루트 메뉴">
+          <MenuItem>Alpha</MenuItem>
+          <MenuItem>Beta</MenuItem>
+          <MenuItem>Charlie</MenuItem>
+        </MenuContent>
+      </Menu>
+    );
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "열기" }));
+    });
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items[0]).toHaveAttribute("data-highlighted", "true");
+
+    await act(async () => {
+      await user.keyboard("{ArrowDown}");
+    });
+    expect(items[1]).toHaveAttribute("data-highlighted", "true");
+
+    await act(async () => {
+      await user.keyboard("{End}");
+    });
+    expect(items[2]).toHaveAttribute("data-highlighted", "true");
+
+    await act(async () => {
+      await user.keyboard("{Home}");
+    });
+    expect(items[0]).toHaveAttribute("data-highlighted", "true");
+
+    await act(async () => {
+      await user.keyboard("c");
+    });
+    expect(items[2]).toHaveAttribute("data-highlighted", "true");
+  });
+
+  it("체크박스/라디오 항목 상태와 aria 속성을 노출한다", async () => {
+    function MenuWithState(): JSX.Element {
+      const [checked, setChecked] = useState(false);
+      const [direction, setDirection] = useState("left");
+
+      return (
+        <Menu>
+          <MenuTrigger>열기</MenuTrigger>
+          <MenuContent aria-label="루트 메뉴">
+            <MenuCheckboxItem checked={checked} onCheckedChange={setChecked}>
+              체크
+            </MenuCheckboxItem>
+            <MenuRadioGroup value={direction} onValueChange={setDirection}>
+              <MenuRadioItem value="left">왼쪽</MenuRadioItem>
+              <MenuRadioItem value="right">오른쪽</MenuRadioItem>
+            </MenuRadioGroup>
+          </MenuContent>
+        </Menu>
+      );
+    }
+
+    render(<MenuWithState />);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "열기" }));
+    });
+
+    const checkbox = screen.getByText("체크").closest("[role=\"menuitemcheckbox\"]");
+    const radio = screen.getByText("왼쪽").closest("[role=\"menuitemradio\"]");
+    expect(checkbox).not.toBeNull();
+    expect(radio).not.toBeNull();
+    expect(checkbox).toHaveAttribute("aria-checked", "false");
+    expect(radio).toHaveAttribute("aria-checked", "true");
+
+    await act(async () => {
+      await user.click(checkbox!);
+      await user.click(screen.getByText("오른쪽"));
+    });
+
+    expect(checkbox).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByText("오른쪽").closest("[role=\"menuitemradio\"]")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("서브메뉴를 ArrowRight/ArrowLeft로 열고 닫는다", async () => {
+    render(
+      <Menu>
+        <MenuTrigger>열기</MenuTrigger>
+        <MenuContent aria-label="루트 메뉴">
+          <MenuItem>단일</MenuItem>
+          <MenuSub>
+            <MenuSubTrigger>더보기</MenuSubTrigger>
+            <MenuSubContent aria-label="서브 메뉴">
+              <MenuItem>서브 1</MenuItem>
+              <MenuItem>서브 2</MenuItem>
+            </MenuSubContent>
+          </MenuSub>
+        </MenuContent>
+      </Menu>
+    );
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "열기" }));
+    });
+
+    await act(async () => {
+      await user.keyboard("{ArrowDown}");
+    });
+
+    const subTrigger = screen.getByText("더보기").closest("[role=\"menuitem\"]");
+    expect(subTrigger).not.toBeNull();
+    expect(subTrigger).toHaveAttribute("data-highlighted", "true");
+
+    await act(async () => {
+      await user.keyboard("{ArrowRight}");
+    });
+
+    const subMenu = await screen.findByRole("menu", { name: "서브 메뉴" });
+    expect(subMenu).toBeInTheDocument();
+    const firstSubItem = screen.getByText("서브 1").closest("[role=\"menuitem\"]");
+    expect(firstSubItem).not.toBeNull();
+    expect(firstSubItem).toHaveAttribute("data-highlighted", "true");
+
+    await act(async () => {
+      await user.keyboard("{ArrowLeft}");
+    });
+
+    await waitFor(() => expect(screen.queryByRole("menu", { name: "서브 메뉴" })).not.toBeInTheDocument());
+    expect(subTrigger).toHaveAttribute("data-highlighted", "true");
+  });
+});

--- a/packages/react/src/components/menu/index.tsx
+++ b/packages/react/src/components/menu/index.tsx
@@ -509,7 +509,7 @@ function MenuItemBase(
   componentClassName: string,
   extraProps?: (isHighlighted: boolean) => Record<string, unknown>
 ) {
-  return forwardRef<HTMLElement, MenuItemComponentProps>(function MenuItem(props, forwardedRef) {
+  return forwardRef<HTMLDivElement, MenuItemComponentProps>(function MenuItem(props, forwardedRef) {
     const {
       children,
       asChild = false,
@@ -523,7 +523,6 @@ function MenuItemBase(
       onKeyDown,
       onPointerEnter,
       onPointerMove,
-      onPointerLeave,
       onFocus,
       ...restProps
     } = props;
@@ -543,9 +542,11 @@ function MenuItemBase(
 
     const clickHandler = composeEventHandlers(itemProps.onClick, onClick);
     const keyDownHandler = composeEventHandlers(itemProps.onKeyDown, onKeyDown);
-    const pointerEnterHandler = composeEventHandlers(itemProps.onPointerEnter, onPointerEnter);
+    const pointerEnterHandler = composeEventHandlers<React.PointerEvent<HTMLElement>>(
+      (event) => itemProps.onPointerMove(event as never),
+      onPointerEnter
+    );
     const pointerMoveHandler = composeEventHandlers(itemProps.onPointerMove, onPointerMove);
-    const pointerLeaveHandler = composeEventHandlers(itemProps.onPointerLeave, onPointerLeave);
     const focusHandler = composeEventHandlers(itemProps.onFocus, onFocus);
 
     return (
@@ -561,7 +562,6 @@ function MenuItemBase(
         onKeyDown={keyDownHandler}
         onPointerEnter={pointerEnterHandler}
         onPointerMove={pointerMoveHandler}
-        onPointerLeave={pointerLeaveHandler}
         onFocus={focusHandler}
         {...extraProps?.(isHighlighted)}
       >
@@ -574,18 +574,18 @@ function MenuItemBase(
 
 export const MenuItem = MenuItemBase("menuitem", "ara-menu__item");
 
-type MenuCheckboxItemProps = MenuItemComponentProps & {
+type MenuCheckboxItemComponentProps = MenuItemComponentProps & {
   readonly checked: boolean;
   readonly onCheckedChange: (checked: boolean) => void;
 };
 
-export const MenuCheckboxItem = forwardRef<HTMLElement, MenuCheckboxItemProps>(function MenuCheckboxItem(
+export const MenuCheckboxItem = forwardRef<HTMLDivElement, MenuCheckboxItemComponentProps>(function MenuCheckboxItem(
   props,
   forwardedRef
 ) {
   const { checked, onCheckedChange, onSelect, ...restProps } = props;
 
-  const handleSelect = useCallback<MenuCheckboxItemProps["onSelect"]>(
+  const handleSelect = useCallback(
     (event) => {
       onSelect?.(event);
       onCheckedChange(!checked);
@@ -606,7 +606,7 @@ export const MenuCheckboxItem = forwardRef<HTMLElement, MenuCheckboxItemProps>(f
   );
 });
 
-type MenuRadioGroupProps = PropsWithChildren<{
+type MenuRadioGroupComponentProps = PropsWithChildren<{
   readonly value: string;
   readonly onValueChange: (value: string) => void;
   readonly name?: string;
@@ -614,7 +614,7 @@ type MenuRadioGroupProps = PropsWithChildren<{
 }> &
   Omit<HTMLAttributes<HTMLElement>, "children">;
 
-export const MenuRadioGroup = forwardRef<HTMLElement, MenuRadioGroupProps>(function MenuRadioGroup(
+export const MenuRadioGroup = forwardRef<HTMLDivElement, MenuRadioGroupComponentProps>(function MenuRadioGroup(
   props,
   forwardedRef
 ) {
@@ -637,11 +637,11 @@ export const MenuRadioGroup = forwardRef<HTMLElement, MenuRadioGroupProps>(funct
   );
 });
 
-type MenuRadioItemProps = MenuItemComponentProps & {
+type MenuRadioItemComponentProps = MenuItemComponentProps & {
   readonly value: string;
 };
 
-export const MenuRadioItem = forwardRef<HTMLElement, MenuRadioItemProps>(function MenuRadioItem(
+export const MenuRadioItem = forwardRef<HTMLDivElement, MenuRadioItemComponentProps>(function MenuRadioItem(
   props,
   forwardedRef
 ) {
@@ -649,7 +649,7 @@ export const MenuRadioItem = forwardRef<HTMLElement, MenuRadioItemProps>(functio
   const radioGroup = useMenuRadioGroupContext();
   const checked = radioGroup.value === value;
 
-  const handleSelect = useCallback<MenuRadioItemProps["onSelect"]>(
+  const handleSelect = useCallback(
     (event) => {
       onSelect?.(event);
       if (!checked) {
@@ -672,12 +672,12 @@ export const MenuRadioItem = forwardRef<HTMLElement, MenuRadioItemProps>(functio
   );
 });
 
-type MenuGroupProps = PropsWithChildren<{
+type MenuGroupComponentProps = PropsWithChildren<{
   readonly asChild?: boolean;
 }> &
   Omit<HTMLAttributes<HTMLElement>, "children">;
 
-export const MenuGroup = forwardRef<HTMLElement, MenuGroupProps>(function MenuGroup(props, forwardedRef) {
+export const MenuGroup = forwardRef<HTMLDivElement, MenuGroupComponentProps>(function MenuGroup(props, forwardedRef) {
   const { children, asChild = false, className, ...restProps } = props;
 
   const [labelId, setLabelId] = useState<string | null>(null);
@@ -696,13 +696,13 @@ export const MenuGroup = forwardRef<HTMLElement, MenuGroupProps>(function MenuGr
   );
 });
 
-type MenuLabelProps = PropsWithChildren<{
+type MenuLabelComponentProps = PropsWithChildren<{
   readonly asChild?: boolean;
   readonly id?: string;
 }> &
   Omit<HTMLAttributes<HTMLElement>, "children">;
 
-export const MenuLabel = forwardRef<HTMLElement, MenuLabelProps>(function MenuLabel(props, forwardedRef) {
+export const MenuLabel = forwardRef<HTMLDivElement, MenuLabelComponentProps>(function MenuLabel(props, forwardedRef) {
   const { children, asChild = false, id, className, ...restProps } = props;
   const group = useMenuGroupContext();
 
@@ -724,7 +724,7 @@ export const MenuLabel = forwardRef<HTMLElement, MenuLabelProps>(function MenuLa
   );
 });
 
-export const MenuSeparator = forwardRef<HTMLElement, ComponentPropsWithoutRef<"div">>(function MenuSeparator(
+export const MenuSeparator = forwardRef<HTMLDivElement, ComponentPropsWithoutRef<"div">>(function MenuSeparator(
   props,
   forwardedRef
 ) {
@@ -749,7 +749,7 @@ export function MenuArrow(): JSX.Element | null {
   return <span {...arrowProps} className={mergeClassNames("ara-menu__arrow")} data-testid="menu-arrow" />;
 }
 
-type MenuSubProps = PropsWithChildren<{
+type MenuSubComponentProps = PropsWithChildren<{
   readonly placement?: Placement;
   readonly offset?: number;
   readonly strategy?: PositionStrategy;
@@ -758,7 +758,7 @@ type MenuSubProps = PropsWithChildren<{
 
 const DEFAULT_SUB_PLACEMENT: Placement = "right-start";
 
-export function MenuSub(props: MenuSubProps): JSX.Element {
+export function MenuSub(props: MenuSubComponentProps): JSX.Element {
   const { children, placement = DEFAULT_SUB_PLACEMENT, offset, strategy, className, style } = props;
   const parentContext = useMenuContext();
 
@@ -856,9 +856,9 @@ export function MenuSub(props: MenuSubProps): JSX.Element {
   );
 }
 
-type MenuSubTriggerProps = MenuItemComponentProps;
+type MenuSubTriggerComponentProps = MenuItemComponentProps;
 
-export const MenuSubTrigger = forwardRef<HTMLElement, MenuSubTriggerProps>(function MenuSubTrigger(
+export const MenuSubTrigger = forwardRef<HTMLDivElement, MenuSubTriggerComponentProps>(function MenuSubTrigger(
   props,
   forwardedRef
 ) {
@@ -936,12 +936,7 @@ export const MenuSubTrigger = forwardRef<HTMLElement, MenuSubTriggerProps>(funct
       : disabled
         ? undefined
         : pointerMoveFromItem;
-  const pointerLeaveHandler =
-    !disabled && context.hoverProps
-      ? composeEventHandlers(context.hoverProps.anchorProps.onPointerLeave, onPointerLeave)
-      : disabled
-        ? undefined
-        : onPointerLeave;
+  const pointerLeaveHandler = disabled ? undefined : onPointerLeave;
 
   return (
     <Component
@@ -967,9 +962,9 @@ export const MenuSubTrigger = forwardRef<HTMLElement, MenuSubTriggerProps>(funct
   );
 });
 
-type MenuSubContentProps = ComponentPropsWithoutRef<typeof MenuContent>;
+type MenuSubContentComponentProps = ComponentPropsWithoutRef<typeof MenuContent>;
 
-export const MenuSubContent = forwardRef<HTMLDivElement, MenuSubContentProps>(function MenuSubContent(
+export const MenuSubContent = forwardRef<HTMLDivElement, MenuSubContentComponentProps>(function MenuSubContent(
   props,
   forwardedRef
 ) {

--- a/packages/react/src/components/menu/index.tsx
+++ b/packages/react/src/components/menu/index.tsx
@@ -1,0 +1,992 @@
+import {
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+  type HTMLAttributes,
+  type MutableRefObject,
+  type PropsWithChildren
+} from "react";
+import type React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { composeRefs } from "@radix-ui/react-compose-refs";
+import {
+  useDismissableLayer,
+  useHoverIntent,
+  useMenu,
+  useMenuItem,
+  useMenuTrigger,
+  type HoverIntentTargetProps,
+  type MenuItemRole,
+  type Placement,
+  type PositionStrategy,
+  type UseMenuResult
+} from "@ara/core";
+
+import { mergeClassNames } from "../layout/shared.js";
+import { Portal } from "../portal/index.js";
+import { usePositioner, type PositionerArrowProps } from "../positioner/index.js";
+
+type MenuContextValue = {
+  readonly menu: UseMenuResult;
+  readonly parent?: MenuContextValue;
+  readonly openOnHover: boolean;
+  readonly closeOnSelect: boolean;
+  readonly placement: Placement;
+  readonly offset: number;
+  readonly strategy: PositionStrategy;
+  readonly loopFocus: boolean;
+  readonly typeaheadTimeout: number;
+  readonly portalContainer?: HTMLElement | null;
+  readonly contentId: string;
+  readonly setContentId: (id: string) => void;
+  readonly anchorRef: MutableRefObject<HTMLElement | null>;
+  readonly floatingRef: MutableRefObject<HTMLElement | null>;
+  readonly setAnchor: (node: HTMLElement | null) => void;
+  readonly setFloating: (node: HTMLElement | null) => void;
+  readonly hoverProps?: {
+    readonly anchorProps: HoverIntentTargetProps;
+    readonly floatingProps: HoverIntentTargetProps;
+  };
+};
+
+type MenuArrowContextValue = {
+  readonly arrowProps?: PositionerArrowProps;
+  readonly withArrow: boolean;
+};
+
+type MenuGroupContextValue = {
+  readonly registerLabelId: (id: string | null) => void;
+};
+
+type MenuRadioGroupContextValue = {
+  readonly value: string;
+  readonly onValueChange: (value: string) => void;
+  readonly name?: string;
+};
+
+const MenuContext = createContext<MenuContextValue | null>(null);
+const MenuArrowContext = createContext<MenuArrowContextValue | null>(null);
+const MenuGroupContext = createContext<MenuGroupContextValue | null>(null);
+const MenuRadioGroupContext = createContext<MenuRadioGroupContextValue | null>(null);
+
+function useMenuContext(): MenuContextValue {
+  const context = useContext(MenuContext);
+  if (!context) {
+    throw new Error("Menu 하위 컴포넌트는 Menu 또는 MenuSub 내부에서만 사용할 수 있습니다.");
+  }
+  return context;
+}
+
+function useMenuArrowContext(): MenuArrowContextValue {
+  const context = useContext(MenuArrowContext);
+  if (!context) {
+    throw new Error("MenuArrow는 MenuContent 또는 MenuSubContent 내부에서만 사용할 수 있습니다.");
+  }
+  return context;
+}
+
+function useMenuGroupContext(): MenuGroupContextValue {
+  const context = useContext(MenuGroupContext);
+  if (!context) {
+    throw new Error("MenuLabel은 MenuGroup 내부에서만 사용할 수 있습니다.");
+  }
+  return context;
+}
+
+function useMenuRadioGroupContext(): MenuRadioGroupContextValue {
+  const context = useContext(MenuRadioGroupContext);
+  if (!context) {
+    throw new Error("MenuRadioItem은 MenuRadioGroup 내부에서만 사용할 수 있습니다.");
+  }
+  return context;
+}
+
+function composeEventHandlers<Event>(
+  ours: ((event: Event) => void) | undefined,
+  theirs: ((event: Event) => void) | undefined
+): (event: Event) => void {
+  if (!ours && !theirs) return () => {};
+  return (event: Event) => {
+    ours?.(event);
+    theirs?.(event);
+  };
+}
+
+type Side = "top" | "bottom" | "left" | "right";
+type Align = "start" | "center" | "end";
+
+function parsePlacement(placement: Placement): { side: Side; align: Align } {
+  const [side, align] = placement.split("-") as [Side, Align];
+  return { side, align };
+}
+
+type MenuRootProps = PropsWithChildren<{
+  readonly open?: boolean;
+  readonly defaultOpen?: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+  readonly placement?: Placement;
+  readonly offset?: number;
+  readonly strategy?: PositionStrategy;
+  readonly openOnHover?: boolean;
+  readonly closeOnSelect?: boolean;
+  readonly loopFocus?: boolean;
+  readonly typeaheadTimeout?: number;
+  readonly portalContainer?: HTMLElement | null;
+}> &
+  Pick<HTMLAttributes<HTMLDivElement>, "className" | "style">;
+
+const DEFAULT_PLACEMENT: Placement = "bottom-start";
+const DEFAULT_OFFSET = 6;
+const DEFAULT_STRATEGY: PositionStrategy = "absolute";
+const DEFAULT_TYPEAHEAD_TIMEOUT = 700;
+
+export function Menu(props: MenuRootProps): JSX.Element {
+  const {
+    children,
+    open,
+    defaultOpen = false,
+    onOpenChange,
+    placement = DEFAULT_PLACEMENT,
+    offset = DEFAULT_OFFSET,
+    strategy = DEFAULT_STRATEGY,
+    openOnHover = false,
+    closeOnSelect = true,
+    loopFocus = true,
+    typeaheadTimeout = DEFAULT_TYPEAHEAD_TIMEOUT,
+    portalContainer,
+    className,
+    style
+  } = props;
+
+  const menu = useMenu({
+    open,
+    defaultOpen,
+    onOpenChange,
+    closeOnSelect,
+    loopFocus,
+    typeaheadTimeout
+  });
+
+  const anchorRef = useRef<HTMLElement | null>(null);
+  const floatingRef = useRef<HTMLElement | null>(null);
+  const [anchorNode, setAnchorNode] = useState<HTMLElement | null>(null);
+  const [floatingNode, setFloatingNode] = useState<HTMLElement | null>(null);
+  const [contentId, setContentId] = useState(menu.menuId);
+
+  const hoverIntent = useHoverIntent({
+    isOpen: menu.isOpen,
+    openDelay: 150,
+    closeDelay: 100,
+    enableSafePolygon: false,
+    anchor: anchorNode,
+    floating: floatingNode,
+    onOpenChange: (next) => {
+      if (next) {
+        menu.openMenu();
+      } else {
+        menu.closeMenu();
+      }
+    }
+  });
+
+  const setAnchor = useCallback((node: HTMLElement | null) => {
+    anchorRef.current = node;
+    setAnchorNode(node);
+  }, []);
+
+  const setFloating = useCallback((node: HTMLElement | null) => {
+    floatingRef.current = node;
+    setFloatingNode(node);
+  }, []);
+
+  const contextValue = useMemo<MenuContextValue>(
+    () => ({
+      menu,
+      openOnHover,
+      closeOnSelect,
+      placement,
+      offset,
+      strategy,
+      loopFocus,
+      typeaheadTimeout,
+      portalContainer,
+      contentId,
+      setContentId,
+      anchorRef,
+      floatingRef,
+      setAnchor,
+      setFloating,
+      hoverProps: openOnHover
+        ? { anchorProps: hoverIntent.anchorProps, floatingProps: hoverIntent.floatingProps }
+        : undefined
+    }),
+    [
+      anchorRef,
+      closeOnSelect,
+      contentId,
+      floatingRef,
+      hoverIntent.anchorProps,
+      hoverIntent.floatingProps,
+      offset,
+      loopFocus,
+      openOnHover,
+      placement,
+      portalContainer,
+      setAnchor,
+      setFloating,
+      typeaheadTimeout,
+      strategy,
+      menu
+    ]
+  );
+
+  return (
+    <MenuContext.Provider value={contextValue}>
+      <div className={mergeClassNames("ara-menu__root", className)} style={style}>
+        {children}
+      </div>
+    </MenuContext.Provider>
+  );
+}
+
+type MenuTriggerComponentProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+  readonly disabled?: boolean;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+export const MenuTrigger = forwardRef<HTMLElement, MenuTriggerComponentProps>(function MenuTrigger(
+  props,
+  forwardedRef
+) {
+  const {
+    children,
+    asChild = false,
+    disabled = false,
+    className,
+    onPointerEnter,
+    onPointerMove,
+    onPointerLeave,
+    onClick,
+    onKeyDown,
+    ...restProps
+  } = props;
+  const { menu, contentId, setAnchor, hoverProps } = useMenuContext();
+
+  const trigger = useMenuTrigger(menu, { disabled });
+  const { ref: triggerRef, onClick: triggerOnClick, onKeyDown: triggerOnKeyDown, ...triggerRestProps } =
+    trigger.triggerProps;
+
+  const Component = asChild ? Slot : "button";
+  const resolvedClassName = mergeClassNames("ara-menu__trigger", className);
+
+  const composedRef = composeRefs<HTMLElement>(
+    forwardedRef,
+    triggerRef,
+    hoverProps?.anchorProps.ref,
+    setAnchor
+  );
+
+  const pointerEnterHandler = !disabled && hoverProps
+    ? composeEventHandlers(hoverProps.anchorProps.onPointerEnter, onPointerEnter)
+    : disabled
+      ? undefined
+      : onPointerEnter;
+  const pointerMoveHandler = !disabled && hoverProps
+    ? composeEventHandlers(hoverProps.anchorProps.onPointerMove, onPointerMove)
+    : disabled
+      ? undefined
+      : onPointerMove;
+  const pointerLeaveHandler = !disabled && hoverProps
+    ? composeEventHandlers(hoverProps.anchorProps.onPointerLeave, onPointerLeave)
+    : disabled
+      ? undefined
+      : onPointerLeave;
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLElement>) => {
+      composeEventHandlers(triggerOnClick, onClick)(event);
+    },
+    [onClick, triggerOnClick]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      composeEventHandlers(triggerOnKeyDown, onKeyDown)(event);
+    },
+    [onKeyDown, triggerOnKeyDown]
+  );
+
+  return (
+    <Component
+      {...restProps}
+      {...triggerRestProps}
+      ref={composedRef}
+      type={!asChild ? "button" : undefined}
+      className={resolvedClassName}
+      aria-controls={contentId}
+      aria-disabled={disabled || undefined}
+      data-state={menu.isOpen ? "open" : "closed"}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onPointerEnter={pointerEnterHandler}
+      onPointerMove={pointerMoveHandler}
+      onPointerLeave={pointerLeaveHandler}
+    >
+      {children}
+    </Component>
+  );
+});
+
+type MenuContentComponentProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+  readonly id?: string;
+  readonly withArrow?: boolean;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children" | "id" | "role"> & {
+    readonly "aria-label"?: string;
+    readonly "aria-labelledby"?: string;
+  };
+
+export const MenuContent = forwardRef<HTMLDivElement, MenuContentComponentProps>(function MenuContent(
+  props,
+  forwardedRef
+) {
+  const {
+    children,
+    asChild = false,
+    id,
+    withArrow = false,
+    className,
+    style,
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledby,
+    onPointerEnter,
+    onPointerMove,
+    onPointerLeave,
+    onKeyDown,
+    ...restProps
+  } = props;
+
+  const {
+    menu,
+    placement,
+    offset,
+    strategy,
+    portalContainer,
+    contentId,
+    setContentId,
+    anchorRef,
+    floatingRef,
+    setFloating,
+    hoverProps
+  } = useMenuContext();
+
+  const resolvedId = id ?? contentId;
+
+  useEffect(() => {
+    setContentId(resolvedId);
+  }, [resolvedId, setContentId]);
+
+  const { floatingProps, arrowProps, placement: resolvedPlacement } = usePositioner({
+    anchorRef,
+    floatingRef,
+    placement,
+    offset,
+    strategy,
+    withArrow
+  });
+
+  const { side, align } = parsePlacement(resolvedPlacement);
+
+  const { containerProps: dismissableContainerProps } = useDismissableLayer({
+    active: menu.isOpen,
+    onDismiss: (event) => {
+      if (event.type === "escape-key") {
+        menu.closeMenu(true);
+      } else {
+        menu.closeMenu();
+      }
+    }
+  });
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-menu__content", className);
+
+  const { ref: floatingRefFromPositioner, style: floatingStyle, ...restFloatingProps } = floatingProps;
+
+  const wrapperRef = composeRefs<HTMLDivElement>(
+    floatingRefFromPositioner,
+    hoverProps?.floatingProps.ref,
+    setFloating,
+    dismissableContainerProps.ref
+  );
+
+  const contentRef = composeRefs<HTMLDivElement>(forwardedRef);
+
+  const pointerEnterHandler = hoverProps
+    ? composeEventHandlers(hoverProps.floatingProps.onPointerEnter, onPointerEnter)
+    : onPointerEnter;
+  const pointerMoveHandler = hoverProps
+    ? composeEventHandlers(hoverProps.floatingProps.onPointerMove, onPointerMove)
+    : onPointerMove;
+  const pointerLeaveHandler = hoverProps
+    ? composeEventHandlers(hoverProps.floatingProps.onPointerLeave, onPointerLeave)
+    : onPointerLeave;
+
+  const { onKeyDown: menuOnKeyDown, ...menuRestProps } = menu.menuProps;
+
+  const handleKeyDown = useCallback<NonNullable<HTMLAttributes<HTMLElement>["onKeyDown"]>>(
+    (event) => {
+      menuOnKeyDown?.(event as never);
+      if (event.defaultPrevented) return;
+      if (event.key === "Tab") {
+        menu.closeMenu();
+      }
+      onKeyDown?.(event);
+    },
+    [menuOnKeyDown, menu, onKeyDown]
+  );
+
+  const arrowContext = useMemo<MenuArrowContextValue>(
+    () => ({ arrowProps, withArrow }),
+    [arrowProps, withArrow]
+  );
+
+  if (!menu.isOpen) return null;
+
+  return (
+    <MenuArrowContext.Provider value={arrowContext}>
+      <Portal container={portalContainer} className="ara-menu__portal">
+        <div ref={wrapperRef} style={floatingStyle} {...restFloatingProps}>
+          <Component
+            {...restProps}
+            {...menuRestProps}
+            ref={contentRef}
+            id={resolvedId}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
+            className={resolvedClassName}
+            data-state={menu.isOpen ? "open" : "closed"}
+            data-placement={resolvedPlacement}
+            data-side={side}
+            data-align={align}
+            style={style}
+            onPointerEnter={pointerEnterHandler}
+            onPointerMove={pointerMoveHandler}
+            onPointerLeave={pointerLeaveHandler}
+            onKeyDown={handleKeyDown}
+            {...restProps}
+          >
+            {children}
+            {withArrow ? <MenuArrow /> : null}
+          </Component>
+        </div>
+      </Portal>
+    </MenuArrowContext.Provider>
+  );
+});
+
+type MenuItemComponentProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+  readonly disabled?: boolean;
+  readonly textValue?: string;
+  readonly inset?: boolean;
+  readonly shortcut?: string;
+  readonly onSelect?: (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => void;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+function MenuItemBase(
+  role: MenuItemRole,
+  componentClassName: string,
+  extraProps?: (isHighlighted: boolean) => Record<string, unknown>
+) {
+  return forwardRef<HTMLElement, MenuItemComponentProps>(function MenuItem(props, forwardedRef) {
+    const {
+      children,
+      asChild = false,
+      disabled = false,
+      textValue,
+      inset = false,
+      shortcut,
+      onSelect,
+      className,
+      onClick,
+      onKeyDown,
+      onPointerEnter,
+      onPointerMove,
+      onPointerLeave,
+      onFocus,
+      ...restProps
+    } = props;
+
+    const { menu, closeOnSelect } = useMenuContext();
+
+    const { itemProps, isHighlighted } = useMenuItem<HTMLElement>(menu, {
+      disabled,
+      textValue,
+      closeOnSelect,
+      role,
+      onSelect
+    });
+
+    const Component = asChild ? Slot : "div";
+    const resolvedClassName = mergeClassNames(componentClassName, className);
+
+    const clickHandler = composeEventHandlers(itemProps.onClick, onClick);
+    const keyDownHandler = composeEventHandlers(itemProps.onKeyDown, onKeyDown);
+    const pointerEnterHandler = composeEventHandlers(itemProps.onPointerEnter, onPointerEnter);
+    const pointerMoveHandler = composeEventHandlers(itemProps.onPointerMove, onPointerMove);
+    const pointerLeaveHandler = composeEventHandlers(itemProps.onPointerLeave, onPointerLeave);
+    const focusHandler = composeEventHandlers(itemProps.onFocus, onFocus);
+
+    return (
+      <Component
+        {...restProps}
+        {...itemProps}
+        ref={forwardedRef}
+        className={resolvedClassName}
+        data-highlighted={isHighlighted ? "true" : undefined}
+        data-disabled={disabled ? "true" : undefined}
+        data-inset={inset ? "true" : undefined}
+        onClick={clickHandler}
+        onKeyDown={keyDownHandler}
+        onPointerEnter={pointerEnterHandler}
+        onPointerMove={pointerMoveHandler}
+        onPointerLeave={pointerLeaveHandler}
+        onFocus={focusHandler}
+        {...extraProps?.(isHighlighted)}
+      >
+        <span className="ara-menu__item-label">{children}</span>
+        {shortcut ? <span className="ara-menu__item-shortcut">{shortcut}</span> : null}
+      </Component>
+    );
+  });
+}
+
+export const MenuItem = MenuItemBase("menuitem", "ara-menu__item");
+
+type MenuCheckboxItemProps = MenuItemComponentProps & {
+  readonly checked: boolean;
+  readonly onCheckedChange: (checked: boolean) => void;
+};
+
+export const MenuCheckboxItem = forwardRef<HTMLElement, MenuCheckboxItemProps>(function MenuCheckboxItem(
+  props,
+  forwardedRef
+) {
+  const { checked, onCheckedChange, onSelect, ...restProps } = props;
+
+  const handleSelect = useCallback<MenuCheckboxItemProps["onSelect"]>(
+    (event) => {
+      onSelect?.(event);
+      onCheckedChange(!checked);
+    },
+    [checked, onCheckedChange, onSelect]
+  );
+
+  const Base = useMemo(() => MenuItemBase("menuitemcheckbox", "ara-menu__checkbox-item"), []);
+
+  return (
+    <Base
+      {...restProps}
+      ref={forwardedRef}
+      aria-checked={checked}
+      data-checked={checked ? "true" : undefined}
+      onSelect={handleSelect}
+    />
+  );
+});
+
+type MenuRadioGroupProps = PropsWithChildren<{
+  readonly value: string;
+  readonly onValueChange: (value: string) => void;
+  readonly name?: string;
+  readonly asChild?: boolean;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+export const MenuRadioGroup = forwardRef<HTMLElement, MenuRadioGroupProps>(function MenuRadioGroup(
+  props,
+  forwardedRef
+) {
+  const { children, value, onValueChange, name, asChild = false, className, ...restProps } = props;
+
+  const contextValue = useMemo<MenuRadioGroupContextValue>(
+    () => ({ value, onValueChange, name }),
+    [name, onValueChange, value]
+  );
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-menu__radio-group", className);
+
+  return (
+    <MenuRadioGroupContext.Provider value={contextValue}>
+      <Component ref={forwardedRef} role="group" className={resolvedClassName} {...restProps}>
+        {children}
+      </Component>
+    </MenuRadioGroupContext.Provider>
+  );
+});
+
+type MenuRadioItemProps = MenuItemComponentProps & {
+  readonly value: string;
+};
+
+export const MenuRadioItem = forwardRef<HTMLElement, MenuRadioItemProps>(function MenuRadioItem(
+  props,
+  forwardedRef
+) {
+  const { value, onSelect, ...restProps } = props;
+  const radioGroup = useMenuRadioGroupContext();
+  const checked = radioGroup.value === value;
+
+  const handleSelect = useCallback<MenuRadioItemProps["onSelect"]>(
+    (event) => {
+      onSelect?.(event);
+      if (!checked) {
+        radioGroup.onValueChange(value);
+      }
+    },
+    [checked, onSelect, radioGroup, value]
+  );
+
+  const Base = useMemo(() => MenuItemBase("menuitemradio", "ara-menu__radio-item"), []);
+
+  return (
+    <Base
+      {...restProps}
+      ref={forwardedRef}
+      aria-checked={checked}
+      data-checked={checked ? "true" : undefined}
+      onSelect={handleSelect}
+    />
+  );
+});
+
+type MenuGroupProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+export const MenuGroup = forwardRef<HTMLElement, MenuGroupProps>(function MenuGroup(props, forwardedRef) {
+  const { children, asChild = false, className, ...restProps } = props;
+
+  const [labelId, setLabelId] = useState<string | null>(null);
+
+  const contextValue = useMemo<MenuGroupContextValue>(() => ({ registerLabelId: setLabelId }), []);
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-menu__group", className);
+
+  return (
+    <MenuGroupContext.Provider value={contextValue}>
+      <Component ref={forwardedRef} role="group" aria-labelledby={labelId ?? undefined} className={resolvedClassName} {...restProps}>
+        {children}
+      </Component>
+    </MenuGroupContext.Provider>
+  );
+});
+
+type MenuLabelProps = PropsWithChildren<{
+  readonly asChild?: boolean;
+  readonly id?: string;
+}> &
+  Omit<HTMLAttributes<HTMLElement>, "children">;
+
+export const MenuLabel = forwardRef<HTMLElement, MenuLabelProps>(function MenuLabel(props, forwardedRef) {
+  const { children, asChild = false, id, className, ...restProps } = props;
+  const group = useMenuGroupContext();
+
+  const reactId = useId();
+  const resolvedId = useMemo(() => id ?? `ara-menu-label-${reactId.replace(/:/g, "-")}`, [id, reactId]);
+
+  useEffect(() => {
+    group.registerLabelId(resolvedId);
+    return () => group.registerLabelId(null);
+  }, [group, resolvedId]);
+
+  const Component = asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-menu__label", className);
+
+  return (
+    <Component ref={forwardedRef} id={resolvedId} className={resolvedClassName} {...restProps}>
+      {children}
+    </Component>
+  );
+});
+
+export const MenuSeparator = forwardRef<HTMLElement, ComponentPropsWithoutRef<"div">>(function MenuSeparator(
+  props,
+  forwardedRef
+) {
+  const { className, ...restProps } = props;
+  const resolvedClassName = mergeClassNames("ara-menu__separator", className);
+
+  return (
+    <div
+      {...restProps}
+      ref={forwardedRef}
+      role="separator"
+      aria-orientation="horizontal"
+      className={resolvedClassName}
+    />
+  );
+});
+
+export function MenuArrow(): JSX.Element | null {
+  const { arrowProps, withArrow } = useMenuArrowContext();
+  if (!withArrow || !arrowProps) return null;
+
+  return <span {...arrowProps} className={mergeClassNames("ara-menu__arrow")} data-testid="menu-arrow" />;
+}
+
+type MenuSubProps = PropsWithChildren<{
+  readonly placement?: Placement;
+  readonly offset?: number;
+  readonly strategy?: PositionStrategy;
+}> &
+  Pick<HTMLAttributes<HTMLDivElement>, "className" | "style">;
+
+const DEFAULT_SUB_PLACEMENT: Placement = "right-start";
+
+export function MenuSub(props: MenuSubProps): JSX.Element {
+  const { children, placement = DEFAULT_SUB_PLACEMENT, offset, strategy, className, style } = props;
+  const parentContext = useMenuContext();
+
+  const menu = useMenu({
+    closeOnSelect: parentContext.closeOnSelect,
+    loopFocus: parentContext.loopFocus,
+    typeaheadTimeout: parentContext.typeaheadTimeout
+  });
+
+  const anchorRef = useRef<HTMLElement | null>(null);
+  const floatingRef = useRef<HTMLElement | null>(null);
+  const [anchorNode, setAnchorNode] = useState<HTMLElement | null>(null);
+  const [floatingNode, setFloatingNode] = useState<HTMLElement | null>(null);
+  const [contentId, setContentId] = useState(menu.menuId);
+
+  const hoverIntent = useHoverIntent({
+    isOpen: menu.isOpen,
+    openDelay: 150,
+    closeDelay: 150,
+    enableSafePolygon: true,
+    anchor: anchorNode,
+    floating: floatingNode,
+    onOpenChange: (next) => {
+      if (next) {
+        menu.openMenu();
+      } else {
+        menu.closeMenu();
+      }
+    }
+  });
+
+  const setAnchor = useCallback((node: HTMLElement | null) => {
+    anchorRef.current = node;
+    setAnchorNode(node);
+  }, []);
+
+  const setFloating = useCallback((node: HTMLElement | null) => {
+    floatingRef.current = node;
+    setFloatingNode(node);
+  }, []);
+
+  useEffect(() => {
+    if (!parentContext.menu.isOpen && menu.isOpen) {
+      menu.closeMenu();
+    }
+  }, [menu.closeMenu, menu.isOpen, parentContext.menu.isOpen]);
+
+  const contextValue = useMemo<MenuContextValue>(
+    () => ({
+      menu,
+      parent: parentContext,
+      openOnHover: true,
+      closeOnSelect: parentContext.closeOnSelect,
+      placement,
+      offset: offset ?? parentContext.offset,
+      strategy: strategy ?? parentContext.strategy,
+      loopFocus: parentContext.loopFocus,
+      typeaheadTimeout: parentContext.typeaheadTimeout,
+      portalContainer: parentContext.portalContainer,
+      contentId,
+      setContentId,
+      anchorRef,
+      floatingRef,
+      setAnchor,
+      setFloating,
+      hoverProps: {
+        anchorProps: hoverIntent.anchorProps,
+        floatingProps: hoverIntent.floatingProps
+      }
+    }),
+    [
+      anchorRef,
+      contentId,
+      floatingRef,
+      hoverIntent.anchorProps,
+      hoverIntent.floatingProps,
+      menu,
+      offset,
+      parentContext,
+      placement,
+      parentContext.loopFocus,
+      parentContext.typeaheadTimeout,
+      setAnchor,
+      setFloating,
+      strategy
+    ]
+  );
+
+  return (
+    <MenuContext.Provider value={contextValue}>
+      <div className={mergeClassNames("ara-menu__sub", className)} style={style}>
+        {children}
+      </div>
+    </MenuContext.Provider>
+  );
+}
+
+type MenuSubTriggerProps = MenuItemComponentProps;
+
+export const MenuSubTrigger = forwardRef<HTMLElement, MenuSubTriggerProps>(function MenuSubTrigger(
+  props,
+  forwardedRef
+) {
+  const {
+    children,
+    disabled = false,
+    textValue,
+    shortcut,
+    className,
+    onClick,
+    onKeyDown: userKeyDown,
+    onFocus,
+    onPointerEnter,
+    onPointerMove,
+    onPointerLeave,
+    ...restProps
+  } = props;
+  const context = useMenuContext();
+  const parentMenu = context.parent;
+
+  if (!parentMenu) {
+    throw new Error("MenuSubTrigger는 MenuSub 내부에서만 사용할 수 있습니다.");
+  }
+
+  const { itemProps, isHighlighted } = useMenuItem<HTMLElement>(parentMenu.menu, {
+    disabled,
+    textValue,
+    closeOnSelect: false,
+    role: "menuitem",
+    onSelect: () => {
+      context.menu.openMenu("first");
+    }
+  });
+
+  const Component = props.asChild ? Slot : "div";
+  const resolvedClassName = mergeClassNames("ara-menu__sub-trigger", className);
+
+  const handleKeyDown = useCallback<NonNullable<HTMLAttributes<HTMLElement>["onKeyDown"]>>(
+    (event) => {
+      if (disabled) return;
+
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        context.menu.openMenu("first");
+        return;
+      }
+
+      if ((event.key === "ArrowLeft" || event.key === "Escape") && context.menu.isOpen) {
+        event.preventDefault();
+        context.menu.closeMenu(true);
+        return;
+      }
+
+      itemProps.onKeyDown(event);
+      userKeyDown?.(event);
+    },
+    [context.menu, disabled, itemProps, userKeyDown]
+  );
+
+  const clickHandler = composeEventHandlers(itemProps.onClick, onClick);
+
+  const focusHandler = composeEventHandlers(itemProps.onFocus, onFocus);
+
+  const pointerEnterHandler =
+    !disabled && context.hoverProps
+      ? composeEventHandlers(context.hoverProps.anchorProps.onPointerEnter, onPointerEnter)
+      : disabled
+        ? undefined
+        : onPointerEnter;
+
+  const pointerMoveFromItem = composeEventHandlers(itemProps.onPointerMove, onPointerMove);
+  const pointerMoveHandler =
+    !disabled && context.hoverProps
+      ? composeEventHandlers(context.hoverProps.anchorProps.onPointerMove, pointerMoveFromItem)
+      : disabled
+        ? undefined
+        : pointerMoveFromItem;
+  const pointerLeaveHandler =
+    !disabled && context.hoverProps
+      ? composeEventHandlers(context.hoverProps.anchorProps.onPointerLeave, onPointerLeave)
+      : disabled
+        ? undefined
+        : onPointerLeave;
+
+  return (
+    <Component
+      {...restProps}
+      {...itemProps}
+      ref={composeRefs(forwardedRef, itemProps.ref, context.hoverProps?.anchorProps.ref, context.setAnchor)}
+      className={resolvedClassName}
+      aria-haspopup="menu"
+      aria-expanded={context.menu.isOpen}
+      data-highlighted={isHighlighted ? "true" : undefined}
+      data-disabled={disabled ? "true" : undefined}
+      data-submenu-open={context.menu.isOpen ? "true" : undefined}
+      onClick={clickHandler}
+      onKeyDown={handleKeyDown}
+      onFocus={focusHandler}
+      onPointerEnter={pointerEnterHandler}
+      onPointerMove={pointerMoveHandler}
+      onPointerLeave={pointerLeaveHandler}
+    >
+      <span className="ara-menu__item-label">{children}</span>
+      <span className="ara-menu__item-shortcut">{shortcut}</span>
+    </Component>
+  );
+});
+
+type MenuSubContentProps = ComponentPropsWithoutRef<typeof MenuContent>;
+
+export const MenuSubContent = forwardRef<HTMLDivElement, MenuSubContentProps>(function MenuSubContent(
+  props,
+  forwardedRef
+) {
+  return <MenuContent {...props} ref={forwardedRef} />;
+});
+
+export type MenuProps = MenuRootProps;
+export type MenuTriggerProps = ComponentPropsWithoutRef<typeof MenuTrigger>;
+export type MenuContentProps = ComponentPropsWithoutRef<typeof MenuContent>;
+export type MenuItemProps = ComponentPropsWithoutRef<typeof MenuItem>;
+export type MenuCheckboxItemProps = ComponentPropsWithoutRef<typeof MenuCheckboxItem>;
+export type MenuRadioGroupProps = ComponentPropsWithoutRef<typeof MenuRadioGroup>;
+export type MenuRadioItemProps = ComponentPropsWithoutRef<typeof MenuRadioItem>;
+export type MenuGroupProps = ComponentPropsWithoutRef<typeof MenuGroup>;
+export type MenuLabelProps = ComponentPropsWithoutRef<typeof MenuLabel>;
+export type MenuSeparatorProps = ComponentPropsWithoutRef<typeof MenuSeparator>;
+export type MenuArrowProps = ComponentPropsWithoutRef<typeof MenuArrow>;
+export type MenuSubProps = ComponentPropsWithoutRef<typeof MenuSub>;
+export type MenuSubTriggerProps = ComponentPropsWithoutRef<typeof MenuSubTrigger>;
+export type MenuSubContentProps = ComponentPropsWithoutRef<typeof MenuSubContent>;

--- a/packages/react/src/components/menu/index.tsx
+++ b/packages/react/src/components/menu/index.tsx
@@ -586,7 +586,7 @@ export const MenuCheckboxItem = forwardRef<HTMLDivElement, MenuCheckboxItemCompo
   const { checked, onCheckedChange, onSelect, ...restProps } = props;
 
   const handleSelect = useCallback(
-    (event) => {
+    (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
       onSelect?.(event);
       onCheckedChange(!checked);
     },
@@ -650,7 +650,7 @@ export const MenuRadioItem = forwardRef<HTMLDivElement, MenuRadioItemComponentPr
   const checked = radioGroup.value === value;
 
   const handleSelect = useCallback(
-    (event) => {
+    (event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
       onSelect?.(event);
       if (!checked) {
         radioGroup.onValueChange(value);

--- a/packages/react/src/components/tooltip/index.test.tsx
+++ b/packages/react/src/components/tooltip/index.test.tsx
@@ -1,18 +1,11 @@
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "./index.js";
 
 describe("Tooltip", () => {
-  let user: ReturnType<typeof userEvent.setup>;
-
-  beforeEach(() => {
-    user = userEvent.setup();
-  });
-
   afterEach(() => {
     cleanup();
   });


### PR DESCRIPTION
## Summary
- Menu 컨텍스트/트리거/콘텐츠를 구현하고 Positioner·DismissableLayer·HoverIntent로 상호작용을 구성했습니다.
- Checkbox/Radio/Group/Label/Separator와 SubTrigger/SubContent를 추가해 서브메뉴·선택 상태·aria 데이터를 노출합니다.
- 메뉴 상호작용을 검증하는 전용 테스트를 작성했습니다.

## Checklist
- [x] 관련 WBS/Task ID를 제목 또는 본문에 언급했습니다.
- [x] 문서/코드 변경 사항을 모두 자체 리뷰했습니다.
- [x] 릴리스 노트나 문서화가 필요하면 업데이트했습니다.
- [x] **Breaking 변경 여부를 확인했고, 있다면 상세히 기록했습니다.**

## Testing
- `pnpm --filter @ara/react test -- src/components/menu/index.test.tsx` (엔진 버전 경고 및 전체 테스트 실행으로 장시간 소요되어 수동 중단)

## Screenshots
없음

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948c57ad6248322a46be9d1bf86e91b)